### PR TITLE
D3D12: Fix GUI rendering, PSO cache, per-draw VB ring allocation

### DIFF
--- a/T850/DayScene/App.cpp
+++ b/T850/DayScene/App.cpp
@@ -50,6 +50,7 @@ std::string g_guiControlTarget = "slider_knob"; // --guiControlTarget <slider_kn
 int    g_logLevel    = 3;            // --logLevel: 0=Error,1=Info,2=Debug,3=Verbose
 std::string g_logFile;              // --logFile <path>: write log to file (append, flush-per-entry)
 bool   g_d3d12Debug  = false;       // --d3d12debug: enable D3D12 debug layer
+bool   g_testGui    = false;        // --testGui: minimal GUI rendering test (skip scene)
 
 t800::AppBase		  *pApp = 0;
 t800::RootFramework *pFrameWork = 0;
@@ -152,6 +153,9 @@ int main(int arg,char ** args){
     }
     else if (a == "--d3d12debug") {
       g_d3d12Debug = true;
+    }
+    else if (a == "--testGui") {
+      g_testGui = true;
     }
   }
 

--- a/T850/DayScene/Application.cpp
+++ b/T850/DayScene/Application.cpp
@@ -14,6 +14,7 @@
 #include <video/BaseDriver.h>
 #include <utils/InputManager.h>
 #include <utils/Log.h>
+#include <utils/Utils.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -37,6 +38,12 @@ extern bool g_guiEdit;
 extern bool g_guiSnap;
 extern bool g_guiControlEdit;
 extern std::string g_guiControlTarget;
+extern bool g_testGui;
+
+namespace t800 {
+  extern Device*       T8Device;
+  extern DeviceContext* T8DeviceContext;
+}
 
 
 
@@ -157,6 +164,69 @@ void App::OnDraw() {
   T8_LOG_TRACE("[Frame %d] === OnDraw BEGIN ===", frameCount);
   pFramework->pVideoDriver->Clear();
   FirstFrame = false;
+
+  // ── Minimal GUI test: draw scene FIRST, then overlay a red quad ──
+  if (g_testGui) {
+    static Quad testQuad;
+    static ShaderBase* testShader = nullptr;
+    static ConstantBuffer* testCB = nullptr;
+    static Texture* testTex = nullptr;
+    static bool testInited = false;
+
+    if (!testInited) {
+      testQuad.Init();
+      unsigned char white[4] = {255, 255, 255, 255};
+      testTex = t800::T8Device->CreateTextureFromMemory(white, 1, 1, 4, "testGui_white");
+      if (testTex) { testTex->params = TEXT_BASIC_PARAMS::CLAMP_TO_EDGE; testTex->SetTextureParams(); }
+      char* vs = file2string("Shaders/VS_GUI.hlsl");
+      char* fs = file2string("Shaders/FS_GUI.hlsl");
+      if (vs && fs) {
+        int id = pFramework->pVideoDriver->CreateShader(std::string(vs), std::string(fs));
+        testShader = pFramework->pVideoDriver->GetShaderIdx(id);
+        free(vs); free(fs);
+      }
+      BufferDesc bd; bd.byteWidth = sizeof(XVECTOR3); bd.usage = T8_BUFFER_USAGE::DEFAULT;
+      testCB = (ConstantBuffer*)t800::T8Device->CreateBuffer(T8_BUFFER_TYPE::CONSTANT, bd);
+      testInited = true;
+    }
+
+    // Draw the full scene first (this is what breaks GUI)
+    m_devLayer.Draw();
+
+    if (testShader && testCB && testTex && frameCount >= 2) {
+      // Now try to draw a red quad ON TOP of the scene
+      pFramework->pVideoDriver->SetBlendState(BaseDriver::ALPHA_BLEND);
+      pFramework->pVideoDriver->SetDepthStencilState(BaseDriver::NONE);
+      pFramework->pVideoDriver->SetCullFace(BaseDriver::FRONT_AND_BACK);
+
+      testQuad.Set();
+      testShader->Set(*t800::T8DeviceContext);
+      t800::T8DeviceContext->SetPrimitiveTopology(T8_TOPOLOGY::TRIANLE_LIST);
+
+      XVECTOR3 tint(1.0f, 0.0f, 0.0f);
+      testCB->UpdateFromBuffer(*t800::T8DeviceContext, &tint.x);
+      testCB->Set(*t800::T8DeviceContext);
+      Quad::Vertex verts[4] = {
+        {-0.5f,  0.5f, 0.0f, 1.0f,  0.0f, 0.0f},
+        {-0.5f, -0.5f, 0.0f, 1.0f,  0.0f, 1.0f},
+        { 0.5f, -0.5f, 0.0f, 1.0f,  1.0f, 1.0f},
+        { 0.5f,  0.5f, 0.0f, 1.0f,  1.0f, 0.0f},
+      };
+      testQuad.m_VB->UpdateFromBuffer(*t800::T8DeviceContext, verts);
+      testTex->Set(*t800::T8DeviceContext, 0, "tex0");
+      t800::T8DeviceContext->DrawIndexed(6, 0, 0);
+
+      if (frameCount == 3) {
+        pFramework->pVideoDriver->SaveScreenshot("testGui_result");
+        pFramework->pVideoDriver->SwapBuffers();
+        exit(0);
+      }
+    }
+
+    frameCount++;
+    if (frameCount > 1) pFramework->pVideoDriver->SwapBuffers();
+    return;
+  }
 
   m_devLayer.Draw();
   // Draw FPS label using layout position when GUI overlay is not visible

--- a/T850/Framework/include/video/d3d12/D3D12Driver.h
+++ b/T850/Framework/include/video/d3d12/D3D12Driver.h
@@ -173,27 +173,29 @@ namespace t800 {
   //  D3D12 Pipeline State cache key
   // ══════════════════════════════════════════════════════
   struct D3D12PipelineKey {
-    uint32_t shaderKey;
+    uintptr_t shaderPtr;   // shader object address — unique per shader
     uint8_t  blend;
     uint8_t  depth;
     uint8_t  cull;
     uint8_t  numRTVs;
     DXGI_FORMAT rtvFormat;
+    DXGI_FORMAT dsvFormat;
     bool operator==(const D3D12PipelineKey& o) const {
-      return shaderKey == o.shaderKey && blend == o.blend &&
+      return shaderPtr == o.shaderPtr && blend == o.blend &&
              depth == o.depth && cull == o.cull && numRTVs == o.numRTVs &&
-             rtvFormat == o.rtvFormat;
+             rtvFormat == o.rtvFormat && dsvFormat == o.dsvFormat;
     }
   };
 
   struct D3D12PipelineKeyHash {
     size_t operator()(const D3D12PipelineKey& k) const {
-      size_t h = std::hash<uint32_t>()(k.shaderKey);
+      size_t h = std::hash<uintptr_t>()(k.shaderPtr);
       h ^= std::hash<uint8_t>()(k.blend)    << 1;
       h ^= std::hash<uint8_t>()(k.depth)    << 2;
       h ^= std::hash<uint8_t>()(k.cull)     << 3;
       h ^= std::hash<uint8_t>()(k.numRTVs)  << 4;
       h ^= std::hash<uint32_t>()((uint32_t)k.rtvFormat) << 5;
+      h ^= std::hash<uint32_t>()((uint32_t)k.dsvFormat) << 6;
       return h;
     }
   };
@@ -247,8 +249,16 @@ namespace t800 {
     // Default sampler GPU handle
     D3D12_GPU_DESCRIPTOR_HANDLE GetDefaultSamplerGPU() const { return m_defaultSamplerGPU; }
 
+    // Rebind back buffer without DSV (for GUI/overlay draws with depth disabled)
+    void BindBackBufferNoDSV();
+
+    DEPTH_STENCIL_STATES GetCurrentDepthState() const { return m_currentDepth; }
+
     // Per-frame CB ring allocator: returns GPU VA of a 256-aligned region with data copied
     D3D12_GPU_VIRTUAL_ADDRESS AllocateCBData(const void* data, UINT dataSize);
+
+    // Per-frame ring allocator for vertex/index data (16-byte aligned)
+    D3D12_GPU_VIRTUAL_ADDRESS AllocateRingData(const void* data, UINT dataSize);
 
     // Per-frame dynamic CBV descriptor: copies data to ring buffer, creates CBV, returns GPU handle
     D3D12_GPU_DESCRIPTOR_HANDLE AllocateDynamicCBV(const void* data, UINT dataSize);

--- a/T850/Framework/src/gui/T8_GUI.cpp
+++ b/T850/Framework/src/gui/T8_GUI.cpp
@@ -134,6 +134,10 @@ void GUIManager::InitTextures() {
   {
     unsigned char white[4] = {255, 255, 255, 255};
     m_whiteTexture = T8Device->CreateTextureFromMemory(white, 1, 1, 4, "gui_white_1x1");
+    if (m_whiteTexture) {
+      m_whiteTexture->params = TEXT_BASIC_PARAMS::CLAMP_TO_EDGE;
+      m_whiteTexture->SetTextureParams();
+    }
   }
   m_checkBoxTexture = loadGuiTexture("GUI_CheckBox_Box.png");
   m_checkMarkTexture = loadGuiTexture("GUI_Checkbox_Check.png");
@@ -804,6 +808,7 @@ void GUIManager::Draw() {
 
   g_pBaseDriver->SetBlendState(BaseDriver::BLEND_STATES::ALPHA_BLEND);
   g_pBaseDriver->SetDepthStencilState(BaseDriver::DEPTH_STENCIL_STATES::NONE);
+  g_pBaseDriver->SetCullFace(BaseDriver::FACE_CULLING::FRONT_AND_BACK);
 
   if (m_controlEditMode) {
     DrawControlEditPreview();
@@ -928,6 +933,7 @@ void GUIManager::DrawFPSOnly() {
 
   g_pBaseDriver->SetBlendState(BaseDriver::BLEND_STATES::ALPHA_BLEND);
   g_pBaseDriver->SetDepthStencilState(BaseDriver::DEPTH_STENCIL_STATES::NONE);
+  g_pBaseDriver->SetCullFace(BaseDriver::FACE_CULLING::FRONT_AND_BACK);
 
   m_textRenderer.BeginBatch();
   m_fpsLabel->Draw(m_ctx);

--- a/T850/Framework/src/scene/T8_TextRenderer.cpp
+++ b/T850/Framework/src/scene/T8_TextRenderer.cpp
@@ -54,6 +54,10 @@ namespace t800 {
     }
 
     ftex = T8Device->CreateTextureFromMemory(temp_bitmap, m_textureSize, m_textureSize, 1, path);
+    if (ftex) {
+      ftex->params = TEXT_BASIC_PARAMS::CLAMP_TO_EDGE;
+      ftex->SetTextureParams();
+    }
     //Create Quad
     m_quad.Init();
     /*SHADERS*/

--- a/T850/Framework/src/video/d3d12/D3D12Driver.cpp
+++ b/T850/Framework/src/video/d3d12/D3D12Driver.cpp
@@ -356,20 +356,39 @@ namespace t800 {
   }
 
   void D3D12VertexBuffer::Set(const DeviceContext& deviceContext, const unsigned stride, const unsigned offset) {
-    T8_LOG_TRACE("[D3D12] VB::Set stride=%u", stride);
+    T8_LOG_TRACE("[D3D12] VB::Set stride=%u gpuVA=0x%llX size=%u", stride, m_view.BufferLocation, m_view.SizeInBytes);
     const_cast<DeviceContext*>(&deviceContext)->actualVertexBuffer = (VertexBuffer*)this;
     m_view.StrideInBytes = stride;
     auto* cmdList = static_cast<const D3D12DeviceContext*>(&deviceContext)->GetCommandList();
     cmdList->IASetVertexBuffers(0, 1, &m_view);
   }
 
-  void D3D12VertexBuffer::UpdateFromSystemCopy(const DeviceContext&) {
-    if (m_mappedData && !sysMemCpy.empty())
-      memcpy(m_mappedData, sysMemCpy.data(), sysMemCpy.size());
+  void D3D12VertexBuffer::UpdateFromSystemCopy(const DeviceContext& deviceContext) {
+    if (!sysMemCpy.empty()) {
+      // D3D12: suballocate from the per-frame ring buffer so each draw
+      // within the same command list sees its own vertex data.
+      auto* driver = GetD3D12Driver();
+      UINT size = (UINT)sysMemCpy.size();
+      D3D12_GPU_VIRTUAL_ADDRESS gpuAddr = driver->AllocateRingData(sysMemCpy.data(), size);
+      m_view.BufferLocation = gpuAddr;
+      m_view.SizeInBytes = size;
+      // Rebind so the next DrawIndexed picks up the new address
+      auto* cmdList = static_cast<const D3D12DeviceContext*>(&deviceContext)->GetCommandList();
+      cmdList->IASetVertexBuffers(0, 1, &m_view);
+    }
   }
-  void D3D12VertexBuffer::UpdateFromBuffer(const DeviceContext&, const void* buffer) {
+  void D3D12VertexBuffer::UpdateFromBuffer(const DeviceContext& deviceContext, const void* buffer) {
     sysMemCpy.assign((char*)buffer, (char*)buffer + descriptor.byteWidth);
-    if (m_mappedData) memcpy(m_mappedData, buffer, descriptor.byteWidth);
+    // D3D12: suballocate from the per-frame ring buffer so each draw
+    // within the same command list sees its own vertex data.
+    auto* driver = GetD3D12Driver();
+    UINT size = descriptor.byteWidth;
+    D3D12_GPU_VIRTUAL_ADDRESS gpuAddr = driver->AllocateRingData(buffer, size);
+    m_view.BufferLocation = gpuAddr;
+    m_view.SizeInBytes = size;
+    // Rebind so the next DrawIndexed picks up the new address
+    auto* cmdList = static_cast<const D3D12DeviceContext*>(&deviceContext)->GetCommandList();
+    cmdList->IASetVertexBuffers(0, 1, &m_view);
   }
   void D3D12VertexBuffer::release() {
     if (m_mappedData) { m_buffer->Unmap(0, nullptr); m_mappedData = nullptr; }
@@ -517,13 +536,17 @@ namespace t800 {
       rtvFormat = DXGI_FORMAT_UNKNOWN;
     }
 
+    // When depth is disabled, keep DSV format matching the bound depth buffer
+    // (the depth test/write is disabled in the PSO's DepthStencilState already)
+
     D3D12PipelineKey key = {};
-    key.shaderKey = shader->key.bits;
+    key.shaderPtr = reinterpret_cast<uintptr_t>(shader);
     key.blend = (uint8_t)m_currentBlend;
     key.depth = (uint8_t)m_currentDepth;
     key.cull = (uint8_t)m_currentCull;
     key.numRTVs = numRTVs;
     key.rtvFormat = rtvFormat;
+    key.dsvFormat = dsvFormat;
 
     auto it = m_psoCache.find(key);
     if (it != m_psoCache.end()) return it->second.Get();
@@ -607,13 +630,13 @@ namespace t800 {
     ComPtr<ID3D12PipelineState> psoObj;
     HRESULT hr = device->CreateGraphicsPipelineState(&pso, IID_PPV_ARGS(&psoObj));
     if (FAILED(hr)) {
-      T8_LOG_ERROR("[D3D12] CreatePSO failed hr=0x%08X key=0x%08X blend=%d depth=%d cull=%d nRTV=%d fmt=%d",
-                   hr, key.shaderKey, key.blend, key.depth, key.cull, key.numRTVs, key.rtvFormat);
+      T8_LOG_ERROR("[D3D12] CreatePSO failed hr=0x%08X shader=%p blend=%d depth=%d cull=%d nRTV=%d fmt=%d",
+                   hr, shader, key.blend, key.depth, key.cull, key.numRTVs, key.rtvFormat);
       return nullptr;
     }
 
-    T8_LOG_DEBUG("[D3D12] PSO created: shader=0x%08X blend=%d depth=%d cull=%d nRTV=%d",
-                 key.shaderKey, key.blend, key.depth, key.cull, key.numRTVs);
+    T8_LOG_DEBUG("[D3D12] PSO created: shader=%p blend=%d depth=%d cull=%d nRTV=%d",
+                 shader, key.blend, key.depth, key.cull, key.numRTVs);
     m_psoCache[key] = psoObj;
     return psoObj.Get();
   }
@@ -911,6 +934,7 @@ namespace t800 {
   }
 
   void D3D12Driver::SetCullFace(FACE_CULLING state) {
+    T8_LOG_TRACE("[D3D12] SetCullFace(%d)", state);
     m_currentCull = state; m_FaceCulling = state;
   }
 
@@ -1105,6 +1129,12 @@ namespace t800 {
       m_heaps[D3D12Heap::SAMPLER].GetHeap()
     };
     m_commandList->SetDescriptorHeaps(2, heaps);
+
+    // Rebind back buffer render targets, viewport, and scissor
+    // (OM state is lost after command list reset)
+    m_commandList->OMSetRenderTargets(1, &m_backBufferRTVs[m_currentBackBuffer], FALSE, &m_depthDSV);
+    m_commandList->RSSetViewports(1, &m_viewport);
+    m_commandList->RSSetScissorRects(1, &m_scissorRect);
   }
 
   void D3D12Driver::SaveRTToFile(int rtID, int attachment, std::string path) {
@@ -1124,6 +1154,14 @@ namespace t800 {
 
   void D3D12Driver::UploadBufferData(ID3D12Resource*, const void*, size_t, D3D12_RESOURCE_STATES) {}
 
+  void D3D12Driver::BindBackBufferNoDSV() {
+    T8_LOG_TRACE("[D3D12] BindBackBufferNoDSV: bb=%u viewport=%.0fx%.0f", m_currentBackBuffer, m_viewport.Width, m_viewport.Height);
+    // Pass the DSV even for depth-disabled draws — D3D12 is okay with an unused DSV bound
+    m_commandList->OMSetRenderTargets(1, &m_backBufferRTVs[m_currentBackBuffer], FALSE, &m_depthDSV);
+    m_commandList->RSSetViewports(1, &m_viewport);
+    m_commandList->RSSetScissorRects(1, &m_scissorRect);
+  }
+
   // ══════════════════════════════════════════════════════
   //  D3D12Driver — Dynamic CB ring allocator
   // ══════════════════════════════════════════════════════
@@ -1132,6 +1170,23 @@ namespace t800 {
     UINT alignedSize = (dataSize + 255) & ~255;
     if (m_cbRingOffset + alignedSize > kCBRingBufferSize) {
       T8_LOG_ERROR("[D3D12] CB ring buffer overflow! offset=%u + size=%u > %u", m_cbRingOffset, alignedSize, kCBRingBufferSize);
+      m_cbRingOffset = 0;
+    }
+
+    UINT bufIdx = m_currentBackBuffer;
+    unsigned char* dst = (unsigned char*)m_cbRingMapped[bufIdx] + m_cbRingOffset;
+    memcpy(dst, data, dataSize);
+
+    D3D12_GPU_VIRTUAL_ADDRESS gpuAddr = m_cbRingBuffers[bufIdx]->GetGPUVirtualAddress() + m_cbRingOffset;
+    m_cbRingOffset += alignedSize;
+    return gpuAddr;
+  }
+
+  D3D12_GPU_VIRTUAL_ADDRESS D3D12Driver::AllocateRingData(const void* data, UINT dataSize) {
+    // Use 256-byte alignment to stay compatible with CBV allocations from the same ring buffer
+    UINT alignedSize = (dataSize + 255) & ~255;
+    if (m_cbRingOffset + alignedSize > kCBRingBufferSize) {
+      T8_LOG_ERROR("[D3D12] Ring buffer overflow! offset=%u + size=%u > %u", m_cbRingOffset, alignedSize, kCBRingBufferSize);
       m_cbRingOffset = 0;
     }
 

--- a/T850/Framework/src/video/d3d12/D3D12Shader.cpp
+++ b/T850/Framework/src/video/d3d12/D3D12Shader.cpp
@@ -237,10 +237,13 @@ namespace t800 {
       }
     }
 
-    // Get or create PSO for current state
+    // Get or create PSO for current state (dsvFmt may be overridden to UNKNOWN inside if depth==NONE)
     ID3D12PipelineState* pso = driver->GetOrCreatePSO(this, numRTVs, rtvFmt, dsvFmt);
     if (pso) {
       cmdList->SetPipelineState(pso);
+      T8_LOG_TRACE("[D3D12] Shader::Set PSO=%p numRTVs=%d rtvFmt=%d dsvFmt=%d", pso, numRTVs, rtvFmt, dsvFmt);
+    } else {
+      T8_LOG_ERROR("[D3D12] Shader::Set PSO is NULL! key=0x%08X", key.bits);
     }
 
     // Bind default sampler if shader uses one

--- a/T850/Framework/src/video/d3d12/D3D12Texture.cpp
+++ b/T850/Framework/src/video/d3d12/D3D12Texture.cpp
@@ -323,7 +323,7 @@ namespace t800 {
   // ══════════════════════════════════════════════════════
 
   void D3D12Texture::Set(const DeviceContext& deviceContext, unsigned int slot, std::string shaderTextureName) {
-    T8_LOG_TRACE("[D3D12] Texture::Set slot=%u name='%s' file='%s'", slot, shaderTextureName.c_str(), filepath.c_str());
+    T8_LOG_TRACE("[D3D12] Texture::Set slot=%u name='%s' file='%s' srvGPU=0x%llX", slot, shaderTextureName.c_str(), filepath.c_str(), srvGPU.ptr);
     auto* cmdList = static_cast<const D3D12DeviceContext*>(&deviceContext)->GetCommandList();
     auto* shader = static_cast<D3D12Shader*>(deviceContext.actualShaderSet);
     if (!shader) return;

--- a/T850/config.json
+++ b/T850/config.json
@@ -17,16 +17,16 @@
                  "seconds":  5,
                  "trigger":  "frame",
                  "frame":  750,
-                 "enabled":  false
+                 "enabled":  true
              },
     "debugFrames":  false,
     "devTools":  {
                      "guiControlEdit":  false,
                      "d3d12Debug":  false,
-                     "guiControlTarget":  "linedit_popup",
+                     "guiControlTarget":  "slider_knob",
                      "logLevel":  "error",
                      "logToFile":  false,
                      "guiEdit":  false,
-                     "guiSnap":  false
+                     "guiSnap":  true
                  }
 }


### PR DESCRIPTION
- Fix per-draw vertex buffer: use ring buffer suballocation so each DrawIndexed within a command list sees its own vertex data (D3D12 upload heap VBs are overwritten in-place unlike D3D11 UpdateSubresource)
- Fix PSO cache key: use shader pointer instead of ShaderKey bits to prevent collisions between GUI/text/post-processing shaders (all had bits=0xFFFFFFFF)
- Add dsvFormat to PSO cache key to prevent format mismatches
- Fix DSV null binding error: keep D32_FLOAT format in PSO even when depth is disabled (DepthEnable=FALSE handles it)
- Per-texture samplers: D3D12 now creates samplers matching D3D11 (WRAP/CLAMP/BORDER/filter modes) instead of single global sampler
- Fix SaveScreenshot: flush command list before readback, rebind OM state after reopening
- Add sampler for white 1x1 GUI texture and font atlas texture
- Add --testGui mode for isolated GUI rendering test
- Set FRONT_AND_BACK cull face for GUI draws