### PR TITLE
Add Recast nav agents and debug visualization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,21 +49,21 @@ jobs:
         shell: pwsh
         run: |
           cd T850/Librerias/vcpkg
-          ./vcpkg.exe install --recurse glew:x86-windows-static angle:x86-windows draco:x86-windows draco:x86-windows-static vulkan-headers:x86-windows-static vulkan-loader:x86-windows-static vulkan-memory-allocator:x86-windows-static glslang:x86-windows-static joltphysics:x86-windows-static "imgui[docking-experimental,dx11-binding,vulkan-binding,opengl3-binding,sdl3-binding,win32-binding]:x86-windows-static"
+          ./vcpkg.exe install --recurse glew:x86-windows-static angle:x86-windows draco:x86-windows draco:x86-windows-static vulkan-headers:x86-windows-static vulkan-loader:x86-windows-static vulkan-memory-allocator:x86-windows-static glslang:x86-windows-static joltphysics:x86-windows-static recastnavigation:x86-windows-static "imgui[docking-experimental,dx11-binding,vulkan-binding,opengl3-binding,sdl3-binding,win32-binding]:x86-windows-static"
 
       - name: Install vcpkg packages (x64)
         if: matrix.platform == 'x64'
         shell: pwsh
         run: |
           cd T850/Librerias/vcpkg
-          ./vcpkg.exe install --recurse glew:x64-windows-static angle:x64-windows draco:x64-windows draco:x64-windows-static vulkan-headers:x64-windows-static vulkan-loader:x64-windows-static vulkan-memory-allocator:x64-windows-static glslang:x64-windows-static joltphysics:x64-windows-static "imgui[docking-experimental,dx11-binding,dx12-binding,vulkan-binding,opengl3-binding,sdl3-binding,win32-binding]:x64-windows-static" imguizmo:x64-windows-static
+          ./vcpkg.exe install --recurse glew:x64-windows-static angle:x64-windows draco:x64-windows draco:x64-windows-static vulkan-headers:x64-windows-static vulkan-loader:x64-windows-static vulkan-memory-allocator:x64-windows-static glslang:x64-windows-static joltphysics:x64-windows-static recastnavigation:x64-windows-static "imgui[docking-experimental,dx11-binding,dx12-binding,vulkan-binding,opengl3-binding,sdl3-binding,win32-binding]:x64-windows-static" imguizmo:x64-windows-static
 
       - name: Install vcpkg packages (ARM64)
         if: matrix.platform == 'ARM64'
         shell: pwsh
         run: |
           cd T850/Librerias/vcpkg
-          ./vcpkg.exe install --recurse glew:arm64-windows-static angle:arm64-windows draco:arm64-windows draco:arm64-windows-static vulkan-headers:arm64-windows-static vulkan-loader:arm64-windows-static vulkan-memory-allocator:arm64-windows-static glslang:arm64-windows-static joltphysics:arm64-windows-static "imgui[docking-experimental,dx11-binding,dx12-binding,vulkan-binding,opengl3-binding,sdl3-binding,win32-binding]:arm64-windows-static"
+          ./vcpkg.exe install --recurse glew:arm64-windows-static angle:arm64-windows draco:arm64-windows draco:arm64-windows-static vulkan-headers:arm64-windows-static vulkan-loader:arm64-windows-static vulkan-memory-allocator:arm64-windows-static glslang:arm64-windows-static joltphysics:arm64-windows-static recastnavigation:arm64-windows-static "imgui[docking-experimental,dx11-binding,dx12-binding,vulkan-binding,opengl3-binding,sdl3-binding,win32-binding]:arm64-windows-static"
 
       - name: Build
         shell: pwsh

--- a/LaunchSolution.bat
+++ b/LaunchSolution.bat
@@ -88,7 +88,7 @@ echo  T850 — Installing vcpkg dependencies
 echo ════════════════════════════════════════
 
 :: ── Common packages for all platforms ──
-set "PACKAGES=glew vulkan-headers vulkan-loader vulkan-memory-allocator glslang draco joltphysics"
+set "PACKAGES=glew vulkan-headers vulkan-loader vulkan-memory-allocator glslang draco joltphysics recastnavigation"
 set "PACKAGES_DYNAMIC=angle draco"
 
 :: ── x64 (always) ──

--- a/SetupAndroidToolchain.bat
+++ b/SetupAndroidToolchain.bat
@@ -316,5 +316,5 @@ if exist "%IMGUI_INCLUDE_DIR%\imgui.h" (
         if errorlevel 1 exit /b 1
     )
 )
-set "VCPKG_PACKAGES=!VCPKG_PACKAGES! draco:%ANDROID_TRIPLET% glslang:%ANDROID_TRIPLET% joltphysics:%ANDROID_TRIPLET% imgui[android-binding,docking-experimental,vulkan-binding]:%ANDROID_TRIPLET%"
+set "VCPKG_PACKAGES=!VCPKG_PACKAGES! draco:%ANDROID_TRIPLET% glslang:%ANDROID_TRIPLET% joltphysics:%ANDROID_TRIPLET% recastnavigation:%ANDROID_TRIPLET% imgui[android-binding,docking-experimental,vulkan-binding]:%ANDROID_TRIPLET%"
 exit /b 0

--- a/T850/Assets/Scenes/DayScene.json
+++ b/T850/Assets/Scenes/DayScene.json
@@ -807,6 +807,11 @@
          "default_val": false
       },
       {
+         "name": "show_navmesh",
+         "label": "NavMesh",
+         "default_val": false
+      },
+      {
          "name": "dof_toggle",
          "label": "DOF",
          "default_val": true

--- a/T850/Assets/Scenes/Q3/q3dm6_mod_3.t8scene
+++ b/T850/Assets/Scenes/Q3/q3dm6_mod_3.t8scene
@@ -58,7 +58,8 @@
          },
          "visible": true,
          "frozen": false,
-         "show_wire": false
+         "show_wire": false,
+         "nav_agent_front_yaw_offset_deg": 270
       },
       {
          "name": "Models/doomslayer_cine_all_animations_no-damage_double-sided-opaque.glb Clone",
@@ -81,7 +82,8 @@
          },
          "visible": true,
          "frozen": false,
-         "show_wire": false
+         "show_wire": false,
+         "nav_agent_front_yaw_offset_deg": 270
       },
       {
          "name": "Models\\rewind_cyborg.glb",
@@ -104,7 +106,8 @@
          },
          "visible": true,
          "frozen": false,
-         "show_wire": false
+         "show_wire": false,
+         "nav_agent_front_yaw_offset_deg": 180
       },
       {
          "name": "Models\\rewind_cyborg.glb Clone",
@@ -127,7 +130,8 @@
          },
          "visible": true,
          "frozen": false,
-         "show_wire": false
+         "show_wire": false,
+         "nav_agent_front_yaw_offset_deg": 180
       },
       {
          "name": "Models\\rewind_cyborg.glb Clone Clone",
@@ -150,7 +154,8 @@
          },
          "visible": true,
          "frozen": false,
-         "show_wire": false
+         "show_wire": false,
+         "nav_agent_front_yaw_offset_deg": 180
       },
       {
          "name": "Models\\porsche_992_gt3_r__www.vecarz.com.glb",

--- a/T850/Assets/Scenes/SandboxScene.json
+++ b/T850/Assets/Scenes/SandboxScene.json
@@ -389,6 +389,12 @@
          "enabled": true
       },
       {
+         "name": "show_navmesh",
+         "label": "NavMesh",
+         "default_val": false,
+         "enabled": true
+      },
+      {
          "name": "show_light_volumes",
          "label": "Light Volumes",
          "default_val": false,

--- a/T850/Assets/Shaders/FS_EditorLine.hlsl
+++ b/T850/Assets/Shaders/FS_EditorLine.hlsl
@@ -1,7 +1,7 @@
 // Editor line fragment shader — depth-tested wireframe overlay.
 // Samples GBuffer depth and discards fragments behind geometry.
 // A small bias pushes wireframe slightly in front of the surface to avoid Z-fighting.
-cbuffer ConstantBuffer{
+cbuffer ConstantBuffer : register(b0) {
     float4x4 WVP;
     float4   LineColor;
     float4   DepthParams;  // x=1/viewW, y=1/viewH, z=farPlane, w=depthBias
@@ -13,10 +13,11 @@ SamplerState SS : register(s0);
 struct VS_OUTPUT{
     float4 hposition  : SV_POSITION;
     float  clipDepth : TEXCOORD0;
+    float2 screenUV : TEXCOORD1;
 };
 
 float4 FS( VS_OUTPUT input ) : SV_TARGET {
-    float2 screenUV = input.hposition.xy * DepthParams.xy;
+    float2 screenUV = saturate(input.screenUV);
     float sceneDepth = depthTex.Sample(SS, screenUV).r;
 
     float wireDepth = saturate(input.clipDepth * (1.0 + DepthParams.w));

--- a/T850/Assets/Shaders/FS_LineFlat.hlsl
+++ b/T850/Assets/Shaders/FS_LineFlat.hlsl
@@ -1,6 +1,6 @@
 // Flat line fragment shader — always visible, no depth testing.
 // Used for skeleton/bone debug visualization that should draw on top.
-cbuffer ConstantBuffer{
+cbuffer ConstantBuffer : register(b0) {
     float4x4 WVP;
     float4   LineColor;
     float4   DepthParams;

--- a/T850/Assets/Shaders/VS_EditorLine.hlsl
+++ b/T850/Assets/Shaders/VS_EditorLine.hlsl
@@ -1,6 +1,6 @@
 // Editor line vertex shader — depth-tested wireframe overlay.
 // Outputs screen UV and clip depth for comparison with GBuffer depth.
-cbuffer ConstantBuffer{
+cbuffer ConstantBuffer : register(b0) {
     float4x4 WVP;
     float4   LineColor;
     float4   DepthParams;  // x=1/viewW, y=1/viewH, z=farPlane, w=unused
@@ -13,11 +13,14 @@ struct VS_INPUT{
 struct VS_OUTPUT{
     float4 hposition  : SV_POSITION;
     float  clipDepth : TEXCOORD0;
+    float2 screenUV : TEXCOORD1;
 };
 
 VS_OUTPUT VS( VS_INPUT input ){
     VS_OUTPUT OUT;
     OUT.hposition = mul(WVP, input.position);
     OUT.clipDepth = OUT.hposition.z / OUT.hposition.w;
+    float2 ndc = OUT.hposition.xy / OUT.hposition.w;
+    OUT.screenUV = float2(ndc.x * 0.5 + 0.5, 0.5 - ndc.y * 0.5);
     return OUT;
 }

--- a/T850/CMakeLists.txt
+++ b/T850/CMakeLists.txt
@@ -109,7 +109,8 @@ function(t850_ensure_vcpkg)
 		glslang:${T850_VCPKG_STATIC_TRIPLET})
 
 	list(APPEND T850_VCPKG_PACKAGE_SPECS
-		joltphysics:${T850_VCPKG_STATIC_TRIPLET})
+		joltphysics:${T850_VCPKG_STATIC_TRIPLET}
+		recastnavigation:${T850_VCPKG_STATIC_TRIPLET})
 
 	set(T850_IMGUI_HEADER ${T850_VCPKG_STATIC}/include/imgui.h)
 	set(T850_IMGUI_DX11_HEADER ${T850_VCPKG_STATIC}/include/imgui_impl_dx11.h)
@@ -166,10 +167,20 @@ list(APPEND CMAKE_PREFIX_PATH ${T850_VCPKG_STATIC})
 set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)
 set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL Release)
 find_package(Jolt CONFIG REQUIRED)
+find_package(recastnavigation CONFIG REQUIRED)
 set_target_properties(Jolt::Jolt PROPERTIES
 	MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
 	MAP_IMPORTED_CONFIG_MINSIZEREL Release)
+set_target_properties(
+	RecastNavigation::Recast
+	RecastNavigation::Detour
+	RecastNavigation::DetourCrowd
+	RecastNavigation::DetourTileCache
+	PROPERTIES
+	MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
+	MAP_IMPORTED_CONFIG_MINSIZEREL Release)
 set(T850_JOLT_ENABLED ON)
+set(T850_RECAST_ENABLED ON)
 
 if(EXISTS ${T850_VCPKG_DYNAMIC}/bin/zlib1.dll)
 	set(T850_ZLIB_RUNTIME_DLL ${T850_VCPKG_DYNAMIC}/bin/zlib1.dll)

--- a/T850/DayScene/DayScene.cpp
+++ b/T850/DayScene/DayScene.cpp
@@ -198,6 +198,7 @@ void DayScene::CaptureSceneProfileState(t850::SandboxProfileDesc& state) const {
   addFloat("material_emissive_intensity", SceneProp.MaterialEmissiveIntensity);
   addFloat("material_transmission_multiplier", SceneProp.MaterialTransmissionMultiplier);
   addFloat("material_refraction_strength", SceneProp.MaterialRefractionStrength);
+  addFloat("navmesh_debug_offset", m_navMeshDebugOffset);
   if (ActiveCam) addFloat("fov", Rad2Deg(ActiveCam->Fov));
 
   for (int kernelIndex = 0; kernelIndex < (int)SceneProp.pGaussKernels.size(); ++kernelIndex) {
@@ -215,6 +216,7 @@ void DayScene::CaptureSceneProfileState(t850::SandboxProfileDesc& state) const {
   addBool("show_spline", m_showSpline);
   addBool("show_lights", m_showLights);
   addBool("show_physics", m_showPhysics);
+  addBool("show_navmesh", m_showNavMesh);
   addBool("dof_toggle", SceneProp.ToogleDOF != 0);
   addBool("parallax_toggle", SceneProp.ToogleParallax != 0);
   addBool("parallax_shadow_toggle", SceneProp.ToogleParallaxShadow != 0);
@@ -230,6 +232,7 @@ void DayScene::CaptureSceneProfileState(t850::SandboxProfileDesc& state) const {
   addInt("active_camera", m_activeCameraIndex);
   addInt("cubemap", m_currentCubemapIndex);
   addInt("luminance_mode", SceneProp.LuminanceMode);
+  addInt("navmesh_debug_shape", m_navMeshDebugShapeMode);
 }
 
 void DayScene::ApplySceneProfileState(const t850::SandboxProfileDesc& state) {
@@ -267,6 +270,7 @@ void DayScene::ApplySceneProfileState(const t850::SandboxProfileDesc& state) {
     else if (value.name == "material_emissive_intensity") SceneProp.MaterialEmissiveIntensity = value.value;
     else if (value.name == "material_transmission_multiplier") SceneProp.MaterialTransmissionMultiplier = value.value;
     else if (value.name == "material_refraction_strength") SceneProp.MaterialRefractionStrength = value.value;
+    else if (value.name == "navmesh_debug_offset") m_navMeshDebugOffset = (std::max)(0.0f, (std::min)(0.25f, value.value));
     else if (value.name == "fov" && ActiveCam) { ActiveCam->SetFov(Deg2Rad(value.value)); ActiveCam->VP = ActiveCam->View * ActiveCam->Projection; VP = ActiveCam->VP; }
 
     for (int kernelIndex = 0; kernelIndex < (int)SceneProp.pGaussKernels.size(); ++kernelIndex) {
@@ -285,6 +289,10 @@ void DayScene::ApplySceneProfileState(const t850::SandboxProfileDesc& state) {
     else if (value.name == "show_spline") m_showSpline = value.value;
     else if (value.name == "show_lights") m_showLights = value.value;
     else if (value.name == "show_physics") m_showPhysics = value.value;
+    else if (value.name == "show_navmesh") {
+      m_showNavMesh = value.value;
+      if (m_showNavMesh && !m_navMesh.IsReady()) m_navMeshBuildAttempted = false;
+    }
     else if (value.name == "dof_toggle") { SceneProp.ToogleDOF = value.value ? 1 : 0; m_renderGraph.SetPassEnabled("CoC", value.value); m_renderGraph.SetPassEnabled("Combine CoC", value.value); m_renderGraph.SetPassEnabled("DOF", value.value); m_renderGraph.SetPassEnabled("DOF 2", value.value); }
     else if (value.name == "parallax_toggle") { SceneProp.ToogleParallax = value.value ? 1 : 0; if (Meshes[0].pBase) Meshes[0].SetParallaxEnabled(value.value); }
     else if (value.name == "parallax_shadow_toggle") { SceneProp.ToogleParallaxShadow = value.value ? 1 : 0; SceneProp.ParallaxShadowStrength = value.value ? SceneProp.ParallaxShadowStrength : 0.0f; }
@@ -302,6 +310,7 @@ void DayScene::ApplySceneProfileState(const t850::SandboxProfileDesc& state) {
     else if (value.name == "luminance_mode") SceneProp.LuminanceMode = value.value;
     else if (value.name == "active_camera") ApplyActiveCameraSelection(value.value);
     else if (value.name == "cubemap") m_currentCubemapIndex = value.value;
+    else if (value.name == "navmesh_debug_shape") m_navMeshDebugShapeMode = (std::max)(0, (std::min)(1, value.value));
     for (int kernelIndex = 0; kernelIndex < (int)SceneProp.pGaussKernels.size(); ++kernelIndex) {
       GaussFilter* kernel = SceneProp.pGaussKernels[kernelIndex];
       if (!kernel) continue;
@@ -337,6 +346,40 @@ t850::SandboxProfileDesc DayScene::BuildSparseSceneProfile(const t850::SandboxPr
     if (!baseline || value.value != baseline->value) sparse.selectors.push_back(value);
   }
   return sparse;
+}
+
+bool DayScene::EnsureNavMeshBuilt() {
+  if (m_navMesh.IsReady()) {
+    return true;
+  }
+  if (m_navMeshBuildAttempted) {
+    return false;
+  }
+  m_navMeshBuildAttempted = true;
+
+  t850::navigation::NavMeshGeometry geometry;
+  t850::navigation::NavSourceBuildStats sourceStats;
+  std::string error;
+  if (!t850::navigation::BuildGeometryFromPrimitiveInstances(Meshes, 1, geometry, &sourceStats, &error)) {
+    T8_LOG_ERROR("[Navigation] DayScene navmesh geometry extraction failed: %s (considered=%d included=%d skippedInvisible=%d skippedSkinned=%d skippedInvalid=%d)",
+                 error.c_str(),
+                 sourceStats.considered,
+                 sourceStats.included,
+                 sourceStats.skippedInvisible,
+                 sourceStats.skippedSkinned,
+                 sourceStats.skippedInvalid);
+    return false;
+  }
+  if (!m_navMesh.Build(geometry, t850::navigation::NavMeshBuildSettings(), &error)) {
+    T8_LOG_ERROR("[Navigation] DayScene navmesh build failed: %s", error.c_str());
+    return false;
+  }
+
+  m_navMeshDebugRenderer.Invalidate();
+  const t850::navigation::NavMeshBuildStats& stats = m_navMesh.GetStats();
+  T8_LOG_INFO("[Navigation] DayScene navmesh ready: sources=%d verts=%d tris=%d polys=%d",
+              sourceStats.included, stats.vertexCount, stats.triangleCount, stats.polygonCount);
+  return true;
 }
 
 void DayScene::LoadSceneProfile() {
@@ -442,6 +485,8 @@ void DayScene::InitVars() {
 
   CamSelection = NORMAL_CAM1;
   SceneSettingSelection = CHANGE_EXPOSURE;
+  m_navMeshDebugOffset = 0.01f;
+  m_navMeshDebugShapeMode = 0;
 
   // Default-initialize scene properties — JSON will overwrite them
   VP.Identity();
@@ -662,6 +707,9 @@ void DayScene::CreateAssets() {
   m_wireframeSphere.Create(8, 16);
   m_wireframeArrow.Create(24, 6);
   m_physicsDebugRenderer.Create();
+  m_navMeshDebugRenderer.Create();
+  m_navMesh.Clear();
+  m_navMeshBuildAttempted = false;
   m_debugText.LoadFromFile(24, "Fonts/Martius-LV9L4.ttf", 512.0f);
 
   t850::Spline& m_spline = m_sceneSetup.splines[0];
@@ -1244,6 +1292,9 @@ void DayScene::DestroyAssets() {
   SceneProp.SSAOKernel.Destroy();
   m_debugText.Destroy();
   m_physicsDebugRenderer.Destroy();
+  m_navMeshDebugRenderer.Destroy();
+  m_navMesh.Clear();
+  m_navMeshBuildAttempted = false;
   m_wireframeSphere.Destroy();
   m_wireframeArrow.Destroy();
   PrimitiveMgr.DestroyPrimitives();
@@ -1649,34 +1700,52 @@ void DayScene::OnDraw() {
     }
   }
 
-  auto drawPhysicsDebugOverlay = [this, viewCam]() {
-    if (!m_showPhysics) {
-      return;
+  auto drawDebugOverlays = [this, viewCam]() {
+    if (m_showPhysics) {
+      t850::EngineContext* engineContext = GetEngineContext();
+      if (!engineContext) engineContext = &t850::GetEngineContext();
+      if (engineContext && engineContext->physics && m_physicsDebugRenderer.IsReady()) {
+        m_physicsDebugRenderer.SetDepthTexture(nullptr);
+        m_physicsDebugRenderer.SetDepthTestEnabled(false);
+        m_physicsDebugRenderer.SetViewport(g_pBaseDriver->width, g_pBaseDriver->height);
+        m_physicsDebugRenderer.SetFarPlane(viewCam ? viewCam->FPlane : 1000.0f);
+        pFramework->pVideoDriver->SetDepthStencilState(BaseDriver::NONE);
+        pFramework->pVideoDriver->SetBlendState(BaseDriver::BLEND_DEFAULT);
+        m_physicsDebugRenderer.Draw(*engineContext->physics, VP);
+      }
     }
 
-    t850::EngineContext* engineContext = GetEngineContext();
-    if (!engineContext) engineContext = &t850::GetEngineContext();
-    if (!engineContext || !engineContext->physics || !m_physicsDebugRenderer.IsReady()) {
-      return;
+    if (m_showNavMesh && m_navMeshDebugRenderer.IsReady() && EnsureNavMeshBuilt()) {
+      Texture* depthTexture = nullptr;
+      if (GBufferPass >= 0 && GBufferPass < (int)pFramework->pVideoDriver->RTs.size()) {
+        if (auto* gbufRT = pFramework->pVideoDriver->RTs[GBufferPass]) {
+          depthTexture = gbufRT->pDepthTexture;
+        }
+      }
+      if (depthTexture) {
+        m_navMeshDebugRenderer.SetVerticalOffset(m_navMeshDebugOffset);
+        m_navMeshDebugRenderer.SetGraphVerticalOffset(m_navMeshDebugOffset + 0.005f);
+        m_navMeshDebugRenderer.SetShapeMode(m_navMeshDebugShapeMode == 1
+            ? t850::navigation::NavMeshDebugShapeMode::Nodes
+            : t850::navigation::NavMeshDebugShapeMode::Geometry);
+        m_navMeshDebugRenderer.SetDepthTexture(depthTexture);
+        m_navMeshDebugRenderer.SetViewport(g_pBaseDriver->width, g_pBaseDriver->height);
+        m_navMeshDebugRenderer.SetFarPlane(viewCam ? viewCam->FPlane : 1000.0f);
+        pFramework->pVideoDriver->SetDepthStencilState(BaseDriver::NONE);
+        pFramework->pVideoDriver->SetBlendState(BaseDriver::BLEND_DEFAULT);
+        m_navMeshDebugRenderer.Draw(m_navMesh, VP);
+      }
     }
-
-    m_physicsDebugRenderer.SetDepthTexture(nullptr);
-    m_physicsDebugRenderer.SetDepthTestEnabled(false);
-    m_physicsDebugRenderer.SetViewport(g_pBaseDriver->width, g_pBaseDriver->height);
-    m_physicsDebugRenderer.SetFarPlane(viewCam ? viewCam->FPlane : 1000.0f);
-    pFramework->pVideoDriver->SetDepthStencilState(BaseDriver::NONE);
-    pFramework->pVideoDriver->SetBlendState(BaseDriver::BLEND_DEFAULT);
-    m_physicsDebugRenderer.Draw(*engineContext->physics, VP);
   };
 
 #ifdef OS_ANDROID
-  if (m_showPhysics) {
+  if (m_showPhysics || m_showNavMesh) {
     if (auto* vkDriver = static_cast<VulkanDriver*>(pFramework->pVideoDriver)) {
-      vkDriver->SetPrePresentOverlayCallback(drawPhysicsDebugOverlay);
+      vkDriver->SetPrePresentOverlayCallback(drawDebugOverlays);
     }
   }
 #else
-  drawPhysicsDebugOverlay();
+  drawDebugOverlays();
 #endif
 
   if (SceneProp.pCameras[0]->Eye.y > 80) {
@@ -2370,6 +2439,7 @@ void DayScene::DrawDevGui(t850::DevGuiContext& gui) {
     {"show_spline", CHANGE_SHOW_SPLINE},
     {"show_lights", CHANGE_SHOW_LIGHTS},
     {"show_physics", CHANGE_SHOW_PHYSICS},
+    {"show_navmesh", CHANGE_SHOW_NAVMESH},
     {"dof_toggle", CHANGE_DOF_TOGGLE},
     {"parallax_toggle", CHANGE_PARALLAX_TOGGLE},
     {"parallax_shadow_toggle", CHANGE_PARALLAX_SHADOW_TOGGLE},
@@ -2500,6 +2570,7 @@ void DayScene::DrawDevGui(t850::DevGuiContext& gui) {
     case CHANGE_SHOW_SPLINE: value = m_showSpline; return true;
     case CHANGE_SHOW_LIGHTS: value = m_showLights; return true;
     case CHANGE_SHOW_PHYSICS: value = m_showPhysics; return true;
+    case CHANGE_SHOW_NAVMESH: value = m_showNavMesh; return true;
     case CHANGE_DOF_TOGGLE: value = (SceneProp.ToogleDOF != 0); return true;
     case CHANGE_PARALLAX_TOGGLE: value = (SceneProp.ToogleParallax != 0); return true;
     case CHANGE_PARALLAX_SHADOW_TOGGLE: value = (SceneProp.ToogleParallaxShadow != 0); return true;
@@ -2517,6 +2588,10 @@ void DayScene::DrawDevGui(t850::DevGuiContext& gui) {
     case CHANGE_SHOW_SPLINE: m_showSpline = value; break;
     case CHANGE_SHOW_LIGHTS: m_showLights = value; break;
     case CHANGE_SHOW_PHYSICS: m_showPhysics = value; break;
+    case CHANGE_SHOW_NAVMESH:
+      m_showNavMesh = value;
+      if (m_showNavMesh && !m_navMesh.IsReady()) m_navMeshBuildAttempted = false;
+      break;
     case CHANGE_DOF_TOGGLE:
       SceneProp.ToogleDOF = value ? 1 : 0;
       m_renderGraph.SetPassEnabled("CoC", value);
@@ -2610,6 +2685,17 @@ void DayScene::DrawDevGui(t850::DevGuiContext& gui) {
         setCheckboxValue(settingIndex, value);
       }
     }
+    t850::SliderDesc navOffsetDesc;
+    navOffsetDesc.name = "navmesh_debug_offset";
+    navOffsetDesc.label = "NavMesh offset";
+    navOffsetDesc.min_val = 0.0f;
+    navOffsetDesc.max_val = 0.25f;
+    navOffsetDesc.step = 0.001f;
+    navOffsetDesc.default_val = 0.01f;
+    gui.Slider(navOffsetDesc, m_navMeshDebugOffset);
+    const char* navShapeOptions[] = { "Geometry", "Nodes" };
+    ImGui::SetNextItemWidth(180.0f);
+    ImGui::Combo("NavMesh magenta", &m_navMeshDebugShapeMode, navShapeOptions, 2);
   }
 
   if (gui.BeginSection("Selectors")) {
@@ -2697,6 +2783,19 @@ void DayScene::DrawAndroidPhysicsPanel(t850::DevGuiContext& gui) {
     m_showPhysics = showPhysics;
     T8_LOG_INFO("[PHYSICS] Debug draw %s", m_showPhysics ? "enabled" : "disabled");
   }
+  bool showNavMesh = m_showNavMesh;
+  if (ImGui::Checkbox("NavMesh Debug", &showNavMesh)) {
+    m_showNavMesh = showNavMesh;
+    if (m_showNavMesh && !m_navMesh.IsReady()) m_navMeshBuildAttempted = false;
+    T8_LOG_INFO("[Navigation] Debug draw %s", m_showNavMesh ? "enabled" : "disabled");
+  }
+  const char* navShapeOptions[] = { "Geometry", "Nodes" };
+  ImGui::SetNextItemWidth(170.0f);
+  ImGui::Combo("NavMesh magenta", &m_navMeshDebugShapeMode, navShapeOptions, 2);
+  ImGui::SetNextItemWidth(220.0f);
+  if (ImGui::SliderFloat("NavMesh offset", &m_navMeshDebugOffset, 0.0f, 0.25f, "%.3f")) {
+    m_navMeshDebugOffset = (std::max)(0.0f, (std::min)(0.25f, m_navMeshDebugOffset));
+  }
   ImGui::TextWrapped("Left triple-tap opens this physics panel. Right triple-tap opens full scene controls.");
 }
 #endif
@@ -2731,6 +2830,7 @@ void DayScene::SaveSceneState() {
     else if (cd.name == "shadow_toggle")    cd.default_val = (SceneProp.ToogleShadow != 0);
     else if (cd.name == "ssao_toggle")      cd.default_val = (SceneProp.ToogleSSAO != 0);
     else if (cd.name == "dof_auto_focus")   cd.default_val = SceneProp.AutoFocus;
+    else if (cd.name == "show_navmesh")      cd.default_val = m_showNavMesh;
     else if (cd.name == "point_lights_enabled") cd.default_val = SceneProp.PointLightsEnabled;
   }
 

--- a/T850/DayScene/DayScene.h
+++ b/T850/DayScene/DayScene.h
@@ -10,6 +10,8 @@
 #include <scene/RenderGraph.h>
 #include <debug/FrameDumper.h>
 #include <physics/PhysicsDebugRenderer.h>
+#include <navigation/NavigationDebugRenderer.h>
+#include <navigation/NavigationSystem.h>
 #include <scene/LensFlare.h>
 #include <scene/TextRenderer.h>
 #include <Config.h>
@@ -90,6 +92,7 @@ class DayScene : public t850::SceneBase
     CHANGE_PARALLAX_SHADOW_STRENGTH,
     CHANGE_PARALLAX_SHADOW_TOGGLE,
     CHANGE_SHOW_PHYSICS,
+    CHANGE_SHOW_NAVMESH,
     CHANGE_POINT_LIGHTS_ENABLED,
     CHANGE_MAX_NUM_OPTIONS
   };
@@ -134,6 +137,7 @@ class DayScene : public t850::SceneBase
   void CaptureSceneProfileState(t850::SandboxProfileDesc& state) const;
   void ApplySceneProfileState(const t850::SandboxProfileDesc& state);
   t850::SandboxProfileDesc BuildSparseSceneProfile(const t850::SandboxProfileDesc& current) const;
+  bool EnsureNavMeshBuilt();
 
   struct BenchmarkCullingTotals {
     unsigned long long samples = 0;
@@ -233,9 +237,15 @@ class DayScene : public t850::SceneBase
   t850::WireframeSphere m_wireframeSphere;
   t850::WireframeArrow m_wireframeArrow;
   t850::PhysicsDebugRenderer m_physicsDebugRenderer;
+  t850::navigation::NavMeshDebugRenderer m_navMeshDebugRenderer;
+  t850::navigation::NavMesh m_navMesh;
   t850::TextRenderer m_debugText;
   bool m_showCullStats = false;
   bool m_showPhysics = false;
+  bool m_showNavMesh = false;
+  float m_navMeshDebugOffset = 0.01f;
+  int m_navMeshDebugShapeMode = 0;
+  bool m_navMeshBuildAttempted = false;
   float m_tourTimeSec = 0.0f;
   std::vector<double> m_benchmarkFrameTimesMs;
   BenchmarkCullingTotals m_benchmarkCullingTotals;

--- a/T850/DayScene/DayScene.vcxproj
+++ b/T850/DayScene/DayScene.vcxproj
@@ -160,7 +160,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\debug\lib;$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;Recast-d.lib;Detour-d.lib;DetourCrowd-d.lib;DetourTileCache-d.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Link>
     <PostBuildEvent>
@@ -197,7 +197,7 @@ copy /Y "$(SolutionDir)config.json" "$(OutDir)"</Command>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\debug\lib;$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;Recast-d.lib;Detour-d.lib;DetourCrowd-d.lib;DetourTileCache-d.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Link>
     <PostBuildEvent>
@@ -234,7 +234,7 @@ copy /Y "$(SolutionDir)config.json" "$(OutDir)"</Command>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\debug\lib;$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;Recast-d.lib;Detour-d.lib;DetourCrowd-d.lib;DetourTileCache-d.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Link>
     <PostBuildEvent>
@@ -272,7 +272,7 @@ copy /Y "$(SolutionDir)config.json" "$(OutDir)"</Command>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;Recast.lib;Detour.lib;DetourCrowd.lib;DetourTileCache.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
@@ -313,7 +313,7 @@ copy /Y "$(SolutionDir)config.json" "$(OutDir)"</Command>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;Recast.lib;Detour.lib;DetourCrowd.lib;DetourTileCache.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
@@ -354,7 +354,7 @@ copy /Y "$(SolutionDir)config.json" "$(OutDir)"</Command>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;vulkan-1.lib;Jolt.lib;Recast.lib;Detour.lib;DetourCrowd.lib;DetourTileCache.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>

--- a/T850/DayScene/SandboxScene.cpp
+++ b/T850/DayScene/SandboxScene.cpp
@@ -55,9 +55,148 @@ namespace {
   constexpr std::array<const char*, 9> kRagdollSimulationSpeedLabels = {
       "0.125x", "0.25x", "0.5x", "1x", "2x", "4x", "8x", "16x", "32x"};
   constexpr std::size_t kSandboxConsoleMaxLines = 500;
+  constexpr int kNavTestModeFurthest = 0;
+  constexpr int kNavTestModeRandom = 1;
+  constexpr int kNavTestModeFollowPlayer = 2;
+  constexpr float kNavTestDiagIntervalSec = 1.0f / 60.0f;
+  constexpr float kNavTestFailedPathRetrySec = 0.25f;
 
   float ClampMouseSensitivity(float value) {
     return (std::max)(0.05f, (std::min)(5.0f, value));
+  }
+
+  int ClampNavTestMode(int value) {
+    return (std::max)(kNavTestModeFurthest, (std::min)(kNavTestModeFollowPlayer, value));
+  }
+
+  float DistanceSquared(const XVECTOR3& a, const XVECTOR3& b) {
+    const float dx = a.x - b.x;
+    const float dy = a.y - b.y;
+    const float dz = a.z - b.z;
+    return dx * dx + dy * dy + dz * dz;
+  }
+
+  uint32_t NextNavTestRandom(uint32_t& state, uint32_t salt) {
+    state = state * 1664525u + 1013904223u + salt * 747796405u;
+    return state;
+  }
+
+  XVECTOR3 FurthestNavTestPoint(const std::vector<XVECTOR3>& points, const XVECTOR3& origin) {
+    XVECTOR3 best = origin;
+    float bestDistanceSq = -1.0f;
+    for (const XVECTOR3& point : points) {
+      const float distanceSq = DistanceSquared(point, origin);
+      if (distanceSq > bestDistanceSq) {
+        bestDistanceSq = distanceSq;
+        best = point;
+      }
+    }
+    return best;
+  }
+
+  XVECTOR3 RandomNavTestPoint(const std::vector<XVECTOR3>& points,
+                              XVECTOR3 fallback,
+                              uint32_t& randomState,
+                              uint32_t salt) {
+    if (points.empty()) {
+      return fallback;
+    }
+    for (std::size_t attempt = 0; attempt < points.size(); ++attempt) {
+      const uint32_t value = NextNavTestRandom(randomState, salt + static_cast<uint32_t>(attempt));
+      const XVECTOR3 candidate = points[static_cast<std::size_t>(value % points.size())];
+      if (DistanceSquared(candidate, fallback) > 0.25f) {
+        return candidate;
+      }
+    }
+    return points[static_cast<std::size_t>(NextNavTestRandom(randomState, salt) % points.size())];
+  }
+
+  XVECTOR3 HorizontalOrFallback(XVECTOR3 value, const XVECTOR3& fallback) {
+    value.y = 0.0f;
+    value.w = 0.0f;
+    if (value.Length() <= 0.0001f) {
+      value = fallback;
+    }
+    value.Normalize();
+    return value;
+  }
+
+  XVECTOR3 NavTestAgentProjectionExtents() {
+    return XVECTOR3(3.0f, 16.0f, 3.0f, 0.0f);
+  }
+
+  XVECTOR3 NavTestFollowProjectionExtents() {
+    return XVECTOR3(8.0f, 32.0f, 8.0f, 0.0f);
+  }
+
+  XVECTOR3 NavTestVisualPosition(const XVECTOR3& navPosition, const XVECTOR3& visualOffset) {
+    XVECTOR3 position = navPosition + visualOffset;
+    position.w = 1.0f;
+    return position;
+  }
+
+  bool RotateNavTestAgentToFace(PrimitiveInst& instance,
+                                const XVECTOR3& agentPosition,
+                                const XVECTOR3& targetPosition,
+                                float yawOffsetDegrees) {
+    const float dx = targetPosition.x - agentPosition.x;
+    const float dz = targetPosition.z - agentPosition.z;
+    if (dx * dx + dz * dz <= 0.0001f) {
+      return false;
+    }
+
+    const float yawDegrees = Rad2Deg(std::atan2(dx, dz)) + yawOffsetDegrees;
+    instance.RotateYAbsolute(yawDegrees);
+    return true;
+  }
+
+  XVECTOR3 NavTestFollowSlotTargetAt(const Camera& camera, XVECTOR3 anchor, int slotIndex) {
+    static constexpr float kBackSpacing = 2.0f;
+    static constexpr float kSideSpacing = 1.5f;
+    const XVECTOR3 forward = HorizontalOrFallback(camera.Look, XVECTOR3(0.0f, 0.0f, 1.0f, 0.0f));
+    const XVECTOR3 right = HorizontalOrFallback(camera.Right, XVECTOR3(1.0f, 0.0f, 0.0f, 0.0f));
+
+    anchor.w = 1.0f;
+    XVECTOR3 target = anchor;
+    if (slotIndex == 0) {
+      target -= forward * kBackSpacing;
+      return target;
+    }
+
+    const int pairIndex = (slotIndex + 1) / 2;
+    const float sideSign = (slotIndex % 2) ? 1.0f : -1.0f;
+    target -= forward * (kBackSpacing + static_cast<float>(pairIndex) * 1.25f);
+    target += right * (sideSign * kSideSpacing * static_cast<float>(pairIndex));
+    return target;
+  }
+
+  XVECTOR3 NavTestFollowSlotTarget(const Camera& camera, int slotIndex) {
+    return NavTestFollowSlotTargetAt(camera, camera.Eye, slotIndex);
+  }
+
+  bool ResolveNavTestFollowTarget(const t850::navigation::NavMesh& navMesh,
+                                  const Camera& camera,
+                                  int slotIndex,
+                                  XVECTOR3& desiredTarget,
+                                  XVECTOR3& projectedTarget,
+                                  std::string* error) {
+    XVECTOR3 playerNavPoint;
+    std::string projectionError;
+    if (!navMesh.ProjectPoint(camera.Eye, playerNavPoint, NavTestFollowProjectionExtents(), &projectionError)) {
+      desiredTarget = NavTestFollowSlotTarget(camera, slotIndex);
+      projectedTarget = desiredTarget;
+      if (error) *error = "player projection failed: " + projectionError;
+      return false;
+    }
+
+    desiredTarget = NavTestFollowSlotTargetAt(camera, playerNavPoint, slotIndex);
+    if (navMesh.ProjectPoint(desiredTarget, projectedTarget, NavTestFollowProjectionExtents(), &projectionError)) {
+      return true;
+    }
+
+    projectedTarget = playerNavPoint;
+    if (error) *error = "slot projection failed, using player nav point: " + projectionError;
+    return true;
   }
 
   struct SandboxConsoleLine {
@@ -2496,6 +2635,10 @@ void SandboxScene::InitVars() {
   m_showWireframe = false;
   m_showSkeleton = false;
   m_showPhysics = false;
+  m_showNavMesh = false;
+  m_navMeshDebugOffset = 0.01f;
+  m_navMeshDebugShapeMode = 0;
+  m_navMeshBuildAttempted = false;
   m_showLightVolumes = false;
   m_drawLightDirection = false;
   m_meshCount = 0;
@@ -2505,7 +2648,15 @@ void SandboxScene::InitVars() {
   m_primaryRagdollResourcePath.clear();
   m_sceneMeshPaths.clear();
   m_sceneRagdollPaths.clear();
+  m_sceneNavAgentFrontYawOffsets.clear();
   m_sceneRagdolls.clear();
+  m_navTestAgents.clear();
+  m_navTestCandidatePoints.clear();
+  m_navTestInitialized = false;
+  m_navTestMode = kNavTestModeFollowPlayer;
+  m_navTestAppliedMode = m_navTestMode;
+  m_navTestRandomState = 0x6d2b79f5u;
+  m_navTestSpeed = 3.0f;
   m_selectedSkinningMeshIndex = 0;
   m_selectedAnimationMeshIndex = 0;
   m_lightAttachToCamera.clear();
@@ -3026,6 +3177,7 @@ bool SandboxScene::LoadEditorSceneAssets(const std::string& scenePath) {
   m_q3CollisionWorld.reset();
   m_sceneMeshPaths.clear();
   m_sceneRagdollPaths.clear();
+  m_sceneNavAgentFrontYawOffsets.clear();
   m_sceneRagdolls.clear();
   m_q3StaticCollisionEntityIds.clear();
   m_primaryRagdollResourcePath.clear();
@@ -3139,8 +3291,10 @@ bool SandboxScene::LoadEditorSceneAssets(const std::string& scenePath) {
     }
     m_sceneMeshPaths.push_back(meshPath);
     m_sceneRagdollPaths.push_back(ragdollPath);
-    T8_LOG_INFO("[SandboxScene] Loaded scene object '%s' mesh='%s' ragdoll='%s' slot=%d",
-                object.name.c_str(), meshPath.c_str(), ragdollPath.c_str(), m_meshCount);
+    const float navAgentFrontYawOffset = object.nav_agent_front_yaw_offset_deg.value_or(0.0f);
+    m_sceneNavAgentFrontYawOffsets.push_back(navAgentFrontYawOffset);
+    T8_LOG_INFO("[SandboxScene] Loaded scene object '%s' mesh='%s' ragdoll='%s' slot=%d navFrontYawOffset=%.1f",
+                object.name.c_str(), meshPath.c_str(), ragdollPath.c_str(), m_meshCount, navAgentFrontYawOffset);
     ++m_meshCount;
   }
 
@@ -3157,6 +3311,445 @@ bool SandboxScene::LoadEditorSceneAssets(const std::string& scenePath) {
   LoadSandboxProfile(true);
   T8_LOG_INFO("[SandboxScene] Loaded editor scene '%s' with %d mesh instances", scenePath.c_str(), m_meshCount);
   return true;
+}
+
+bool SandboxScene::EnsureNavMeshBuilt() {
+  if (m_navMesh.IsReady()) {
+    return true;
+  }
+  if (m_navMeshBuildAttempted) {
+    return false;
+  }
+  m_navMeshBuildAttempted = true;
+
+  t850::navigation::NavMeshGeometry geometry;
+  const int meshCount = (std::min)(kMaxSandboxMeshes, (std::max)(m_meshCount, Meshes[0].pBase ? 1 : 0));
+  t850::navigation::NavSourceBuildStats sourceStats;
+  std::string error;
+  if (!t850::navigation::BuildGeometryFromPrimitiveInstances(Meshes, meshCount, geometry, &sourceStats, &error)) {
+    T8_LOG_ERROR("[Navigation] Sandbox navmesh build skipped: %s (considered=%d included=%d skippedInvisible=%d skippedSkinned=%d skippedInvalid=%d)",
+                 error.c_str(),
+                 sourceStats.considered,
+                 sourceStats.included,
+                 sourceStats.skippedInvisible,
+                 sourceStats.skippedSkinned,
+                 sourceStats.skippedInvalid);
+    return false;
+  }
+
+  if (!m_navMesh.Build(geometry, t850::navigation::NavMeshBuildSettings(), &error)) {
+    T8_LOG_ERROR("[Navigation] Sandbox navmesh build failed: %s", error.c_str());
+    return false;
+  }
+
+  m_navMeshDebugRenderer.Invalidate();
+  const t850::navigation::NavMeshBuildStats& stats = m_navMesh.GetStats();
+  T8_LOG_INFO("[Navigation] Sandbox navmesh ready: sources=%d skippedSkinned=%d skippedInvalid=%d verts=%d tris=%d polys=%d",
+              sourceStats.included, sourceStats.skippedSkinned, sourceStats.skippedInvalid,
+              stats.vertexCount, stats.triangleCount, stats.polygonCount);
+  return true;
+}
+
+void SandboxScene::InitializeNavTestAgents() {
+  if (m_navTestInitialized) {
+    return;
+  }
+  m_navTestInitialized = true;
+  m_navTestAgents.clear();
+  m_navTestCandidatePoints.clear();
+
+  if (!EnsureNavMeshBuilt()) {
+    return;
+  }
+
+  std::vector<unsigned int> graphIndices;
+  m_navMesh.GetDebugGraphEdges(m_navTestCandidatePoints, graphIndices, 0.0f);
+  if (m_navTestCandidatePoints.empty()) {
+    std::vector<unsigned int> wireIndices;
+    m_navMesh.GetDebugWireframe(m_navTestCandidatePoints, wireIndices, 0.0f);
+  }
+  if (m_navTestCandidatePoints.empty()) {
+    T8_LOG_ERROR("[NavigationTest] No navmesh candidate points available for skinned mesh path test");
+    return;
+  }
+
+  const int meshCount = (std::min)(kMaxSandboxMeshes, (std::max)(m_meshCount, Meshes[0].pBase ? 1 : 0));
+  int followSlot = 0;
+  for (int meshIndex = 0; meshIndex < meshCount; ++meshIndex) {
+    PrimitiveInst& instance = Meshes[meshIndex];
+    RenderSkinnedMesh* skinned = instance.GetSkinnedMesh();
+    if (!instance.Visible || !skinned || !skinned->HasSkinData()) {
+      continue;
+    }
+
+    NavTestAgentRuntime agent;
+    agent.meshIndex = meshIndex;
+    agent.followSlot = followSlot++;
+    if (meshIndex < static_cast<int>(m_sceneNavAgentFrontYawOffsets.size())) {
+      agent.frontYawOffsetDeg = m_sceneNavAgentFrontYawOffsets[static_cast<std::size_t>(meshIndex)];
+    }
+    const XVECTOR3 visualPosition(instance.Final.m41, instance.Final.m42, instance.Final.m43, 1.0f);
+    std::string projectionError;
+    if (!m_navMesh.ProjectPoint(visualPosition, agent.navPosition, NavTestAgentProjectionExtents(), &projectionError)) {
+      T8_LOG_ERROR("[NavigationTest] Skipping mesh %d nav agent; cannot project initial position (%.2f,%.2f,%.2f): %s",
+                   meshIndex,
+                   visualPosition.x, visualPosition.y, visualPosition.z,
+                   projectionError.c_str());
+      continue;
+    }
+    agent.home = agent.navPosition;
+    agent.visualOffset = visualPosition - agent.navPosition;
+    agent.visualOffset.x = 0.0f;
+    agent.visualOffset.z = 0.0f;
+    agent.visualOffset.w = 0.0f;
+    agent.navToOriginOffset = agent.visualOffset;
+    if (m_navTestMode == kNavTestModeFollowPlayer) {
+      if (!ResolveNavTestFollowTarget(m_navMesh, Cam, agent.followSlot,
+                                      agent.desiredTarget, agent.target, &agent.lastPathError)) {
+        agent.target = agent.navPosition;
+        agent.repathCooldownSec = kNavTestFailedPathRetrySec;
+      }
+    } else if (m_navTestMode == kNavTestModeRandom) {
+      agent.target = RandomNavTestPoint(m_navTestCandidatePoints,
+                                        agent.home,
+                                        m_navTestRandomState,
+                                        static_cast<uint32_t>(meshIndex + 1));
+      agent.desiredTarget = agent.target;
+    } else {
+      agent.target = FurthestNavTestPoint(m_navTestCandidatePoints, agent.home);
+      agent.desiredTarget = agent.target;
+    }
+    agent.targetInitialized = true;
+    agent.active = DistanceSquared(agent.target, agent.home) > 0.25f || m_navTestMode == kNavTestModeFollowPlayer;
+    agent.needsPath = agent.active && agent.repathCooldownSec <= 0.0f;
+    m_navTestAgents.push_back(std::move(agent));
+  }
+
+  if (!m_navTestAgents.empty()) {
+    T8_LOG_INFO("[NavigationTest] Initialized %zu skinned mesh nav agents mode=%d speed=%.2f q3 units/sec",
+                m_navTestAgents.size(), m_navTestMode, m_navTestSpeed);
+  }
+}
+
+void SandboxScene::PlanNavTestAgentPaths() {
+  if (!m_navMesh.IsReady() || m_navTestAgents.empty()) {
+    return;
+  }
+
+  std::vector<int> agentIndices;
+  std::vector<unsigned int> requestGenerations;
+  std::vector<t850::navigation::NavPathRequest> requests;
+  for (int i = 0; i < static_cast<int>(m_navTestAgents.size()); ++i) {
+    NavTestAgentRuntime& agent = m_navTestAgents[static_cast<std::size_t>(i)];
+    if (!agent.active || !agent.needsPath || agent.repathCooldownSec > 0.0f ||
+        agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
+        !Meshes[agent.meshIndex].pBase) {
+      continue;
+    }
+
+    t850::navigation::NavPathRequest request;
+    request.start = agent.navPosition;
+    request.end = (m_navTestMode == kNavTestModeFurthest && agent.returning) ? agent.home : agent.target;
+    request.queryExtents = NavTestAgentProjectionExtents();
+    agent.lastPathStart = request.start;
+    agent.lastPathEnd = request.end;
+    ++agent.pathGeneration;
+    requests.push_back(request);
+    agentIndices.push_back(i);
+    requestGenerations.push_back(agent.pathGeneration);
+  }
+
+  if (requests.empty()) {
+    return;
+  }
+
+  std::vector<t850::navigation::NavPathResult> results;
+  m_navMesh.FindPaths(requests, results);
+  for (std::size_t i = 0; i < agentIndices.size(); ++i) {
+    NavTestAgentRuntime& agent = m_navTestAgents[static_cast<std::size_t>(agentIndices[i])];
+    if (i >= requestGenerations.size() || agent.pathGeneration != requestGenerations[i]) {
+      continue;
+    }
+    agent.needsPath = false;
+    if (i >= results.size() || !results[i].success || results[i].points.empty()) {
+      const PrimitiveInst& instance = Meshes[agent.meshIndex];
+      const XVECTOR3 current(instance.Final.m41, instance.Final.m42, instance.Final.m43, 1.0f);
+      agent.lastPathSuccess = false;
+      agent.lastPathError = i < results.size() ? results[i].error : "missing result";
+      agent.repathCooldownSec = kNavTestFailedPathRetrySec;
+      agent.path.clear();
+      agent.waypointIndex = 0;
+      if (m_navTestMode == kNavTestModeRandom) {
+        agent.target = RandomNavTestPoint(m_navTestCandidatePoints,
+                                          agent.navPosition,
+                                          m_navTestRandomState,
+                                          static_cast<uint32_t>(agent.meshIndex + 43));
+        agent.desiredTarget = agent.target;
+      } else if (m_navTestMode == kNavTestModeFollowPlayer) {
+        XVECTOR3 desiredTarget;
+        XVECTOR3 projectedTarget;
+        if (ResolveNavTestFollowTarget(m_navMesh, Cam, agent.followSlot,
+                                       desiredTarget, projectedTarget, nullptr)) {
+          agent.desiredTarget = desiredTarget;
+          agent.target = projectedTarget;
+        } else {
+          agent.desiredTarget = desiredTarget;
+          agent.target = agent.navPosition;
+        }
+      } else {
+        agent.active = false;
+      }
+      T8_LOG_ERROR("[NavigationTest] Agent mesh %d failed to find path gen=%u start=(%.2f,%.2f,%.2f) end=(%.2f,%.2f,%.2f) desired=(%.2f,%.2f,%.2f) player=(%.2f,%.2f,%.2f) nav=(%.2f,%.2f,%.2f) visual=(%.2f,%.2f,%.2f) offset=(%.2f,%.2f,%.2f): %s",
+                   agent.meshIndex,
+                   agent.pathGeneration,
+                   agent.lastPathStart.x, agent.lastPathStart.y, agent.lastPathStart.z,
+                   agent.lastPathEnd.x, agent.lastPathEnd.y, agent.lastPathEnd.z,
+                   agent.desiredTarget.x, agent.desiredTarget.y, agent.desiredTarget.z,
+                   Cam.Eye.x, Cam.Eye.y, Cam.Eye.z,
+                   agent.navPosition.x, agent.navPosition.y, agent.navPosition.z,
+                   current.x, current.y, current.z,
+                   agent.visualOffset.x, agent.visualOffset.y, agent.visualOffset.z,
+                   agent.lastPathError.c_str());
+      continue;
+    }
+
+    agent.navPosition = results[i].points.front();
+    agent.navToOriginOffset = agent.visualOffset;
+    agent.lastPathFirst = results[i].points.front();
+    agent.lastPathSuccess = true;
+    agent.lastPathError.clear();
+    agent.repathCooldownSec = 0.0f;
+    agent.path = results[i].points;
+    agent.waypointIndex = agent.path.size() > 1 ? 1 : 0;
+  }
+}
+
+void SandboxScene::UpdateNavTestAgents(float dtSecs) {
+  if (!m_loadedEditorScene) {
+    return;
+  }
+  m_navTestMode = ClampNavTestMode(m_navTestMode);
+  m_navTestSpeed = (std::max)(0.0f, (std::min)(10.0f, m_navTestSpeed));
+  if (m_navTestMode != m_navTestAppliedMode) {
+    m_navTestAppliedMode = m_navTestMode;
+    m_navTestInitialized = false;
+    m_navTestAgents.clear();
+    m_navTestRandomState = 0x6d2b79f5u;
+    m_navTestDiagAccumSec = 0.0f;
+  }
+  InitializeNavTestAgents();
+  if (m_navTestAgents.empty()) {
+    return;
+  }
+
+  for (NavTestAgentRuntime& agent : m_navTestAgents) {
+    if (!agent.active ||
+        agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
+        !Meshes[agent.meshIndex].pBase) {
+      continue;
+    }
+
+    agent.repathCooldownSec = (std::max)(0.0f, agent.repathCooldownSec - (std::max)(0.0f, dtSecs));
+    if (m_navTestMode == kNavTestModeFollowPlayer) {
+      XVECTOR3 desiredTarget;
+      XVECTOR3 projectedTarget;
+      std::string targetError;
+      if (ResolveNavTestFollowTarget(m_navMesh, Cam, agent.followSlot, desiredTarget, projectedTarget, &targetError)) {
+        agent.desiredTarget = desiredTarget;
+        if ((!agent.targetInitialized || agent.path.empty() || DistanceSquared(agent.target, projectedTarget) > 1.0f) &&
+            agent.repathCooldownSec <= 0.0f) {
+          agent.target = projectedTarget;
+          agent.returning = false;
+          agent.needsPath = true;
+          agent.targetInitialized = true;
+        }
+      } else {
+        agent.desiredTarget = desiredTarget;
+        agent.lastPathSuccess = false;
+        agent.lastPathError = targetError;
+        agent.repathCooldownSec = kNavTestFailedPathRetrySec;
+        agent.needsPath = false;
+      }
+    } else if (m_navTestMode == kNavTestModeRandom) {
+      if (!agent.targetInitialized || (agent.path.empty() && !agent.needsPath)) {
+        agent.target = RandomNavTestPoint(m_navTestCandidatePoints,
+                                          agent.navPosition,
+                                          m_navTestRandomState,
+                                          static_cast<uint32_t>(agent.meshIndex + 17));
+        agent.desiredTarget = agent.target;
+        agent.returning = false;
+        agent.needsPath = true;
+        agent.targetInitialized = true;
+      }
+    } else if (!agent.targetInitialized) {
+      agent.target = FurthestNavTestPoint(m_navTestCandidatePoints, agent.home);
+      agent.desiredTarget = agent.target;
+      agent.returning = false;
+      agent.needsPath = true;
+      agent.targetInitialized = true;
+    }
+  }
+
+  PlanNavTestAgentPaths();
+
+  const float maxStep = (std::max)(0.0f, dtSecs) * m_navTestSpeed;
+  std::vector<XVECTOR3> proposedPositions(m_navTestAgents.size());
+  std::vector<unsigned char> movedAgents(m_navTestAgents.size(), 0);
+  for (std::size_t agentIndex = 0; agentIndex < m_navTestAgents.size(); ++agentIndex) {
+    NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
+    if (!agent.active || agent.needsPath || agent.path.empty() ||
+        agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
+        !Meshes[agent.meshIndex].pBase) {
+      continue;
+    }
+
+    XVECTOR3 current = agent.navPosition;
+    float remaining = maxStep;
+    while (remaining > 0.0f && agent.waypointIndex < static_cast<int>(agent.path.size())) {
+      const XVECTOR3 target = agent.path[static_cast<std::size_t>(agent.waypointIndex)];
+      XVECTOR3 delta = target - current;
+      const float distance = delta.Length();
+      if (distance <= 0.0001f) {
+        current = target;
+        ++agent.waypointIndex;
+        continue;
+      }
+      if (distance <= remaining) {
+        current = target;
+        remaining -= distance;
+        ++agent.waypointIndex;
+      } else {
+        delta /= distance;
+        current += delta * remaining;
+        remaining = 0.0f;
+      }
+    }
+
+    if (agent.waypointIndex >= static_cast<int>(agent.path.size())) {
+      if (m_navTestMode == kNavTestModeFurthest && agent.returning) {
+        current = agent.home;
+        agent.returning = false;
+      } else if (m_navTestMode == kNavTestModeFurthest) {
+        agent.returning = true;
+      } else if (m_navTestMode == kNavTestModeRandom) {
+        agent.target = RandomNavTestPoint(m_navTestCandidatePoints,
+                                          current,
+                                          m_navTestRandomState,
+                                          static_cast<uint32_t>(agent.meshIndex + 31));
+        agent.desiredTarget = agent.target;
+        agent.returning = false;
+      } else {
+        XVECTOR3 desiredTarget;
+        XVECTOR3 projectedTarget;
+        if (ResolveNavTestFollowTarget(m_navMesh, Cam, agent.followSlot,
+                                       desiredTarget, projectedTarget, nullptr)) {
+          agent.desiredTarget = desiredTarget;
+          agent.target = projectedTarget;
+        } else {
+          agent.desiredTarget = desiredTarget;
+          agent.target = current;
+        }
+        agent.returning = false;
+      }
+      agent.needsPath = true;
+      agent.path.clear();
+      agent.waypointIndex = 0;
+    }
+
+      proposedPositions[agentIndex] = current;
+      movedAgents[agentIndex] = 1;
+  }
+
+  constexpr float kAgentSeparation = 1.2f;
+  constexpr float kAgentSeparationSq = kAgentSeparation * kAgentSeparation;
+  for (std::size_t a = 0; a < m_navTestAgents.size(); ++a) {
+      if (!movedAgents[a]) continue;
+      for (std::size_t b = a + 1; b < m_navTestAgents.size(); ++b) {
+        if (!movedAgents[b]) continue;
+        XVECTOR3 delta = proposedPositions[b] - proposedPositions[a];
+        delta.y = 0.0f;
+        const float distanceSq = delta.x * delta.x + delta.z * delta.z;
+        if (distanceSq <= 0.0001f || distanceSq >= kAgentSeparationSq) {
+          continue;
+        }
+        const float distance = std::sqrt(distanceSq);
+        const float push = (kAgentSeparation - distance) * 0.5f;
+        delta /= distance;
+        proposedPositions[a] -= delta * push;
+        proposedPositions[b] += delta * push;
+      }
+  }
+
+  for (std::size_t agentIndex = 0; agentIndex < m_navTestAgents.size(); ++agentIndex) {
+    NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
+    if (!agent.active ||
+        agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
+        !Meshes[agent.meshIndex].pBase) {
+      continue;
+    }
+
+    PrimitiveInst& instance = Meshes[agent.meshIndex];
+    if (movedAgents[agentIndex]) {
+      XVECTOR3 navPosition = proposedPositions[agentIndex];
+      if (!m_navMesh.ProjectPoint(navPosition, navPosition, NavTestAgentProjectionExtents(), nullptr)) {
+        navPosition = agent.navPosition;
+      }
+      agent.navPosition = navPosition;
+      agent.navToOriginOffset = agent.visualOffset;
+    }
+
+    const XVECTOR3 visualPosition = NavTestVisualPosition(agent.navPosition, agent.visualOffset);
+    instance.TranslateAbsolute(visualPosition.x, visualPosition.y, visualPosition.z);
+    RotateNavTestAgentToFace(instance, visualPosition, Cam.Eye, agent.frontYawOffsetDeg);
+    instance.Update();
+  }
+
+  if (m_navTestMode == kNavTestModeFollowPlayer) {
+    m_navTestDiagAccumSec += (std::max)(0.0f, dtSecs);
+    if (m_navTestDiagAccumSec >= kNavTestDiagIntervalSec) {
+      m_navTestDiagAccumSec = 0.0f;
+      for (const NavTestAgentRuntime& agent : m_navTestAgents) {
+        if (!agent.active ||
+            agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
+            !Meshes[agent.meshIndex].pBase) {
+          continue;
+        }
+
+        const PrimitiveInst& instance = Meshes[agent.meshIndex];
+        const XVECTOR3 position(instance.Final.m41, instance.Final.m42, instance.Final.m43, 1.0f);
+        const bool hasNextWaypoint =
+            !agent.path.empty() &&
+            agent.waypointIndex >= 0 &&
+            agent.waypointIndex < static_cast<int>(agent.path.size());
+        const XVECTOR3 nextNav = hasNextWaypoint
+            ? agent.path[static_cast<std::size_t>(agent.waypointIndex)]
+            : agent.lastPathFirst;
+        const XVECTOR3 nextWorld = NavTestVisualPosition(nextNav, agent.visualOffset);
+        T8_LOG_INFO("[NavigationTestPos] mesh=%d slot=%d active=%d needsPath=%d cooldown=%.3f pathOk=%d pathCount=%zu wp=%d player=(%.2f,%.2f,%.2f) nav=(%.2f,%.2f,%.2f) visual=(%.2f,%.2f,%.2f) dyPlayer=%.2f desired=(%.2f,%.2f,%.2f) target=(%.2f,%.2f,%.2f) lastStart=(%.2f,%.2f,%.2f) lastEnd=(%.2f,%.2f,%.2f) pathFirst=(%.2f,%.2f,%.2f) nextNav=(%.2f,%.2f,%.2f) nextWorld=(%.2f,%.2f,%.2f) offset=(%.2f,%.2f,%.2f) err='%s'",
+                    agent.meshIndex,
+                    agent.followSlot,
+                    agent.active ? 1 : 0,
+                    agent.needsPath ? 1 : 0,
+                    agent.repathCooldownSec,
+                    agent.lastPathSuccess ? 1 : 0,
+                    agent.path.size(),
+                    agent.waypointIndex,
+                    Cam.Eye.x, Cam.Eye.y, Cam.Eye.z,
+                    agent.navPosition.x, agent.navPosition.y, agent.navPosition.z,
+                    position.x, position.y, position.z,
+                    position.y - Cam.Eye.y,
+                    agent.desiredTarget.x, agent.desiredTarget.y, agent.desiredTarget.z,
+                    agent.target.x, agent.target.y, agent.target.z,
+                    agent.lastPathStart.x, agent.lastPathStart.y, agent.lastPathStart.z,
+                    agent.lastPathEnd.x, agent.lastPathEnd.y, agent.lastPathEnd.z,
+                    agent.lastPathFirst.x, agent.lastPathFirst.y, agent.lastPathFirst.z,
+                    nextNav.x, nextNav.y, nextNav.z,
+                    nextWorld.x, nextWorld.y, nextWorld.z,
+                    agent.visualOffset.x, agent.visualOffset.y, agent.visualOffset.z,
+                    agent.lastPathError.c_str());
+      }
+    }
+  }
 }
 
 void SandboxScene::CreateAssets() {
@@ -3251,6 +3844,9 @@ void SandboxScene::CreateAssets() {
   m_lightArrowRenderer.Create();
   m_ragdollJointRenderer.Create();
   m_physicsDebugRenderer.Create();
+  m_navMeshDebugRenderer.Create();
+  m_navMesh.Clear();
+  m_navMeshBuildAttempted = false;
   float arrowVerts[10 * 4] = {};
   unsigned short arrowIndices[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   m_lightArrowVB = t850::LineRenderer::CreatePositionVB(arrowVerts, 10, BufferUsage::DINAMIC);
@@ -3419,7 +4015,11 @@ void SandboxScene::DestroyAssets() {
   m_primaryRagdollResourcePath.clear();
   m_sceneMeshPaths.clear();
   m_sceneRagdollPaths.clear();
+  m_sceneNavAgentFrontYawOffsets.clear();
   m_sceneRagdolls.clear();
+  m_navTestAgents.clear();
+  m_navTestCandidatePoints.clear();
+  m_navTestInitialized = false;
   m_selectedSkinningMeshIndex = 0;
   m_selectedAnimationMeshIndex = 0;
   m_debugText.Destroy();
@@ -3433,6 +4033,9 @@ void SandboxScene::DestroyAssets() {
   m_lightArrowRenderer.Destroy();
   m_ragdollJointRenderer.Destroy();
   m_physicsDebugRenderer.Destroy();
+  m_navMeshDebugRenderer.Destroy();
+  m_navMesh.Clear();
+  m_navMeshBuildAttempted = false;
   PrimitiveMgr.DestroyPrimitives();
   pFramework->pVideoDriver->DestroyRTs();
 }
@@ -3583,6 +4186,7 @@ void SandboxScene::OnUpdate(float _DtSecs) {
     UpdateAttachedLights();
     SyncLightCameraFromDirectionalLight();
   }
+  UpdateNavTestAgents(DtSecs);
 
   // --dumpMatrices: log all camera matrices per frame, then exit
   if (g_config.flags.dumpMatrices) {
@@ -11174,6 +11778,27 @@ void SandboxScene::DrawSkeletonEditPanel(t850::DevGuiContext& gui) {
       m_showPhysics = !m_showPhysics;
     }
     ImGui::SameLine();
+    if (gui.Button(m_showNavMesh ? "NavMesh: On" : "NavMesh: Off")) {
+      m_showNavMesh = !m_showNavMesh;
+      if (m_showNavMesh && !m_navMesh.IsReady()) m_navMeshBuildAttempted = false;
+    }
+    const char* navModeOptions[] = { "Furthest loop", "Random nodes", "Follow player" };
+    ImGui::SetNextItemWidth(220.0f);
+    if (ImGui::Combo("Bot nav mode", &m_navTestMode, navModeOptions, 3)) {
+      m_navTestMode = ClampNavTestMode(m_navTestMode);
+    }
+    ImGui::SetNextItemWidth(220.0f);
+    if (ImGui::SliderFloat("Bot speed multiplier", &m_navTestSpeed, 0.0f, 10.0f, "%.2fx")) {
+      m_navTestSpeed = (std::max)(0.0f, (std::min)(10.0f, m_navTestSpeed));
+    }
+    const char* navShapeOptions[] = { "Geometry", "Nodes" };
+    ImGui::SetNextItemWidth(170.0f);
+    ImGui::Combo("NavMesh magenta", &m_navMeshDebugShapeMode, navShapeOptions, 2);
+    ImGui::SetNextItemWidth(220.0f);
+    if (ImGui::SliderFloat("NavMesh offset", &m_navMeshDebugOffset, 0.0f, 0.25f, "%.3f")) {
+      m_navMeshDebugOffset = (std::max)(0.0f, (std::min)(0.25f, m_navMeshDebugOffset));
+    }
+    ImGui::SameLine();
     if (gui.Button(m_showSkeleton ? "Skeleton Debug: On" : "Skeleton Debug: Off")) {
       m_showSkeleton = !m_showSkeleton;
     }
@@ -11388,6 +12013,11 @@ void SandboxScene::DrawAndroidPhysicsPanel(t850::DevGuiContext& gui) {
 
   if (gui.Button(m_showPhysics ? "Physics Debug: On" : "Physics Debug: Off")) {
     m_showPhysics = !m_showPhysics;
+  }
+  ImGui::SameLine();
+  if (gui.Button(m_showNavMesh ? "NavMesh: On" : "NavMesh: Off")) {
+    m_showNavMesh = !m_showNavMesh;
+    if (m_showNavMesh && !m_navMesh.IsReady()) m_navMeshBuildAttempted = false;
   }
   ImGui::SameLine();
   if (gui.Button(m_showSkeleton ? "Skeleton Debug: On" : "Skeleton Debug: Off")) {
@@ -12424,6 +13054,8 @@ void SandboxScene::CaptureSandboxProfileState(t850::SandboxProfileDesc& state) {
   addFloat("material_refraction_strength", SceneProp.MaterialRefractionStrength);
   addFloat("mouse_sensitivity_x", m_mouseSensitivityX);
   addFloat("mouse_sensitivity_y", m_mouseSensitivityY);
+  addFloat("navmesh_debug_offset", m_navMeshDebugOffset);
+  addFloat("nav_agent_speed_multiplier", m_navTestSpeed);
 
   for (int kernelIndex = 0; kernelIndex < (int)SceneProp.pGaussKernels.size(); ++kernelIndex) {
     GaussFilter* kernel = SceneProp.pGaussKernels[kernelIndex];
@@ -12452,6 +13084,7 @@ void SandboxScene::CaptureSandboxProfileState(t850::SandboxProfileDesc& state) {
   addBool("show_wireframe", m_showWireframe);
   addBool("show_skeleton", GetSelectedSkinningMesh() != nullptr && m_showSkeleton);
   addBool("show_physics", m_showPhysics);
+  addBool("show_navmesh", m_showNavMesh);
   addBool("show_light_volumes", m_showLightVolumes);
   addBool("point_lights_enabled", SceneProp.PointLightsEnabled);
   addBool("draw_direction", m_drawLightDirection);
@@ -12463,6 +13096,7 @@ void SandboxScene::CaptureSandboxProfileState(t850::SandboxProfileDesc& state) {
   addInt("gauss_kernel_sample_count", 0);
   addInt("active_gauss_kernel", ChangeActiveGaussSelection);
   addInt("active_light", m_selectedLightIndex);
+  addInt("navmesh_debug_shape", m_navMeshDebugShapeMode);
 
   EnsureLightRuntimeState();
   for (int lightIndex = 0; lightIndex < (int)SceneProp.Lights.size(); ++lightIndex) {
@@ -12548,6 +13182,8 @@ void SandboxScene::ApplySandboxProfileState(const t850::SandboxProfileDesc& stat
     else if (value.name == "material_refraction_strength") SceneProp.MaterialRefractionStrength = value.value;
     else if (value.name == "mouse_sensitivity_x") m_mouseSensitivityX = ClampMouseSensitivity(value.value);
     else if (value.name == "mouse_sensitivity_y") m_mouseSensitivityY = ClampMouseSensitivity(value.value);
+    else if (value.name == "navmesh_debug_offset") m_navMeshDebugOffset = (std::max)(0.0f, (std::min)(0.25f, value.value));
+    else if (value.name == "nav_agent_speed_multiplier") m_navTestSpeed = (std::max)(0.0f, (std::min)(10.0f, value.value));
     else if (value.name == "anim_speed") { if (RenderSkinnedMesh* skinned = GetSelectedAnimationMesh()) skinned->SetAnimSpeed(value.value); }
 
     for (int kernelIndex = 0; kernelIndex < (int)SceneProp.pGaussKernels.size(); ++kernelIndex) {
@@ -12565,6 +13201,10 @@ void SandboxScene::ApplySandboxProfileState(const t850::SandboxProfileDesc& stat
     else if (value.name == "show_wireframe") m_showWireframe = value.value;
     else if (value.name == "show_skeleton") m_showSkeleton = value.value && (GetSelectedSkinningMesh() != nullptr);
     else if (value.name == "show_physics") m_showPhysics = value.value;
+    else if (value.name == "show_navmesh") {
+      m_showNavMesh = value.value;
+      if (m_showNavMesh && !m_navMesh.IsReady()) m_navMeshBuildAttempted = false;
+    }
     else if (value.name == "show_light_volumes") m_showLightVolumes = value.value;
     else if (value.name == "point_lights_enabled") SceneProp.PointLightsEnabled = value.value;
     else if (value.name == "draw_direction") m_drawLightDirection = value.value;
@@ -12586,6 +13226,7 @@ void SandboxScene::ApplySandboxProfileState(const t850::SandboxProfileDesc& stat
       }
     }
     else if (value.name == "active_gauss_kernel") ChangeActiveGaussSelection = value.value;
+    else if (value.name == "navmesh_debug_shape") m_navMeshDebugShapeMode = (std::max)(0, (std::min)(1, value.value));
     else if (value.name == "animation_model") {
       if (GetSkinnedMeshForIndex(value.value)) {
         m_selectedAnimationMeshIndex = value.value;
@@ -13140,6 +13781,28 @@ void SandboxScene::OnDraw() {
       }
     }
 
+    if (m_showNavMesh && m_navMeshDebugRenderer.IsReady() && EnsureNavMeshBuilt()) {
+      Texture* depthTexture = nullptr;
+      if (GBufferPass >= 0 && GBufferPass < (int)pFramework->pVideoDriver->RTs.size()) {
+        if (auto* gbufRT = pFramework->pVideoDriver->RTs[GBufferPass]) {
+          depthTexture = gbufRT->pDepthTexture;
+        }
+      }
+      if (depthTexture) {
+        m_navMeshDebugRenderer.SetVerticalOffset(m_navMeshDebugOffset);
+        m_navMeshDebugRenderer.SetGraphVerticalOffset(m_navMeshDebugOffset + 0.005f);
+        m_navMeshDebugRenderer.SetShapeMode(m_navMeshDebugShapeMode == 1
+            ? t850::navigation::NavMeshDebugShapeMode::Nodes
+            : t850::navigation::NavMeshDebugShapeMode::Geometry);
+        m_navMeshDebugRenderer.SetDepthTexture(depthTexture);
+        m_navMeshDebugRenderer.SetViewport(g_pBaseDriver->width, g_pBaseDriver->height);
+        m_navMeshDebugRenderer.SetFarPlane(Cam.FPlane);
+        pFramework->pVideoDriver->SetDepthStencilState(BaseDriver::NONE);
+        pFramework->pVideoDriver->SetBlendState(BaseDriver::BLEND_DEFAULT);
+        m_navMeshDebugRenderer.Draw(m_navMesh, VP);
+      }
+    }
+
     if (m_showLightVolumes) {
       pFramework->pVideoDriver->SetDepthStencilState(BaseDriver::NONE);
       pFramework->pVideoDriver->SetBlendState(BaseDriver::ALPHA_BLEND);
@@ -13173,7 +13836,7 @@ void SandboxScene::OnDraw() {
   };
 
 #ifdef OS_ANDROID
-  if (m_showWireframe || m_showSkeleton || m_showPhysics || m_showLightVolumes) {
+  if (m_showWireframe || m_showSkeleton || m_showPhysics || m_showNavMesh || m_showLightVolumes) {
     if (auto* vkDriver = static_cast<VulkanDriver*>(pFramework->pVideoDriver)) {
       vkDriver->SetPrePresentOverlayCallback(drawMeshDebugOverlays);
     }
@@ -13327,6 +13990,7 @@ void SandboxScene::DrawDevGui(t850::DevGuiContext& gui) {
     {"show_wireframe", CHANGE_SHOW_WIREFRAME},
     {"show_skeleton", CHANGE_SHOW_SKELETON},
     {"show_physics", CHANGE_SHOW_PHYSICS},
+    {"show_navmesh", CHANGE_SHOW_NAVMESH},
     {"show_light_volumes", CHANGE_SHOW_LIGHT_VOLUMES},
     {"point_lights_enabled", CHANGE_POINT_LIGHTS_ENABLED},
     {"debug_luminance", CHANGE_DEBUG_LUMINANCE},
@@ -13467,6 +14131,7 @@ void SandboxScene::DrawDevGui(t850::DevGuiContext& gui) {
     case CHANGE_SHOW_WIREFRAME: value = m_showWireframe; return true;
     case CHANGE_SHOW_SKELETON: value = (skinnedMesh() != nullptr) && m_showSkeleton; return true;
     case CHANGE_SHOW_PHYSICS: value = m_showPhysics; return true;
+    case CHANGE_SHOW_NAVMESH: value = m_showNavMesh; return true;
     case CHANGE_SHOW_LIGHT_VOLUMES: value = m_showLightVolumes; return true;
     case CHANGE_POINT_LIGHTS_ENABLED: value = SceneProp.PointLightsEnabled; return true;
     case CHANGE_DEBUG_LUMINANCE: value = SceneProp.DebugLuminanceEnabled; return true;
@@ -13481,6 +14146,10 @@ void SandboxScene::DrawDevGui(t850::DevGuiContext& gui) {
     case CHANGE_SHOW_WIREFRAME: m_showWireframe = value; break;
     case CHANGE_SHOW_SKELETON: m_showSkeleton = value && (skinnedMesh() != nullptr); break;
     case CHANGE_SHOW_PHYSICS: m_showPhysics = value; break;
+    case CHANGE_SHOW_NAVMESH:
+      m_showNavMesh = value;
+      if (m_showNavMesh && !m_navMesh.IsReady()) m_navMeshBuildAttempted = false;
+      break;
     case CHANGE_SHOW_LIGHT_VOLUMES: m_showLightVolumes = value; break;
     case CHANGE_POINT_LIGHTS_ENABLED: SceneProp.PointLightsEnabled = value; break;
     case CHANGE_DEBUG_LUMINANCE: SceneProp.DebugLuminanceEnabled = value; if (!value) SceneProp.DebugAdaptedLuminanceValid = false; break;
@@ -13705,6 +14374,31 @@ void SandboxScene::DrawDevGui(t850::DevGuiContext& gui) {
     drawCheckboxByName("show_wireframe");
     drawCheckboxByName("show_skeleton");
     drawCheckboxByName("show_physics");
+    drawCheckboxByName("show_navmesh");
+    t850::SliderDesc navOffsetDesc;
+    navOffsetDesc.name = "navmesh_debug_offset";
+    navOffsetDesc.label = "NavMesh offset";
+    navOffsetDesc.min_val = 0.0f;
+    navOffsetDesc.max_val = 0.25f;
+    navOffsetDesc.step = 0.001f;
+    navOffsetDesc.default_val = 0.01f;
+    gui.Slider(navOffsetDesc, m_navMeshDebugOffset);
+    const char* navModeOptions[] = { "Furthest loop", "Random nodes", "Follow player" };
+    ImGui::SetNextItemWidth(220.0f);
+    if (ImGui::Combo("Bot nav mode", &m_navTestMode, navModeOptions, 3)) {
+      m_navTestMode = ClampNavTestMode(m_navTestMode);
+    }
+    t850::SliderDesc navSpeedDesc;
+    navSpeedDesc.name = "nav_agent_speed_multiplier";
+    navSpeedDesc.label = "Bot speed multiplier";
+    navSpeedDesc.min_val = 0.0f;
+    navSpeedDesc.max_val = 10.0f;
+    navSpeedDesc.step = 0.1f;
+    navSpeedDesc.default_val = 3.0f;
+    gui.Slider(navSpeedDesc, m_navTestSpeed);
+    const char* navShapeOptions[] = { "Geometry", "Nodes" };
+    ImGui::SetNextItemWidth(180.0f);
+    ImGui::Combo("NavMesh magenta", &m_navMeshDebugShapeMode, navShapeOptions, 2);
     drawCheckboxByName("show_light_volumes");
   }
 

--- a/T850/DayScene/SandboxScene.h
+++ b/T850/DayScene/SandboxScene.h
@@ -13,6 +13,8 @@
 #include <scene/LineRenderer.h>
 #include <scene/TextRenderer.h>
 #include <physics/PhysicsDebugRenderer.h>
+#include <navigation/NavigationDebugRenderer.h>
+#include <navigation/NavigationSystem.h>
 #include <physics/Q3BspCollision.h>
 #include <physics/PhysicsTypes.h>
 #include <debug/FrameDumper.h>
@@ -76,6 +78,7 @@ class SandboxScene : public t850::SceneBase, public t850::CameraCollisionWorld
     CHANGE_SHOW_WIREFRAME,
     CHANGE_SHOW_SKELETON,
     CHANGE_SHOW_PHYSICS,
+    CHANGE_SHOW_NAVMESH,
     CHANGE_SHOW_LIGHT_VOLUMES,
     CHANGE_POINT_LIGHTS_ENABLED,
     CHANGE_DEBUG_LUMINANCE,
@@ -93,6 +96,10 @@ public:
   void DestroyAssets() override;
 
   void DrawDevGui(t850::DevGuiContext& gui) override;
+  bool EnsureNavMeshBuilt();
+  void InitializeNavTestAgents();
+  void UpdateNavTestAgents(float dtSecs);
+  void PlanNavTestAgentPaths();
 #ifdef OS_ANDROID
   bool HandleAndroidVirtualControls(AInputEvent* event);
   bool AndroidVirtualControlsActive() const;
@@ -167,6 +174,8 @@ public:
   t850::LineRenderer m_lightArrowRenderer;
   t850::LineRenderer m_ragdollJointRenderer;
   t850::PhysicsDebugRenderer m_physicsDebugRenderer;
+  t850::navigation::NavMeshDebugRenderer m_navMeshDebugRenderer;
+  t850::navigation::NavMesh m_navMesh;
   t850::VertexBuffer* m_lightArrowVB = nullptr;
   t850::IndexBuffer* m_lightArrowIB = nullptr;
   unsigned m_lightArrowIndexCount = 0;
@@ -180,6 +189,10 @@ public:
   bool m_showWireframe = false;
   bool m_showSkeleton = false;
   bool m_showPhysics = false;
+  bool m_showNavMesh = false;
+  float m_navMeshDebugOffset = 0.01f;
+  int m_navMeshDebugShapeMode = 0;
+  bool m_navMeshBuildAttempted = false;
   bool m_showLightVolumes = false;
   bool m_drawLightDirection = false;
   bool m_profileReady = false;
@@ -192,6 +205,7 @@ public:
   std::string m_primaryRagdollResourcePath;
   std::vector<std::string> m_sceneMeshPaths;
   std::vector<std::string> m_sceneRagdollPaths;
+  std::vector<float> m_sceneNavAgentFrontYawOffsets;
   std::vector<uint32_t> m_q3StaticCollisionEntityIds;
   struct SceneRagdollRuntime {
     int meshIndex = -1;
@@ -206,6 +220,38 @@ public:
     bool physicsLogEmitted = false;
   };
   std::vector<SceneRagdollRuntime> m_sceneRagdolls;
+  struct NavTestAgentRuntime {
+    int meshIndex = -1;
+    XVECTOR3 home = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+    XVECTOR3 navPosition = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+    XVECTOR3 visualOffset = XVECTOR3(0.0f, 0.0f, 0.0f, 0.0f);
+    XVECTOR3 desiredTarget = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+    XVECTOR3 target = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+    XVECTOR3 lastPathStart = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+    XVECTOR3 lastPathEnd = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+    XVECTOR3 lastPathFirst = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+    XVECTOR3 navToOriginOffset = XVECTOR3(0.0f, 0.0f, 0.0f, 0.0f);
+    std::vector<XVECTOR3> path;
+    std::string lastPathError;
+    int waypointIndex = 0;
+    int followSlot = 0;
+    unsigned int pathGeneration = 0;
+    float repathCooldownSec = 0.0f;
+    float frontYawOffsetDeg = 0.0f;
+    bool returning = false;
+    bool active = false;
+    bool needsPath = false;
+    bool targetInitialized = false;
+    bool lastPathSuccess = false;
+  };
+  std::vector<NavTestAgentRuntime> m_navTestAgents;
+  std::vector<XVECTOR3> m_navTestCandidatePoints;
+  bool m_navTestInitialized = false;
+  float m_navTestSpeed = 3.0f;
+  int m_navTestMode = 2;
+  int m_navTestAppliedMode = 2;
+  uint32_t m_navTestRandomState = 0x6d2b79f5u;
+  float m_navTestDiagAccumSec = 0.0f;
   int m_selectedSkinningMeshIndex = 0;
   int m_selectedAnimationMeshIndex = 0;
   std::string m_profileModelKey;

--- a/T850/Framework/CMakeLists.txt
+++ b/T850/Framework/CMakeLists.txt
@@ -14,6 +14,8 @@ set(FRAMEWORK_SOURCES
   src/physics/PhysicsDebugRenderer.cpp
   src/physics/Q3BspCollision.cpp
   src/physics/PhysicsAuthoring.cpp
+  src/navigation/NavigationSystem.cpp
+  src/navigation/NavigationDebugRenderer.cpp
   src/scene/LensFlare.cpp
   src/scene/RenderMesh.cpp
   src/scene/RenderSkinnedMesh.cpp
@@ -128,6 +130,14 @@ target_precompile_headers(Framework PRIVATE $<$<COMPILE_LANGUAGE:CXX>:pch.h>)
 if(T850_JOLT_ENABLED)
   target_compile_definitions(Framework PUBLIC T850_ENABLE_JOLT=1)
   target_link_libraries(Framework PUBLIC Jolt::Jolt)
+endif()
+if(T850_RECAST_ENABLED)
+  target_compile_definitions(Framework PUBLIC T850_ENABLE_RECAST=1)
+  target_link_libraries(Framework PUBLIC
+    RecastNavigation::Recast
+    RecastNavigation::Detour
+    RecastNavigation::DetourCrowd
+    RecastNavigation::DetourTileCache)
 endif()
 target_include_directories(Framework PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}

--- a/T850/Framework/Framework.vcxproj
+++ b/T850/Framework/Framework.vcxproj
@@ -34,6 +34,8 @@
     <ClInclude Include="include\core\EngineContext.h" />
     <ClInclude Include="include\core\Config.h" />
     <ClInclude Include="include\core\windows\Win32Framework.h" />
+    <ClInclude Include="include\navigation\NavigationSystem.h" />
+    <ClInclude Include="include\navigation\NavigationDebugRenderer.h" />
     <ClInclude Include="include\scene\LensFlare.h" />
     <ClInclude Include="include\scene\RenderMesh.h" />
     <ClInclude Include="include\scene\RenderSkinnedMesh.h" />
@@ -170,6 +172,8 @@
     <ClCompile Include="src\physics\PhysicsDebugRenderer.cpp" />
     <ClCompile Include="src\physics\Q3BspCollision.cpp" />
     <ClCompile Include="src\physics\PhysicsAuthoring.cpp" />
+    <ClCompile Include="src\navigation\NavigationSystem.cpp" />
+    <ClCompile Include="src\navigation\NavigationDebugRenderer.cpp" />
     <ClCompile Include="src\scene\LensFlare.cpp" />
     <ClCompile Include="src\scene\RenderMesh.cpp" />
     <ClCompile Include="src\scene\RenderSkinnedMesh.cpp" />
@@ -582,7 +586,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>T850_ENABLE_JOLT;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;T8_VULKAN_VALIDATION;WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>T850_ENABLE_JOLT;T850_ENABLE_RECAST;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;T8_VULKAN_VALIDATION;WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)Librerias\glaze\include;$(SolutionDir)Librerias\tinyxml2\include;$(ProjectDir);$(ProjectDir)include;$(SolutionDir)Librerias\SDL3\include;$(T8VcpkgStatic)\include;$(T8VcpkgDynamic)\include;$(SolutionDir)Librerias\stb\include;$(SolutionDir)Librerias\mikktspace\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -601,7 +605,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>T850_ENABLE_JOLT;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>T850_ENABLE_JOLT;T850_ENABLE_RECAST;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)Librerias\glaze\include;$(SolutionDir)Librerias\tinyxml2\include;$(ProjectDir);$(ProjectDir)include;$(SolutionDir)Librerias\SDL3\include;$(T8VcpkgStatic)\include;$(T8VcpkgDynamic)\include;$(SolutionDir)Librerias\stb\include;$(SolutionDir)Librerias\mikktspace\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -620,7 +624,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>T850_ENABLE_JOLT;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;T8_VULKAN_VALIDATION;_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>T850_ENABLE_JOLT;T850_ENABLE_RECAST;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;T8_VULKAN_VALIDATION;_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)Librerias\glaze\include;$(SolutionDir)Librerias\tinyxml2\include;$(ProjectDir);$(ProjectDir)include;$(SolutionDir)Librerias\SDL3\include;$(T8VcpkgStatic)\include;$(T8VcpkgDynamic)\include;$(SolutionDir)Librerias\stb\include;$(SolutionDir)Librerias\mikktspace\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -641,7 +645,7 @@
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>T850_ENABLE_JOLT;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>T850_ENABLE_JOLT;T850_ENABLE_RECAST;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)Librerias\glaze\include;$(SolutionDir)Librerias\tinyxml2\include;$(ProjectDir);$(ProjectDir)include;$(SolutionDir)Librerias\SDL3\include;$(T8VcpkgStatic)\include;$(T8VcpkgDynamic)\include;$(SolutionDir)Librerias\stb\include;$(SolutionDir)Librerias\mikktspace\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -669,7 +673,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>T850_ENABLE_JOLT;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>T850_ENABLE_JOLT;T850_ENABLE_RECAST;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)Librerias\glaze\include;$(SolutionDir)Librerias\tinyxml2\include;$(ProjectDir);$(ProjectDir)include;$(SolutionDir)Librerias\SDL3\include;$(T8VcpkgStatic)\include;$(T8VcpkgDynamic)\include;$(SolutionDir)Librerias\stb\include;$(SolutionDir)Librerias\mikktspace\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -697,7 +701,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>T850_ENABLE_JOLT;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>T850_ENABLE_JOLT;T850_ENABLE_RECAST;JPH_FLOATING_POINT_EXCEPTIONS_ENABLED;JPH_OBJECT_STREAM;_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)Librerias\glaze\include;$(SolutionDir)Librerias\tinyxml2\include;$(ProjectDir);$(ProjectDir)include;$(SolutionDir)Librerias\SDL3\include;$(T8VcpkgStatic)\include;$(T8VcpkgDynamic)\include;$(SolutionDir)Librerias\stb\include;$(SolutionDir)Librerias\mikktspace\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/T850/Framework/Framework.vcxproj.filters
+++ b/T850/Framework/Framework.vcxproj.filters
@@ -81,6 +81,12 @@
     <Filter Include="Source Files\physics">
       <UniqueIdentifier>{fb7d6cf1-65eb-4045-984c-2ef7a95d15cc}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\navigation">
+      <UniqueIdentifier>{1ec2dc93-6f40-45e4-b451-82da44d7a934}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\navigation">
+      <UniqueIdentifier>{f15980be-8b52-4411-bfad-e309f6e4a7f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\core\Core.h">
@@ -352,6 +358,12 @@
     </ClInclude>
     <ClInclude Include="include\core\Config.h">
       <Filter>Header Files\core</Filter>
+    </ClInclude>
+    <ClInclude Include="include\navigation\NavigationSystem.h">
+      <Filter>Header Files\navigation</Filter>
+    </ClInclude>
+    <ClInclude Include="include\navigation\NavigationDebugRenderer.h">
+      <Filter>Header Files\navigation</Filter>
     </ClInclude>
     <ClInclude Include="include\debug\FrameDumper.h">
       <Filter>Header Files\utils</Filter>
@@ -705,6 +717,12 @@
     </ClCompile>
     <ClCompile Include="src\debug\RenderTrace.cpp">
       <Filter>Source Files\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="src\navigation\NavigationSystem.cpp">
+      <Filter>Source Files\navigation</Filter>
+    </ClCompile>
+    <ClCompile Include="src\navigation\NavigationDebugRenderer.cpp">
+      <Filter>Source Files\navigation</Filter>
     </ClCompile>
     <ClCompile Include="src\utils\SPIRVReflection.cpp">
       <Filter>Source Files\utils</Filter>

--- a/T850/Framework/include/navigation/NavigationDebugRenderer.h
+++ b/T850/Framework/include/navigation/NavigationDebugRenderer.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <navigation/NavigationSystem.h>
+#include <scene/LineRenderer.h>
+
+#include <vector>
+
+namespace t850 {
+namespace navigation {
+
+enum class NavMeshDebugShapeMode {
+  Geometry = 0,
+  Nodes = 1
+};
+
+class NavMeshDebugRenderer {
+public:
+  bool Create();
+  void Destroy();
+  bool IsReady() const { return m_lineRenderer.IsReady(); }
+
+  void Invalidate();
+  void SetDepthTexture(Texture* depthTexture) { m_depthTexture = depthTexture; }
+  void SetViewport(int width, int height) { m_viewWidth = width; m_viewHeight = height; }
+  void SetFarPlane(float farPlane) { m_farPlane = farPlane; }
+  void SetVerticalOffset(float offset) { m_verticalOffset = offset; }
+  void SetGraphVerticalOffset(float offset) { m_graphVerticalOffset = offset; }
+  void SetShapeMode(NavMeshDebugShapeMode mode) { m_shapeMode = mode; }
+
+  void Draw(const NavMesh& navMesh, const XMATRIX44& viewProjection);
+
+private:
+  void ReleaseGeometryBuffers();
+  bool UploadGeometry(const NavMesh& navMesh);
+
+  LineRenderer m_lineRenderer;
+  VertexBuffer* m_vertexBuffer = nullptr;
+  IndexBuffer* m_indexBuffer = nullptr;
+  VertexBuffer* m_graphVertexBuffer = nullptr;
+  IndexBuffer* m_graphIndexBuffer = nullptr;
+  unsigned m_vertexCapacity = 0;
+  unsigned m_indexCapacity = 0;
+  unsigned m_graphVertexCapacity = 0;
+  unsigned m_graphIndexCapacity = 0;
+  unsigned m_indexCount = 0;
+  unsigned m_graphIndexCount = 0;
+  Texture* m_depthTexture = nullptr;
+  int m_viewWidth = 1280;
+  int m_viewHeight = 720;
+  float m_farPlane = 1000.0f;
+  float m_verticalOffset = 0.01f;
+  float m_graphVerticalOffset = 0.015f;
+  const NavMesh* m_uploadedNavMesh = nullptr;
+  int m_uploadedPolygonCount = 0;
+  int m_uploadedDetailTriangleCount = 0;
+  float m_uploadedVerticalOffset = -1.0f;
+  float m_uploadedGraphVerticalOffset = -1.0f;
+  NavMeshDebugShapeMode m_shapeMode = NavMeshDebugShapeMode::Geometry;
+  NavMeshDebugShapeMode m_uploadedShapeMode = NavMeshDebugShapeMode::Geometry;
+
+  std::vector<XVECTOR3> m_points;
+  std::vector<unsigned int> m_indices;
+  std::vector<float> m_vertices;
+  std::vector<XVECTOR3> m_graphPoints;
+  std::vector<unsigned int> m_graphIndices;
+  std::vector<float> m_graphVertices;
+};
+
+} // namespace navigation
+} // namespace t850

--- a/T850/Framework/include/navigation/NavigationSystem.h
+++ b/T850/Framework/include/navigation/NavigationSystem.h
@@ -1,0 +1,214 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <utils/xMaths.h>
+
+namespace xF {
+class XDataBase;
+}
+
+namespace t850 {
+class PrimitiveInst;
+
+namespace navigation {
+
+struct NavigationBackendInfo {
+  bool recastAvailable = false;
+  bool detourAvailable = false;
+  bool detourCrowdAvailable = false;
+  bool detourTileCacheAvailable = false;
+  std::string recastVersion;
+};
+
+NavigationBackendInfo GetNavigationBackendInfo();
+bool ValidateNavigationBackend();
+
+struct NavMeshBuildSettings {
+  float cellSize = 0.30f;
+  float cellHeight = 0.20f;
+  float agentHeight = 2.0f;
+  float agentRadius = 0.6f;
+  float agentMaxClimb = 0.9f;
+  float agentMaxSlope = 45.0f;
+  float regionMinSize = 8.0f;
+  float regionMergeSize = 20.0f;
+  float edgeMaxLen = 12.0f;
+  float edgeMaxError = 1.3f;
+  int vertsPerPoly = 6;
+  float detailSampleDist = 6.0f;
+  float detailSampleMaxError = 1.0f;
+  XVECTOR3 queryExtents = XVECTOR3(2.0f, 4.0f, 2.0f, 0.0f);
+};
+
+struct NavMeshGeometry {
+  std::vector<XVECTOR3> vertices;
+  std::vector<int> indices;
+};
+
+struct NavMeshBuildStats {
+  int vertexCount = 0;
+  int triangleCount = 0;
+  int width = 0;
+  int height = 0;
+  int polygonCount = 0;
+  int detailTriangleCount = 0;
+};
+
+struct NavSourceBuildStats {
+  int considered = 0;
+  int included = 0;
+  int skippedInvisible = 0;
+  int skippedSkinned = 0;
+  int skippedInvalid = 0;
+  int vertexCount = 0;
+  int triangleCount = 0;
+};
+
+struct NavSourceInstance {
+  unsigned int entityId = 0;
+  const PrimitiveInst* instance = nullptr;
+  const xF::XDataBase* database = nullptr;
+  XMATRIX44 worldTransform;
+  bool visible = true;
+  bool includeInNavigation = true;
+  bool navigationStatic = true;
+  bool navigationWalkable = true;
+  int area = 0;
+  int flags = 0;
+  std::string debugName;
+};
+
+struct NavPathRequest {
+  XVECTOR3 start;
+  XVECTOR3 end;
+  XVECTOR3 queryExtents = XVECTOR3(2.0f, 4.0f, 2.0f, 0.0f);
+};
+
+struct NavPathResult {
+  bool success = false;
+  std::vector<XVECTOR3> points;
+  std::string error;
+};
+
+class INavigationMesh {
+public:
+  virtual ~INavigationMesh() = default;
+  virtual bool IsReady() const = 0;
+  virtual const NavMeshBuildStats& GetStats() const = 0;
+  virtual bool ProjectPoint(const XVECTOR3& point,
+                            XVECTOR3& outPoint,
+                            const XVECTOR3& queryExtents = XVECTOR3(0.0f, 0.0f, 0.0f, 0.0f),
+                            std::string* error = nullptr) const = 0;
+  virtual NavPathResult FindPath(const NavPathRequest& request) const = 0;
+  virtual void FindPaths(const std::vector<NavPathRequest>& requests,
+                         std::vector<NavPathResult>& outResults) const {
+    outResults.resize(requests.size());
+    for (std::size_t i = 0; i < requests.size(); ++i) {
+      outResults[i] = FindPath(requests[i]);
+    }
+  }
+};
+
+class NavMesh : public INavigationMesh {
+public:
+  NavMesh();
+  ~NavMesh();
+  NavMesh(NavMesh&&) noexcept;
+  NavMesh& operator=(NavMesh&&) noexcept;
+  NavMesh(const NavMesh&) = delete;
+  NavMesh& operator=(const NavMesh&) = delete;
+
+  bool Build(const NavMeshGeometry& geometry,
+             const NavMeshBuildSettings& settings = NavMeshBuildSettings(),
+             std::string* error = nullptr);
+  bool BuildFromXDataBase(const xF::XDataBase& database,
+                          const NavMeshBuildSettings& settings = NavMeshBuildSettings(),
+                          std::string* error = nullptr);
+
+  bool IsReady() const override;
+  void Clear();
+
+  bool FindPath(const XVECTOR3& start,
+                const XVECTOR3& end,
+                std::vector<XVECTOR3>& outPath,
+                std::string* error = nullptr) const;
+  bool ProjectPoint(const XVECTOR3& point,
+                    XVECTOR3& outPoint,
+                    const XVECTOR3& queryExtents = XVECTOR3(0.0f, 0.0f, 0.0f, 0.0f),
+                    std::string* error = nullptr) const override;
+  NavPathResult FindPath(const NavPathRequest& request) const override;
+  void FindPaths(const std::vector<NavPathRequest>& requests,
+                 std::vector<NavPathResult>& outResults) const override;
+  bool GetDebugWireframe(std::vector<XVECTOR3>& outVertices,
+                         std::vector<unsigned int>& outIndices,
+                         float verticalOffset = 0.01f) const;
+  bool GetDebugNodeMarkers(std::vector<XVECTOR3>& outVertices,
+                           std::vector<unsigned int>& outIndices,
+                           float verticalOffset = 0.01f) const;
+  bool GetDebugGraphEdges(std::vector<XVECTOR3>& outVertices,
+                          std::vector<unsigned int>& outIndices,
+                          float verticalOffset = 0.015f) const;
+
+  const NavMeshBuildStats& GetStats() const override { return m_stats; }
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> m_impl;
+  NavMeshBuildStats m_stats;
+};
+
+class NavigationWorld : public INavigationMesh {
+public:
+  void ClearSources();
+  void RegisterSource(const NavSourceInstance& source);
+  bool UnregisterSource(unsigned int entityId);
+  bool UpdateSourceTransform(unsigned int entityId, const XMATRIX44& worldTransform);
+  void MarkDirty() { m_dirty = true; }
+  bool IsDirty() const { return m_dirty; }
+
+  void SetBuildSettings(const NavMeshBuildSettings& settings);
+  const NavMeshBuildSettings& GetBuildSettings() const { return m_settings; }
+
+  bool Rebuild(std::string* error = nullptr);
+
+  bool IsReady() const override { return m_navMesh.IsReady(); }
+  const NavMeshBuildStats& GetStats() const override { return m_navMesh.GetStats(); }
+  bool ProjectPoint(const XVECTOR3& point,
+                    XVECTOR3& outPoint,
+                    const XVECTOR3& queryExtents = XVECTOR3(0.0f, 0.0f, 0.0f, 0.0f),
+                    std::string* error = nullptr) const override {
+    return m_navMesh.ProjectPoint(point, outPoint, queryExtents, error);
+  }
+  NavPathResult FindPath(const NavPathRequest& request) const override { return m_navMesh.FindPath(request); }
+  void FindPaths(const std::vector<NavPathRequest>& requests,
+                 std::vector<NavPathResult>& outResults) const override { m_navMesh.FindPaths(requests, outResults); }
+
+  const NavMesh& GetNavMesh() const { return m_navMesh; }
+  NavMesh& GetNavMesh() { return m_navMesh; }
+  const NavSourceBuildStats& GetLastSourceStats() const { return m_lastSourceStats; }
+  const std::vector<NavSourceInstance>& GetSources() const { return m_sources; }
+
+private:
+  std::vector<NavSourceInstance> m_sources;
+  NavMeshBuildSettings m_settings;
+  NavMesh m_navMesh;
+  NavSourceBuildStats m_lastSourceStats;
+  bool m_dirty = true;
+};
+
+bool BuildGeometryFromXDataBase(const xF::XDataBase& database, NavMeshGeometry& outGeometry, std::string* error = nullptr);
+bool AppendGeometryFromXDataBase(const xF::XDataBase& database,
+                                 const XMATRIX44& worldTransform,
+                                 NavMeshGeometry& outGeometry,
+                                 std::string* error = nullptr);
+bool BuildGeometryFromPrimitiveInstances(const PrimitiveInst* instances,
+                                         int instanceCount,
+                                         NavMeshGeometry& outGeometry,
+                                         NavSourceBuildStats* stats = nullptr,
+                                         std::string* error = nullptr);
+
+} // namespace navigation
+} // namespace t850

--- a/T850/Framework/include/scene/EditorSceneFile.h
+++ b/T850/Framework/include/scene/EditorSceneFile.h
@@ -24,6 +24,7 @@ struct SceneObjectDesc {
   std::optional<bool> mobile_visible;
   bool frozen = false;
   bool show_wire = false;
+  std::optional<float> nav_agent_front_yaw_offset_deg;
 };
 
 struct SceneCameraDesc {

--- a/T850/Framework/include/scene/LineRenderer.h
+++ b/T850/Framework/include/scene/LineRenderer.h
@@ -56,6 +56,9 @@ public:
   // Set the camera far plane for depth-tested overlays.
   void SetFarPlane(float farPlane) { m_farPlane = farPlane; }
 
+  // Set proportional reversed-Z depth bias for shader depth-tested overlays.
+  void SetDepthBias(float bias) { m_depthBias = bias; }
+
   // Issue one indexed line-list draw using the supplied VB/IB.
   void DrawLines(const XMATRIX44& world,
                  const XMATRIX44& vp,
@@ -85,6 +88,7 @@ private:
   int             m_viewW       = 1280;
   int             m_viewH       = 720;
   float           m_farPlane    = 1000.0f;
+  float           m_depthBias   = 0.005f;
   bool            m_depthTest   = true;
 };
 

--- a/T850/Framework/src/core/android/AndroidFramework.cpp
+++ b/T850/Framework/src/core/android/AndroidFramework.cpp
@@ -11,6 +11,7 @@
 #include <utils/Log.h>
 #include <utils/ThreadPool.h>
 #include <debug/RuntimeTelemetry.h>
+#include <navigation/NavigationSystem.h>
 
 #include <android/native_activity.h>
 #include <android/native_window.h>
@@ -87,6 +88,14 @@ namespace t850 {
     aplicationDescriptor.api = GraphicsApi::VULKAN;
     InitGlobalThreadPool();
     RuntimeTelemetry::InitializeFromConfig(g_config);
+    const navigation::NavigationBackendInfo navInfo = navigation::GetNavigationBackendInfo();
+    T8_LOG_INFO("[Navigation] Recast=%d Detour=%d Crowd=%d TileCache=%d version=%s validation=%s",
+                navInfo.recastAvailable ? 1 : 0,
+                navInfo.detourAvailable ? 1 : 0,
+                navInfo.detourCrowdAvailable ? 1 : 0,
+                navInfo.detourTileCacheAvailable ? 1 : 0,
+                navInfo.recastVersion.c_str(),
+                navigation::ValidateNavigationBackend() ? "ok" : "failed");
     pBaseApp->InitVars();
     m_inited = true;
   }

--- a/T850/Framework/src/core/windows/Win32Framework.cpp
+++ b/T850/Framework/src/core/windows/Win32Framework.cpp
@@ -29,6 +29,7 @@
 #include <utils/ThreadPool.h>
 #include <utils/Log.h>
 #include <debug/RuntimeTelemetry.h>
+#include <navigation/NavigationSystem.h>
 namespace t850 {
   void Win32Framework::InitGlobalVars() {
 
@@ -39,6 +40,14 @@ namespace t850 {
     aplicationDescriptor = desc;
     InitGlobalThreadPool();
     RuntimeTelemetry::InitializeFromConfig(g_config);
+    const navigation::NavigationBackendInfo navInfo = navigation::GetNavigationBackendInfo();
+    T8_LOG_INFO("[Navigation] Recast=%d Detour=%d Crowd=%d TileCache=%d version=%s validation=%s",
+                navInfo.recastAvailable ? 1 : 0,
+                navInfo.detourAvailable ? 1 : 0,
+                navInfo.detourCrowdAvailable ? 1 : 0,
+                navInfo.detourTileCacheAvailable ? 1 : 0,
+                navInfo.recastVersion.c_str(),
+                navigation::ValidateNavigationBackend() ? "ok" : "failed");
     if (!SDL_Init(SDL_INIT_VIDEO)) {
       printf("Video initialization failed: %s\n", SDL_GetError());
     }

--- a/T850/Framework/src/navigation/NavigationDebugRenderer.cpp
+++ b/T850/Framework/src/navigation/NavigationDebugRenderer.cpp
@@ -1,0 +1,258 @@
+#include <pch.h>
+
+#include <navigation/NavigationDebugRenderer.h>
+
+#include <utils/Log.h>
+
+#include <algorithm>
+
+namespace t850 {
+  extern Device* T8Device;
+  extern DeviceContext* T8DeviceContext;
+}
+
+namespace t850 {
+namespace navigation {
+
+bool NavMeshDebugRenderer::Create() {
+  return m_lineRenderer.Create();
+}
+
+void NavMeshDebugRenderer::Destroy() {
+  ReleaseGeometryBuffers();
+  m_lineRenderer.Destroy();
+}
+
+void NavMeshDebugRenderer::Invalidate() {
+  m_uploadedNavMesh = nullptr;
+  m_uploadedPolygonCount = 0;
+  m_uploadedDetailTriangleCount = 0;
+  m_uploadedVerticalOffset = -1.0f;
+  m_uploadedGraphVerticalOffset = -1.0f;
+  m_uploadedShapeMode = m_shapeMode;
+  m_indexCount = 0;
+  m_graphIndexCount = 0;
+}
+
+void NavMeshDebugRenderer::ReleaseGeometryBuffers() {
+  if (m_vertexBuffer) {
+    m_vertexBuffer->release();
+    m_vertexBuffer = nullptr;
+  }
+  if (m_indexBuffer) {
+    m_indexBuffer->release();
+    m_indexBuffer = nullptr;
+  }
+  if (m_graphVertexBuffer) {
+    m_graphVertexBuffer->release();
+    m_graphVertexBuffer = nullptr;
+  }
+  if (m_graphIndexBuffer) {
+    m_graphIndexBuffer->release();
+    m_graphIndexBuffer = nullptr;
+  }
+  m_vertexCapacity = 0;
+  m_indexCapacity = 0;
+  m_graphVertexCapacity = 0;
+  m_graphIndexCapacity = 0;
+  Invalidate();
+}
+
+bool NavMeshDebugRenderer::UploadGeometry(const NavMesh& navMesh) {
+  const NavMeshBuildStats& stats = navMesh.GetStats();
+  if (m_vertexBuffer && m_indexBuffer &&
+      m_uploadedNavMesh == &navMesh &&
+      m_uploadedPolygonCount == stats.polygonCount &&
+      m_uploadedDetailTriangleCount == stats.detailTriangleCount &&
+      m_uploadedVerticalOffset == m_verticalOffset &&
+      m_uploadedGraphVerticalOffset == m_graphVerticalOffset &&
+      m_uploadedShapeMode == m_shapeMode) {
+    return m_indexCount > 0;
+  }
+
+  const bool hasShape = (m_shapeMode == NavMeshDebugShapeMode::Nodes)
+      ? navMesh.GetDebugNodeMarkers(m_points, m_indices, m_verticalOffset)
+      : navMesh.GetDebugWireframe(m_points, m_indices, m_verticalOffset);
+  if (!hasShape) {
+    m_indexCount = 0;
+    return false;
+  }
+
+  XVECTOR3 minPoint( 1.0e30f,  1.0e30f,  1.0e30f, 1.0f);
+  XVECTOR3 maxPoint(-1.0e30f, -1.0e30f, -1.0e30f, 1.0f);
+  for (const XVECTOR3& point : m_points) {
+    minPoint.x = (std::min)(minPoint.x, point.x);
+    minPoint.y = (std::min)(minPoint.y, point.y);
+    minPoint.z = (std::min)(minPoint.z, point.z);
+    maxPoint.x = (std::max)(maxPoint.x, point.x);
+    maxPoint.y = (std::max)(maxPoint.y, point.y);
+    maxPoint.z = (std::max)(maxPoint.z, point.z);
+  }
+
+  m_vertices.clear();
+  m_vertices.reserve(m_points.size() * 4u);
+  for (const XVECTOR3& point : m_points) {
+    m_vertices.push_back(point.x);
+    m_vertices.push_back(point.y);
+    m_vertices.push_back(point.z);
+    m_vertices.push_back(1.0f);
+  }
+
+  const unsigned vertexCount = static_cast<unsigned>(m_vertices.size() / 4u);
+  const unsigned indexCount = static_cast<unsigned>(m_indices.size());
+  if (vertexCount == 0 || indexCount == 0) {
+    m_indexCount = 0;
+    return false;
+  }
+
+  if (!m_vertexBuffer || !m_indexBuffer ||
+      vertexCount > m_vertexCapacity ||
+      indexCount > m_indexCapacity) {
+    ReleaseGeometryBuffers();
+
+    m_vertexBuffer = LineRenderer::CreatePositionVB(m_vertices.data(), vertexCount, BufferUsage::DINAMIC);
+
+    BufferDesc indexDesc;
+    indexDesc.byteWidth = static_cast<int>(sizeof(unsigned int) * indexCount);
+    indexDesc.usage = BufferUsage::DINAMIC;
+    m_indexBuffer = T8Device ? static_cast<IndexBuffer*>(
+        T8Device->CreateBuffer(BufferType::INDEX, indexDesc, m_indices.data())) : nullptr;
+
+    if (!m_vertexBuffer || !m_indexBuffer) {
+      T8_LOG_ERROR("[NavigationDebugRenderer] Failed to create navmesh line buffers");
+      ReleaseGeometryBuffers();
+      return false;
+    }
+
+    m_vertexCapacity = vertexCount;
+    m_indexCapacity = indexCount;
+  } else {
+    if (!T8DeviceContext) {
+      return false;
+    }
+    m_vertices.resize(static_cast<std::size_t>(m_vertexCapacity) * 4u, 0.0f);
+    m_indices.resize(m_indexCapacity, 0u);
+    m_vertexBuffer->UpdateFromBuffer(*T8DeviceContext, m_vertices.data());
+    m_indexBuffer->UpdateFromBuffer(*T8DeviceContext, m_indices.data());
+  }
+
+  navMesh.GetDebugGraphEdges(m_graphPoints, m_graphIndices, m_graphVerticalOffset);
+  m_graphVertices.clear();
+  m_graphVertices.reserve(m_graphPoints.size() * 4u);
+  for (const XVECTOR3& point : m_graphPoints) {
+    m_graphVertices.push_back(point.x);
+    m_graphVertices.push_back(point.y);
+    m_graphVertices.push_back(point.z);
+    m_graphVertices.push_back(1.0f);
+  }
+
+  const unsigned graphVertexCount = static_cast<unsigned>(m_graphVertices.size() / 4u);
+  const unsigned graphIndexCount = static_cast<unsigned>(m_graphIndices.size());
+  if (graphVertexCount == 0 || graphIndexCount == 0) {
+    m_graphIndexCount = 0;
+  } else if (!m_graphVertexBuffer || !m_graphIndexBuffer ||
+             graphVertexCount > m_graphVertexCapacity ||
+             graphIndexCount > m_graphIndexCapacity) {
+    if (m_graphVertexBuffer) {
+      m_graphVertexBuffer->release();
+      m_graphVertexBuffer = nullptr;
+    }
+    if (m_graphIndexBuffer) {
+      m_graphIndexBuffer->release();
+      m_graphIndexBuffer = nullptr;
+    }
+    m_graphVertexCapacity = 0;
+    m_graphIndexCapacity = 0;
+
+    m_graphVertexBuffer = LineRenderer::CreatePositionVB(m_graphVertices.data(), graphVertexCount, BufferUsage::DINAMIC);
+
+    BufferDesc graphIndexDesc;
+    graphIndexDesc.byteWidth = static_cast<int>(sizeof(unsigned int) * graphIndexCount);
+    graphIndexDesc.usage = BufferUsage::DINAMIC;
+    m_graphIndexBuffer = T8Device ? static_cast<IndexBuffer*>(
+        T8Device->CreateBuffer(BufferType::INDEX, graphIndexDesc, m_graphIndices.data())) : nullptr;
+
+    if (!m_graphVertexBuffer || !m_graphIndexBuffer) {
+      T8_LOG_ERROR("[NavigationDebugRenderer] Failed to create navmesh graph edge buffers");
+      if (m_graphVertexBuffer) {
+        m_graphVertexBuffer->release();
+        m_graphVertexBuffer = nullptr;
+      }
+      if (m_graphIndexBuffer) {
+        m_graphIndexBuffer->release();
+        m_graphIndexBuffer = nullptr;
+      }
+      m_graphIndexCount = 0;
+    } else {
+      m_graphVertexCapacity = graphVertexCount;
+      m_graphIndexCapacity = graphIndexCount;
+      m_graphIndexCount = graphIndexCount;
+    }
+  } else {
+    if (!T8DeviceContext) {
+      return false;
+    }
+    m_graphVertices.resize(static_cast<std::size_t>(m_graphVertexCapacity) * 4u, 0.0f);
+    m_graphIndices.resize(m_graphIndexCapacity, 0u);
+    m_graphVertexBuffer->UpdateFromBuffer(*T8DeviceContext, m_graphVertices.data());
+    m_graphIndexBuffer->UpdateFromBuffer(*T8DeviceContext, m_graphIndices.data());
+    m_graphIndexCount = graphIndexCount;
+  }
+
+  m_uploadedNavMesh = &navMesh;
+  m_uploadedPolygonCount = stats.polygonCount;
+  m_uploadedDetailTriangleCount = stats.detailTriangleCount;
+  m_uploadedVerticalOffset = m_verticalOffset;
+  m_uploadedGraphVerticalOffset = m_graphVerticalOffset;
+  m_uploadedShapeMode = m_shapeMode;
+  m_indexCount = indexCount;
+  T8_LOG_INFO("[NavigationDebugRenderer] Uploaded navmesh debug mode=%d magentaLines=%u graphEdges=%u verts=%u bounds=(%.2f,%.2f,%.2f)-(%.2f,%.2f,%.2f) offsets=(%.2f,%.2f)",
+              static_cast<int>(m_shapeMode),
+              indexCount / 2u, m_graphIndexCount / 2u, vertexCount,
+              minPoint.x, minPoint.y, minPoint.z,
+              maxPoint.x, maxPoint.y, maxPoint.z,
+              m_verticalOffset, m_graphVerticalOffset);
+  return true;
+}
+
+void NavMeshDebugRenderer::Draw(const NavMesh& navMesh, const XMATRIX44& viewProjection) {
+  if (!m_lineRenderer.IsReady() || !navMesh.IsReady()) {
+    return;
+  }
+  if (!UploadGeometry(navMesh)) {
+    return;
+  }
+
+  if (!m_depthTexture) {
+    return;
+  }
+
+  XMATRIX44 identity;
+  identity.Identity();
+  m_lineRenderer.SetDepthTestEnabled(true);
+  m_lineRenderer.SetDepthTexture(m_depthTexture);
+  m_lineRenderer.SetViewport(m_viewWidth, m_viewHeight);
+  m_lineRenderer.SetFarPlane(m_farPlane);
+  m_lineRenderer.SetDepthBias(0.025f);
+  m_lineRenderer.DrawLines(identity,
+                           viewProjection,
+                           XVECTOR3(1.0f, 0.0f, 1.0f, 1.0f),
+                           m_vertexBuffer,
+                           m_indexBuffer,
+                           m_indexCount,
+                           sizeof(float) * 4,
+                           IndexBufferFormat::R32);
+  if (m_graphVertexBuffer && m_graphIndexBuffer && m_graphIndexCount > 0) {
+    m_lineRenderer.DrawLines(identity,
+                             viewProjection,
+                             XVECTOR3(0.0f, 1.0f, 0.05f, 1.0f),
+                             m_graphVertexBuffer,
+                             m_graphIndexBuffer,
+                             m_graphIndexCount,
+                             sizeof(float) * 4,
+                             IndexBufferFormat::R32);
+  }
+}
+
+} // namespace navigation
+} // namespace t850

--- a/T850/Framework/src/navigation/NavigationSystem.cpp
+++ b/T850/Framework/src/navigation/NavigationSystem.cpp
@@ -1,0 +1,1107 @@
+#include <pch.h>
+
+#include <navigation/NavigationSystem.h>
+
+#include <utils/Log.h>
+#include <utils/XDataBase.h>
+#include <utils/xDefs.h>
+#include <utils/ThreadPool.h>
+#include <scene/PrimitiveInstance.h>
+#include <scene/RenderMesh.h>
+#include <scene/RenderSkinnedMesh.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+#if defined(T850_ENABLE_RECAST)
+#include <recastnavigation/DetourCrowd.h>
+#include <recastnavigation/DetourNavMesh.h>
+#include <recastnavigation/DetourNavMeshBuilder.h>
+#include <recastnavigation/DetourNavMeshQuery.h>
+#include <recastnavigation/DetourStatus.h>
+#include <recastnavigation/DetourTileCache.h>
+#include <recastnavigation/Recast.h>
+#include <recastnavigation/version.h>
+#endif
+
+namespace t850 {
+namespace navigation {
+
+namespace {
+
+void SetError(std::string* out, const std::string& message) {
+  if (out) *out = message;
+  T8_LOG_ERROR("[Navigation] %s", message.c_str());
+}
+
+bool IsFiniteVec3(const XVECTOR3& v) {
+  return std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z);
+}
+
+XVECTOR3 TransformPoint(const XVECTOR3& point, const XMATRIX44& matrix) {
+  return XVECTOR3(
+      point.x * matrix.m11 + point.y * matrix.m21 + point.z * matrix.m31 + matrix.m41,
+      point.x * matrix.m12 + point.y * matrix.m22 + point.z * matrix.m32 + matrix.m42,
+      point.x * matrix.m13 + point.y * matrix.m23 + point.z * matrix.m33 + matrix.m43,
+      1.0f);
+}
+
+#if defined(T850_ENABLE_RECAST)
+template <typename T, void(*FreeFn)(T*)>
+struct RecastDeleter {
+  void operator()(T* ptr) const {
+    if (ptr) FreeFn(ptr);
+  }
+};
+
+using HeightfieldPtr = std::unique_ptr<rcHeightfield, RecastDeleter<rcHeightfield, rcFreeHeightField>>;
+using CompactHeightfieldPtr = std::unique_ptr<rcCompactHeightfield, RecastDeleter<rcCompactHeightfield, rcFreeCompactHeightfield>>;
+using ContourSetPtr = std::unique_ptr<rcContourSet, RecastDeleter<rcContourSet, rcFreeContourSet>>;
+using PolyMeshPtr = std::unique_ptr<rcPolyMesh, RecastDeleter<rcPolyMesh, rcFreePolyMesh>>;
+using PolyMeshDetailPtr = std::unique_ptr<rcPolyMeshDetail, RecastDeleter<rcPolyMeshDetail, rcFreePolyMeshDetail>>;
+
+struct NavMeshDeleter {
+  void operator()(dtNavMesh* ptr) const { if (ptr) dtFreeNavMesh(ptr); }
+};
+
+struct NavMeshQueryDeleter {
+  void operator()(dtNavMeshQuery* ptr) const { if (ptr) dtFreeNavMeshQuery(ptr); }
+};
+
+constexpr unsigned short kNavPolyFlagWalk = 0x01;
+constexpr int kMaxPathPolys = 256;
+constexpr int kMaxStraightPath = 256;
+
+NavPathResult FindPathWithQuery(dtNavMeshQuery* query,
+                                const NavMeshBuildSettings& settings,
+                                const NavPathRequest& request) {
+  NavPathResult result;
+  if (!query) {
+    result.error = "Navigation query is not available";
+    return result;
+  }
+
+  const float startPos[3] = { request.start.x, request.start.y, request.start.z };
+  const float endPos[3] = { request.end.x, request.end.y, request.end.z };
+  const float extents[3] = {
+    request.queryExtents.x > 0.0f ? request.queryExtents.x : settings.queryExtents.x,
+    request.queryExtents.y > 0.0f ? request.queryExtents.y : settings.queryExtents.y,
+    request.queryExtents.z > 0.0f ? request.queryExtents.z : settings.queryExtents.z
+  };
+
+  dtQueryFilter filter;
+  filter.setIncludeFlags(kNavPolyFlagWalk);
+  filter.setExcludeFlags(0);
+
+  dtPolyRef startRef = 0;
+  dtPolyRef endRef = 0;
+  float nearestStart[3] = {};
+  float nearestEnd[3] = {};
+  dtStatus status = query->findNearestPoly(startPos, extents, &filter, &startRef, nearestStart);
+  if (dtStatusFailed(status) || !startRef) {
+    result.error = "Failed to find nearest start nav polygon";
+    return result;
+  }
+  status = query->findNearestPoly(endPos, extents, &filter, &endRef, nearestEnd);
+  if (dtStatusFailed(status) || !endRef) {
+    result.error = "Failed to find nearest end nav polygon";
+    return result;
+  }
+
+  dtPolyRef pathPolys[kMaxPathPolys] = {};
+  int pathPolyCount = 0;
+  status = query->findPath(startRef, endRef, nearestStart, nearestEnd,
+                           &filter, pathPolys, &pathPolyCount, kMaxPathPolys);
+  if (dtStatusFailed(status) || pathPolyCount <= 0) {
+    result.error = "Detour failed to find a path";
+    return result;
+  }
+
+  float straightPath[kMaxStraightPath * 3] = {};
+  unsigned char straightFlags[kMaxStraightPath] = {};
+  dtPolyRef straightPolys[kMaxStraightPath] = {};
+  int straightPathCount = 0;
+  status = query->findStraightPath(nearestStart, nearestEnd,
+                                   pathPolys, pathPolyCount,
+                                   straightPath, straightFlags, straightPolys,
+                                   &straightPathCount, kMaxStraightPath);
+  if (dtStatusFailed(status) || straightPathCount <= 0) {
+    result.error = "Detour failed to straighten path";
+    return result;
+  }
+
+  result.points.reserve(static_cast<std::size_t>(straightPathCount));
+  for (int i = 0; i < straightPathCount; ++i) {
+    const float* p = &straightPath[i * 3];
+    result.points.emplace_back(p[0], p[1], p[2], 1.0f);
+  }
+  result.success = true;
+  return result;
+}
+#endif
+
+} // namespace
+
+NavigationBackendInfo GetNavigationBackendInfo() {
+  NavigationBackendInfo info;
+#if defined(T850_ENABLE_RECAST)
+  info.recastAvailable = true;
+  info.detourAvailable = true;
+  info.detourCrowdAvailable = true;
+  info.detourTileCacheAvailable = true;
+  info.recastVersion = RECASTNAV_VERSION;
+#else
+  info.recastVersion = "unavailable";
+#endif
+  return info;
+}
+
+bool ValidateNavigationBackend() {
+#if defined(T850_ENABLE_RECAST)
+  rcHeightfield* heightfield = rcAllocHeightfield();
+  dtNavMesh* navMesh = dtAllocNavMesh();
+  dtCrowd* crowd = dtAllocCrowd();
+  dtTileCache* tileCache = dtAllocTileCache();
+
+  const bool ok = heightfield && navMesh && crowd && tileCache;
+
+  if (tileCache) dtFreeTileCache(tileCache);
+  if (crowd) dtFreeCrowd(crowd);
+  if (navMesh) dtFreeNavMesh(navMesh);
+  if (heightfield) rcFreeHeightField(heightfield);
+
+  return ok;
+#else
+  return false;
+#endif
+}
+
+struct NavMesh::Impl {
+#if defined(T850_ENABLE_RECAST)
+  std::unique_ptr<dtNavMesh, NavMeshDeleter> navMesh;
+  std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> query;
+  NavMeshBuildSettings settings;
+#endif
+};
+
+NavMesh::NavMesh()
+  : m_impl(std::make_unique<Impl>()) {
+}
+
+NavMesh::~NavMesh() = default;
+NavMesh::NavMesh(NavMesh&&) noexcept = default;
+NavMesh& NavMesh::operator=(NavMesh&&) noexcept = default;
+
+void NavMesh::Clear() {
+  m_impl = std::make_unique<Impl>();
+  m_stats = NavMeshBuildStats{};
+}
+
+bool NavMesh::IsReady() const {
+#if defined(T850_ENABLE_RECAST)
+  return m_impl && m_impl->navMesh && m_impl->query;
+#else
+  return false;
+#endif
+}
+
+bool BuildGeometryFromXDataBase(const xF::XDataBase& database, NavMeshGeometry& outGeometry, std::string* error) {
+  outGeometry.vertices.clear();
+  outGeometry.indices.clear();
+
+  XMATRIX44 identity;
+  identity.Identity();
+  return AppendGeometryFromXDataBase(database, identity, outGeometry, error);
+}
+
+bool AppendGeometryFromXDataBase(const xF::XDataBase& database,
+                                 const XMATRIX44& worldTransform,
+                                 NavMeshGeometry& outGeometry,
+                                 std::string* error) {
+  if (database.XMeshDataBase.empty() || !database.XMeshDataBase[0]) {
+    SetError(error, "XDataBase has no mesh container");
+    return false;
+  }
+
+  const xF::xMeshContainer* meshContainer = database.XMeshDataBase[0];
+  const std::size_t geometryCount = (std::min)(database.MeshInfo.size(), meshContainer->Geometry.size());
+  if (geometryCount == 0) {
+    SetError(error, "XDataBase has no geometry");
+    return false;
+  }
+
+  for (std::size_t gi = 0; gi < geometryCount; ++gi) {
+    const xF::xFinalGeometry& finalGeometry = database.MeshInfo[gi];
+    const xF::xMeshGeometry& sourceGeometry = meshContainer->Geometry[gi];
+    const unsigned int stride = finalGeometry.VertexSize / sizeof(float);
+    if (!finalGeometry.pData || stride < 3 || finalGeometry.NumVertex == 0) {
+      continue;
+    }
+
+    const int baseVertex = static_cast<int>(outGeometry.vertices.size());
+    outGeometry.vertices.reserve(outGeometry.vertices.size() + finalGeometry.NumVertex);
+    for (unsigned int v = 0; v < finalGeometry.NumVertex; ++v) {
+      const float* vertex = &finalGeometry.pData[v * stride];
+      XVECTOR3 pos(vertex[0], vertex[1], vertex[2], 1.0f);
+      if (IsFiniteVec3(pos)) {
+        outGeometry.vertices.push_back(TransformPoint(pos, worldTransform));
+      } else {
+        outGeometry.vertices.push_back(TransformPoint(XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f), worldTransform));
+      }
+    }
+
+    const std::size_t triangleIndexCount = sourceGeometry.Indices32Bit
+      ? sourceGeometry.Triangles32.size()
+      : sourceGeometry.Triangles.size();
+    outGeometry.indices.reserve(outGeometry.indices.size() + triangleIndexCount);
+    if (sourceGeometry.Indices32Bit) {
+      for (std::size_t i = 0; i + 2 < sourceGeometry.Triangles32.size(); i += 3) {
+        const xF::xDWORD i0 = sourceGeometry.Triangles32[i + 0];
+        const xF::xDWORD i1 = sourceGeometry.Triangles32[i + 1];
+        const xF::xDWORD i2 = sourceGeometry.Triangles32[i + 2];
+        if (i0 >= finalGeometry.NumVertex || i1 >= finalGeometry.NumVertex || i2 >= finalGeometry.NumVertex) continue;
+        outGeometry.indices.push_back(baseVertex + static_cast<int>(i0));
+        outGeometry.indices.push_back(baseVertex + static_cast<int>(i1));
+        outGeometry.indices.push_back(baseVertex + static_cast<int>(i2));
+      }
+    } else {
+      for (std::size_t i = 0; i + 2 < sourceGeometry.Triangles.size(); i += 3) {
+        const xF::xWORD i0 = sourceGeometry.Triangles[i + 0];
+        const xF::xWORD i1 = sourceGeometry.Triangles[i + 1];
+        const xF::xWORD i2 = sourceGeometry.Triangles[i + 2];
+        if (i0 >= finalGeometry.NumVertex || i1 >= finalGeometry.NumVertex || i2 >= finalGeometry.NumVertex) continue;
+        outGeometry.indices.push_back(baseVertex + static_cast<int>(i0));
+        outGeometry.indices.push_back(baseVertex + static_cast<int>(i1));
+        outGeometry.indices.push_back(baseVertex + static_cast<int>(i2));
+      }
+    }
+  }
+
+  if (outGeometry.vertices.empty() || outGeometry.indices.size() < 3) {
+    SetError(error, "Extracted navigation geometry is empty");
+    return false;
+  }
+  return !outGeometry.indices.empty();
+}
+
+bool BuildGeometryFromPrimitiveInstances(const PrimitiveInst* instances,
+                                         int instanceCount,
+                                         NavMeshGeometry& outGeometry,
+                                         NavSourceBuildStats* stats,
+                                         std::string* error) {
+  outGeometry.vertices.clear();
+  outGeometry.indices.clear();
+  if (stats) {
+    *stats = NavSourceBuildStats{};
+  }
+
+  if (!instances || instanceCount <= 0) {
+    SetError(error, "No primitive instances were provided for navigation geometry");
+    return false;
+  }
+
+  for (int instanceIndex = 0; instanceIndex < instanceCount; ++instanceIndex) {
+    const PrimitiveInst& instance = instances[instanceIndex];
+    if (stats) ++stats->considered;
+
+    if (!instance.Visible || !instance.pBase) {
+      if (stats) ++stats->skippedInvisible;
+      continue;
+    }
+
+    if (instance.GetSkinnedMesh()) {
+      if (stats) ++stats->skippedSkinned;
+      continue;
+    }
+
+    const RenderMesh* mesh = dynamic_cast<const RenderMesh*>(instance.pBase);
+    if (!mesh || !mesh->xFile) {
+      if (stats) ++stats->skippedInvalid;
+      continue;
+    }
+
+    const std::size_t indicesBefore = outGeometry.indices.size();
+    std::string sourceError;
+    if (!AppendGeometryFromXDataBase(*mesh->xFile, instance.Final, outGeometry, &sourceError) ||
+        outGeometry.indices.size() == indicesBefore) {
+      if (stats) ++stats->skippedInvalid;
+      continue;
+    }
+
+    if (stats) ++stats->included;
+  }
+
+  if (outGeometry.vertices.empty() || outGeometry.indices.size() < 3) {
+    SetError(error, "Primitive instances produced no navigation geometry");
+    return false;
+  }
+
+  if (stats) {
+    stats->vertexCount = static_cast<int>(outGeometry.vertices.size());
+    stats->triangleCount = static_cast<int>(outGeometry.indices.size() / 3);
+  }
+  return true;
+}
+
+bool NavMesh::BuildFromXDataBase(const xF::XDataBase& database,
+                                 const NavMeshBuildSettings& settings,
+                                 std::string* error) {
+  NavMeshGeometry geometry;
+  if (!BuildGeometryFromXDataBase(database, geometry, error)) {
+    return false;
+  }
+  return Build(geometry, settings, error);
+}
+
+bool NavMesh::Build(const NavMeshGeometry& geometry,
+                    const NavMeshBuildSettings& settings,
+                    std::string* error) {
+#if !defined(T850_ENABLE_RECAST)
+  SetError(error, "RecastNavigation is not enabled in this build");
+  return false;
+#else
+  Clear();
+  m_impl->settings = settings;
+
+  if (geometry.vertices.size() < 3 || geometry.indices.size() < 3) {
+    SetError(error, "Navigation geometry must contain vertices and triangle indices");
+    return false;
+  }
+  if ((geometry.indices.size() % 3) != 0) {
+    SetError(error, "Navigation geometry indices must be a triangle list");
+    return false;
+  }
+  if (settings.cellSize <= 0.0f || settings.cellHeight <= 0.0f ||
+      settings.agentHeight <= 0.0f || settings.agentRadius < 0.0f ||
+      settings.vertsPerPoly < 3) {
+    SetError(error, "Invalid navigation build settings");
+    return false;
+  }
+
+  std::vector<float> verts;
+  verts.reserve(geometry.vertices.size() * 3);
+  for (const XVECTOR3& v : geometry.vertices) {
+    if (!IsFiniteVec3(v)) {
+      SetError(error, "Navigation geometry contains non-finite vertex");
+      return false;
+    }
+    verts.push_back(v.x);
+    verts.push_back(v.y);
+    verts.push_back(v.z);
+  }
+
+  std::vector<int> tris = geometry.indices;
+  for (int idx : tris) {
+    if (idx < 0 || idx >= static_cast<int>(geometry.vertices.size())) {
+      SetError(error, "Navigation geometry contains out-of-range index");
+      return false;
+    }
+  }
+
+  rcContext context;
+  rcConfig config;
+  std::memset(&config, 0, sizeof(config));
+
+  config.cs = settings.cellSize;
+  config.ch = settings.cellHeight;
+  config.walkableSlopeAngle = settings.agentMaxSlope;
+  config.walkableHeight = static_cast<int>(std::ceil(settings.agentHeight / config.ch));
+  config.walkableClimb = static_cast<int>(std::floor(settings.agentMaxClimb / config.ch));
+  config.walkableRadius = static_cast<int>(std::ceil(settings.agentRadius / config.cs));
+  config.maxEdgeLen = static_cast<int>(settings.edgeMaxLen / settings.cellSize);
+  config.maxSimplificationError = settings.edgeMaxError;
+  config.minRegionArea = static_cast<int>(settings.regionMinSize * settings.regionMinSize);
+  config.mergeRegionArea = static_cast<int>(settings.regionMergeSize * settings.regionMergeSize);
+  config.maxVertsPerPoly = settings.vertsPerPoly;
+  config.detailSampleDist = settings.detailSampleDist < 0.9f ? 0.0f : settings.cellSize * settings.detailSampleDist;
+  config.detailSampleMaxError = settings.cellHeight * settings.detailSampleMaxError;
+
+  rcCalcBounds(verts.data(), static_cast<int>(geometry.vertices.size()), config.bmin, config.bmax);
+  rcCalcGridSize(config.bmin, config.bmax, config.cs, &config.width, &config.height);
+  if (config.width <= 0 || config.height <= 0) {
+    SetError(error, "Navigation geometry bounds produced an empty Recast grid");
+    return false;
+  }
+
+  HeightfieldPtr heightfield(rcAllocHeightfield());
+  if (!heightfield || !rcCreateHeightfield(&context, *heightfield, config.width, config.height,
+                                           config.bmin, config.bmax, config.cs, config.ch)) {
+    SetError(error, "Failed to create Recast heightfield");
+    return false;
+  }
+
+  const int triangleCount = static_cast<int>(tris.size() / 3);
+  std::vector<unsigned char> areas(static_cast<std::size_t>(triangleCount), RC_NULL_AREA);
+  rcMarkWalkableTriangles(&context, config.walkableSlopeAngle, verts.data(),
+                          static_cast<int>(geometry.vertices.size()), tris.data(), triangleCount, areas.data());
+  if (!rcRasterizeTriangles(&context, verts.data(), static_cast<int>(geometry.vertices.size()),
+                            tris.data(), areas.data(), triangleCount, *heightfield, config.walkableClimb)) {
+    SetError(error, "Failed to rasterize navigation triangles");
+    return false;
+  }
+
+  rcFilterLowHangingWalkableObstacles(&context, config.walkableClimb, *heightfield);
+  rcFilterLedgeSpans(&context, config.walkableHeight, config.walkableClimb, *heightfield);
+  rcFilterWalkableLowHeightSpans(&context, config.walkableHeight, *heightfield);
+
+  CompactHeightfieldPtr compact(rcAllocCompactHeightfield());
+  if (!compact || !rcBuildCompactHeightfield(&context, config.walkableHeight, config.walkableClimb, *heightfield, *compact)) {
+    SetError(error, "Failed to build compact navigation heightfield");
+    return false;
+  }
+
+  if (!rcErodeWalkableArea(&context, config.walkableRadius, *compact)) {
+    SetError(error, "Failed to erode walkable navigation area");
+    return false;
+  }
+  if (!rcBuildDistanceField(&context, *compact)) {
+    SetError(error, "Failed to build navigation distance field");
+    return false;
+  }
+  if (!rcBuildRegions(&context, *compact, 0, config.minRegionArea, config.mergeRegionArea)) {
+    SetError(error, "Failed to build navigation regions");
+    return false;
+  }
+
+  ContourSetPtr contours(rcAllocContourSet());
+  if (!contours || !rcBuildContours(&context, *compact, config.maxSimplificationError, config.maxEdgeLen, *contours)) {
+    SetError(error, "Failed to build navigation contours");
+    return false;
+  }
+
+  PolyMeshPtr polyMesh(rcAllocPolyMesh());
+  if (!polyMesh || !rcBuildPolyMesh(&context, *contours, config.maxVertsPerPoly, *polyMesh)) {
+    SetError(error, "Failed to build navigation polygon mesh");
+    return false;
+  }
+
+  PolyMeshDetailPtr detailMesh(rcAllocPolyMeshDetail());
+  if (!detailMesh || !rcBuildPolyMeshDetail(&context, *polyMesh, *compact,
+                                            config.detailSampleDist, config.detailSampleMaxError, *detailMesh)) {
+    SetError(error, "Failed to build navigation detail mesh");
+    return false;
+  }
+
+  if (polyMesh->npolys <= 0) {
+    SetError(error, "Navigation build produced no polygons");
+    return false;
+  }
+
+  for (int i = 0; i < polyMesh->npolys; ++i) {
+    if (polyMesh->areas[i] == RC_WALKABLE_AREA) {
+      polyMesh->areas[i] = 0;
+    }
+    polyMesh->flags[i] = kNavPolyFlagWalk;
+  }
+
+  dtNavMeshCreateParams params;
+  std::memset(&params, 0, sizeof(params));
+  params.verts = polyMesh->verts;
+  params.vertCount = polyMesh->nverts;
+  params.polys = polyMesh->polys;
+  params.polyAreas = polyMesh->areas;
+  params.polyFlags = polyMesh->flags;
+  params.polyCount = polyMesh->npolys;
+  params.nvp = polyMesh->nvp;
+  params.detailMeshes = detailMesh->meshes;
+  params.detailVerts = detailMesh->verts;
+  params.detailVertsCount = detailMesh->nverts;
+  params.detailTris = detailMesh->tris;
+  params.detailTriCount = detailMesh->ntris;
+  params.walkableHeight = settings.agentHeight;
+  params.walkableRadius = settings.agentRadius;
+  params.walkableClimb = settings.agentMaxClimb;
+  rcVcopy(params.bmin, polyMesh->bmin);
+  rcVcopy(params.bmax, polyMesh->bmax);
+  params.cs = config.cs;
+  params.ch = config.ch;
+  params.buildBvTree = true;
+
+  unsigned char* navData = nullptr;
+  int navDataSize = 0;
+  if (!dtCreateNavMeshData(&params, &navData, &navDataSize) || !navData || navDataSize <= 0) {
+    SetError(error, "Failed to create Detour navmesh data");
+    return false;
+  }
+
+  std::unique_ptr<dtNavMesh, NavMeshDeleter> navMesh(dtAllocNavMesh());
+  if (!navMesh) {
+    dtFree(navData);
+    SetError(error, "Failed to allocate Detour navmesh");
+    return false;
+  }
+  dtStatus status = navMesh->init(navData, navDataSize, DT_TILE_FREE_DATA);
+  if (dtStatusFailed(status)) {
+    dtFree(navData);
+    SetError(error, "Failed to initialize Detour navmesh");
+    return false;
+  }
+
+  std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> query(dtAllocNavMeshQuery());
+  if (!query) {
+    SetError(error, "Failed to allocate Detour navmesh query");
+    return false;
+  }
+  status = query->init(navMesh.get(), 2048);
+  if (dtStatusFailed(status)) {
+    SetError(error, "Failed to initialize Detour navmesh query");
+    return false;
+  }
+
+  m_stats.vertexCount = static_cast<int>(geometry.vertices.size());
+  m_stats.triangleCount = triangleCount;
+  m_stats.width = config.width;
+  m_stats.height = config.height;
+  m_stats.polygonCount = polyMesh->npolys;
+  m_stats.detailTriangleCount = detailMesh->ntris;
+  m_impl->navMesh = std::move(navMesh);
+  m_impl->query = std::move(query);
+
+  T8_LOG_INFO("[Navigation] Built navmesh: verts=%d tris=%d grid=%dx%d polys=%d detailTris=%d",
+              m_stats.vertexCount, m_stats.triangleCount, m_stats.width, m_stats.height,
+              m_stats.polygonCount, m_stats.detailTriangleCount);
+  return true;
+#endif
+}
+
+bool NavMesh::FindPath(const XVECTOR3& start,
+                       const XVECTOR3& end,
+                       std::vector<XVECTOR3>& outPath,
+                       std::string* error) const {
+  outPath.clear();
+#if !defined(T850_ENABLE_RECAST)
+  SetError(error, "RecastNavigation is not enabled in this build");
+  return false;
+#else
+  if (!IsReady()) {
+    SetError(error, "Navigation mesh is not ready");
+    return false;
+  }
+
+  const float startPos[3] = { start.x, start.y, start.z };
+  const float endPos[3] = { end.x, end.y, end.z };
+  const float extents[3] = { m_impl->settings.queryExtents.x, m_impl->settings.queryExtents.y, m_impl->settings.queryExtents.z };
+
+  dtQueryFilter filter;
+  filter.setIncludeFlags(kNavPolyFlagWalk);
+  filter.setExcludeFlags(0);
+
+  dtPolyRef startRef = 0;
+  dtPolyRef endRef = 0;
+  float nearestStart[3] = {};
+  float nearestEnd[3] = {};
+  dtStatus status = m_impl->query->findNearestPoly(startPos, extents, &filter, &startRef, nearestStart);
+  if (dtStatusFailed(status) || !startRef) {
+    SetError(error, "Failed to find nearest start nav polygon");
+    return false;
+  }
+  status = m_impl->query->findNearestPoly(endPos, extents, &filter, &endRef, nearestEnd);
+  if (dtStatusFailed(status) || !endRef) {
+    SetError(error, "Failed to find nearest end nav polygon");
+    return false;
+  }
+
+  dtPolyRef pathPolys[kMaxPathPolys] = {};
+  int pathPolyCount = 0;
+  status = m_impl->query->findPath(startRef, endRef, nearestStart, nearestEnd,
+                                   &filter, pathPolys, &pathPolyCount, kMaxPathPolys);
+  if (dtStatusFailed(status) || pathPolyCount <= 0) {
+    SetError(error, "Detour failed to find a path");
+    return false;
+  }
+
+  float straightPath[kMaxStraightPath * 3] = {};
+  unsigned char straightFlags[kMaxStraightPath] = {};
+  dtPolyRef straightPolys[kMaxStraightPath] = {};
+  int straightPathCount = 0;
+  status = m_impl->query->findStraightPath(nearestStart, nearestEnd,
+                                           pathPolys, pathPolyCount,
+                                           straightPath, straightFlags, straightPolys,
+                                           &straightPathCount, kMaxStraightPath);
+  if (dtStatusFailed(status) || straightPathCount <= 0) {
+    SetError(error, "Detour failed to straighten path");
+    return false;
+  }
+
+  outPath.reserve(static_cast<std::size_t>(straightPathCount));
+  for (int i = 0; i < straightPathCount; ++i) {
+    const float* p = &straightPath[i * 3];
+    outPath.emplace_back(p[0], p[1], p[2], 1.0f);
+  }
+  return true;
+#endif
+}
+
+bool NavMesh::ProjectPoint(const XVECTOR3& point,
+                           XVECTOR3& outPoint,
+                           const XVECTOR3& queryExtents,
+                           std::string* error) const {
+#if !defined(T850_ENABLE_RECAST)
+  if (error) *error = "RecastNavigation is not enabled in this build";
+  outPoint = point;
+  return false;
+#else
+  outPoint = point;
+  if (!IsReady()) {
+    if (error) *error = "Navigation mesh is not ready";
+    return false;
+  }
+  if (!IsFiniteVec3(point)) {
+    if (error) *error = "Navigation projection point is not finite";
+    return false;
+  }
+
+  const float position[3] = { point.x, point.y, point.z };
+  const float extents[3] = {
+    queryExtents.x > 0.0f ? queryExtents.x : m_impl->settings.queryExtents.x,
+    queryExtents.y > 0.0f ? queryExtents.y : m_impl->settings.queryExtents.y,
+    queryExtents.z > 0.0f ? queryExtents.z : m_impl->settings.queryExtents.z
+  };
+
+  dtQueryFilter filter;
+  filter.setIncludeFlags(kNavPolyFlagWalk);
+  filter.setExcludeFlags(0);
+
+  dtPolyRef nearestRef = 0;
+  float nearestPoint[3] = {};
+  const dtStatus status = m_impl->query->findNearestPoly(position, extents, &filter, &nearestRef, nearestPoint);
+  if (dtStatusFailed(status) || !nearestRef) {
+    if (error) *error = "Failed to project point onto nearest nav polygon";
+    return false;
+  }
+
+  outPoint = XVECTOR3(nearestPoint[0], nearestPoint[1], nearestPoint[2], 1.0f);
+  return true;
+#endif
+}
+
+NavPathResult NavMesh::FindPath(const NavPathRequest& request) const {
+#if !defined(T850_ENABLE_RECAST)
+  NavPathResult result;
+  result.error = "RecastNavigation is not enabled in this build";
+  SetError(nullptr, result.error);
+  return result;
+#else
+  if (!IsReady()) {
+    NavPathResult result;
+    result.error = "Navigation mesh is not ready";
+    SetError(nullptr, result.error);
+    return result;
+  }
+
+  NavPathResult result = FindPathWithQuery(m_impl->query.get(), m_impl->settings, request);
+  if (!result.success && !result.error.empty()) {
+    SetError(nullptr, result.error);
+  }
+  return result;
+#endif
+}
+
+void NavMesh::FindPaths(const std::vector<NavPathRequest>& requests,
+                        std::vector<NavPathResult>& outResults) const {
+  outResults.clear();
+  outResults.resize(requests.size());
+  if (requests.empty()) {
+    return;
+  }
+
+#if !defined(T850_ENABLE_RECAST)
+  for (NavPathResult& result : outResults) {
+    result.error = "RecastNavigation is not enabled in this build";
+  }
+  SetError(nullptr, "RecastNavigation is not enabled in this build");
+  return;
+#else
+  if (!IsReady()) {
+    for (NavPathResult& result : outResults) {
+      result.error = "Navigation mesh is not ready";
+    }
+    SetError(nullptr, "Navigation mesh is not ready");
+    return;
+  }
+
+  auto runRequest = [&](int requestIndex) {
+    std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> query(dtAllocNavMeshQuery());
+    if (!query) {
+      outResults[static_cast<std::size_t>(requestIndex)].error = "Failed to allocate Detour navmesh query";
+      return;
+    }
+
+    dtStatus status = query->init(m_impl->navMesh.get(), 2048);
+    if (dtStatusFailed(status)) {
+      outResults[static_cast<std::size_t>(requestIndex)].error = "Failed to initialize Detour navmesh query";
+      return;
+    }
+
+    outResults[static_cast<std::size_t>(requestIndex)] =
+        FindPathWithQuery(query.get(), m_impl->settings, requests[static_cast<std::size_t>(requestIndex)]);
+  };
+
+  if (g_threadPool &&
+      requests.size() > 1 &&
+      g_threadPool->NumWorkers() > 0 &&
+      !g_threadPool->IsWorkerThread()) {
+    g_threadPool->ParallelForHeavy(0, static_cast<int>(requests.size()), runRequest);
+  } else {
+    for (int i = 0; i < static_cast<int>(requests.size()); ++i) {
+      runRequest(i);
+    }
+  }
+#endif
+}
+
+bool NavMesh::GetDebugWireframe(std::vector<XVECTOR3>& outVertices,
+                                std::vector<unsigned int>& outIndices,
+                                float verticalOffset) const {
+  outVertices.clear();
+  outIndices.clear();
+#if !defined(T850_ENABLE_RECAST)
+  return false;
+#else
+  if (!IsReady()) {
+    return false;
+  }
+
+  const dtNavMesh* detourMesh = m_impl->navMesh.get();
+  const int maxTiles = detourMesh ? detourMesh->getMaxTiles() : 0;
+  for (int tileIndex = 0; tileIndex < maxTiles; ++tileIndex) {
+    const dtMeshTile* tile = detourMesh->getTile(tileIndex);
+    if (!tile || !tile->header || !tile->verts || !tile->polys) {
+      continue;
+    }
+
+    for (int polyIndex = 0; polyIndex < tile->header->polyCount; ++polyIndex) {
+      const dtPoly& poly = tile->polys[polyIndex];
+      if (poly.getType() == DT_POLYTYPE_OFFMESH_CONNECTION || poly.vertCount < 2) {
+        continue;
+      }
+
+      auto appendEdge = [&](const float* v0, const float* v1) {
+        const unsigned int base = static_cast<unsigned int>(outVertices.size());
+        outVertices.emplace_back(v0[0], v0[1] + verticalOffset, v0[2], 1.0f);
+        outVertices.emplace_back(v1[0], v1[1] + verticalOffset, v1[2], 1.0f);
+        outIndices.push_back(base);
+        outIndices.push_back(base + 1);
+      };
+
+      if (tile->detailMeshes && tile->detailTris) {
+        const dtPolyDetail& detail = tile->detailMeshes[polyIndex];
+        auto detailVertex = [&](int localIndex) -> const float* {
+          if (localIndex < static_cast<int>(poly.vertCount)) {
+            const unsigned short polyVertexIndex = poly.verts[localIndex];
+            if (polyVertexIndex < tile->header->vertCount) {
+              return &tile->verts[polyVertexIndex * 3];
+            }
+            return nullptr;
+          }
+
+          const int detailVertexIndex = detail.vertBase + localIndex - static_cast<int>(poly.vertCount);
+          if (detailVertexIndex >= 0 && detailVertexIndex < tile->header->detailVertCount) {
+            return &tile->detailVerts[detailVertexIndex * 3];
+          }
+          return nullptr;
+        };
+
+        for (unsigned int detailTriIndex = 0; detailTriIndex < detail.triCount; ++detailTriIndex) {
+          const unsigned char* tri = &tile->detailTris[(detail.triBase + detailTriIndex) * 4];
+          const float* v0 = detailVertex(tri[0]);
+          const float* v1 = detailVertex(tri[1]);
+          const float* v2 = detailVertex(tri[2]);
+          if (!v0 || !v1 || !v2) {
+            continue;
+          }
+          appendEdge(v0, v1);
+          appendEdge(v1, v2);
+          appendEdge(v2, v0);
+        }
+        continue;
+      }
+
+      for (unsigned char edgeIndex = 0; edgeIndex < poly.vertCount; ++edgeIndex) {
+        const unsigned short v0Index = poly.verts[edgeIndex];
+        const unsigned short v1Index = poly.verts[(edgeIndex + 1) % poly.vertCount];
+        if (v0Index >= tile->header->vertCount || v1Index >= tile->header->vertCount) {
+          continue;
+        }
+
+        const float* v0 = &tile->verts[v0Index * 3];
+        const float* v1 = &tile->verts[v1Index * 3];
+        appendEdge(v0, v1);
+      }
+    }
+  }
+
+  return !outVertices.empty() && !outIndices.empty();
+#endif
+}
+
+bool NavMesh::GetDebugNodeMarkers(std::vector<XVECTOR3>& outVertices,
+                                  std::vector<unsigned int>& outIndices,
+                                  float verticalOffset) const {
+  outVertices.clear();
+  outIndices.clear();
+#if !defined(T850_ENABLE_RECAST)
+  return false;
+#else
+  if (!IsReady()) {
+    return false;
+  }
+
+  const dtNavMesh* detourMesh = m_impl->navMesh.get();
+  const int maxTiles = detourMesh ? detourMesh->getMaxTiles() : 0;
+  const float nodeMarkerSize = (std::max)(0.10f, m_impl->settings.agentRadius * 0.25f);
+  for (int tileIndex = 0; tileIndex < maxTiles; ++tileIndex) {
+    const dtMeshTile* tile = detourMesh->getTile(tileIndex);
+    if (!tile || !tile->header || !tile->verts || !tile->polys) {
+      continue;
+    }
+
+    for (int polyIndex = 0; polyIndex < tile->header->polyCount; ++polyIndex) {
+      const dtPoly& poly = tile->polys[polyIndex];
+      if (poly.getType() == DT_POLYTYPE_OFFMESH_CONNECTION || poly.vertCount < 2) {
+        continue;
+      }
+
+      auto appendMarkerLine = [&](const XVECTOR3& a, const XVECTOR3& b) {
+        const unsigned int base = static_cast<unsigned int>(outVertices.size());
+        outVertices.push_back(a);
+        outVertices.push_back(b);
+        outIndices.push_back(base);
+        outIndices.push_back(base + 1);
+      };
+
+      XVECTOR3 center(0.0f, 0.0f, 0.0f, 1.0f);
+      int validVertices = 0;
+      for (unsigned char vertexIndex = 0; vertexIndex < poly.vertCount; ++vertexIndex) {
+        const unsigned short polyVertexIndex = poly.verts[vertexIndex];
+        if (polyVertexIndex >= tile->header->vertCount) {
+          continue;
+        }
+        const float* v = &tile->verts[polyVertexIndex * 3];
+        center.x += v[0];
+        center.y += v[1];
+        center.z += v[2];
+        ++validVertices;
+      }
+      if (validVertices <= 0) {
+        continue;
+      }
+      const float invVertCount = 1.0f / static_cast<float>(validVertices);
+      center.x *= invVertCount;
+      center.y = center.y * invVertCount + verticalOffset;
+      center.z *= invVertCount;
+      appendMarkerLine(XVECTOR3(center.x - nodeMarkerSize, center.y, center.z, 1.0f),
+                       XVECTOR3(center.x + nodeMarkerSize, center.y, center.z, 1.0f));
+      appendMarkerLine(XVECTOR3(center.x, center.y, center.z - nodeMarkerSize, 1.0f),
+                       XVECTOR3(center.x, center.y, center.z + nodeMarkerSize, 1.0f));
+
+    }
+  }
+
+  return !outVertices.empty() && !outIndices.empty();
+#endif
+}
+
+bool NavMesh::GetDebugGraphEdges(std::vector<XVECTOR3>& outVertices,
+                                 std::vector<unsigned int>& outIndices,
+                                 float verticalOffset) const {
+  outVertices.clear();
+  outIndices.clear();
+#if !defined(T850_ENABLE_RECAST)
+  return false;
+#else
+  if (!IsReady()) {
+    return false;
+  }
+
+  const dtNavMesh* detourMesh = m_impl->navMesh.get();
+  const int maxTiles = detourMesh ? detourMesh->getMaxTiles() : 0;
+  for (int tileIndex = 0; tileIndex < maxTiles; ++tileIndex) {
+    const dtMeshTile* tile = detourMesh->getTile(tileIndex);
+    if (!tile || !tile->header || !tile->verts || !tile->polys) {
+      continue;
+    }
+
+    std::vector<XVECTOR3> centers(static_cast<std::size_t>(tile->header->polyCount));
+    std::vector<unsigned char> centerValid(static_cast<std::size_t>(tile->header->polyCount), 0);
+    for (int polyIndex = 0; polyIndex < tile->header->polyCount; ++polyIndex) {
+      const dtPoly& poly = tile->polys[polyIndex];
+      if (poly.getType() == DT_POLYTYPE_OFFMESH_CONNECTION || poly.vertCount < 2) {
+        continue;
+      }
+
+      XVECTOR3 center(0.0f, 0.0f, 0.0f, 1.0f);
+      int validVertices = 0;
+      for (unsigned char vertexIndex = 0; vertexIndex < poly.vertCount; ++vertexIndex) {
+        const unsigned short polyVertexIndex = poly.verts[vertexIndex];
+        if (polyVertexIndex >= tile->header->vertCount) {
+          continue;
+        }
+        const float* v = &tile->verts[polyVertexIndex * 3];
+        center.x += v[0];
+        center.y += v[1];
+        center.z += v[2];
+        ++validVertices;
+      }
+      if (validVertices <= 0) {
+        continue;
+      }
+
+      const float invVertexCount = 1.0f / static_cast<float>(validVertices);
+      center.x *= invVertexCount;
+      center.y = center.y * invVertexCount + verticalOffset;
+      center.z *= invVertexCount;
+      centers[static_cast<std::size_t>(polyIndex)] = center;
+      centerValid[static_cast<std::size_t>(polyIndex)] = 1;
+    }
+
+    auto appendGraphEdge = [&](const XVECTOR3& a, const XVECTOR3& b) {
+      const unsigned int base = static_cast<unsigned int>(outVertices.size());
+      outVertices.push_back(a);
+      outVertices.push_back(b);
+      outIndices.push_back(base);
+      outIndices.push_back(base + 1);
+    };
+
+    for (int polyIndex = 0; polyIndex < tile->header->polyCount; ++polyIndex) {
+      if (!centerValid[static_cast<std::size_t>(polyIndex)]) {
+        continue;
+      }
+      const dtPoly& poly = tile->polys[polyIndex];
+      for (unsigned char edgeIndex = 0; edgeIndex < poly.vertCount; ++edgeIndex) {
+        const unsigned short neighbor = poly.neis[edgeIndex];
+        if (!neighbor || (neighbor & DT_EXT_LINK)) {
+          continue;
+        }
+
+        const int neighborPolyIndex = static_cast<int>(neighbor & ~DT_EXT_LINK) - 1;
+        if (neighborPolyIndex <= polyIndex ||
+            neighborPolyIndex < 0 ||
+            neighborPolyIndex >= tile->header->polyCount ||
+            !centerValid[static_cast<std::size_t>(neighborPolyIndex)]) {
+          continue;
+        }
+        appendGraphEdge(centers[static_cast<std::size_t>(polyIndex)],
+                        centers[static_cast<std::size_t>(neighborPolyIndex)]);
+      }
+    }
+  }
+
+  return !outVertices.empty() && !outIndices.empty();
+#endif
+}
+
+void NavigationWorld::ClearSources() {
+  m_sources.clear();
+  m_lastSourceStats = NavSourceBuildStats{};
+  m_navMesh.Clear();
+  m_dirty = true;
+}
+
+void NavigationWorld::RegisterSource(const NavSourceInstance& source) {
+  auto existing = std::find_if(m_sources.begin(), m_sources.end(),
+      [&](const NavSourceInstance& item) { return item.entityId == source.entityId && source.entityId != 0; });
+  if (existing != m_sources.end()) {
+    *existing = source;
+  } else {
+    m_sources.push_back(source);
+  }
+  m_dirty = true;
+}
+
+bool NavigationWorld::UnregisterSource(unsigned int entityId) {
+  const auto oldSize = m_sources.size();
+  m_sources.erase(std::remove_if(m_sources.begin(), m_sources.end(),
+      [&](const NavSourceInstance& source) { return source.entityId == entityId; }), m_sources.end());
+  if (m_sources.size() == oldSize) {
+    return false;
+  }
+  m_dirty = true;
+  return true;
+}
+
+bool NavigationWorld::UpdateSourceTransform(unsigned int entityId, const XMATRIX44& worldTransform) {
+  auto existing = std::find_if(m_sources.begin(), m_sources.end(),
+      [&](const NavSourceInstance& source) { return source.entityId == entityId; });
+  if (existing == m_sources.end()) {
+    return false;
+  }
+  existing->worldTransform = worldTransform;
+  m_dirty = true;
+  return true;
+}
+
+void NavigationWorld::SetBuildSettings(const NavMeshBuildSettings& settings) {
+  m_settings = settings;
+  m_dirty = true;
+}
+
+bool NavigationWorld::Rebuild(std::string* error) {
+  NavMeshGeometry geometry;
+  m_lastSourceStats = NavSourceBuildStats{};
+
+  for (const NavSourceInstance& source : m_sources) {
+    ++m_lastSourceStats.considered;
+    if (!source.includeInNavigation || !source.visible || !source.navigationStatic) {
+      ++m_lastSourceStats.skippedInvisible;
+      continue;
+    }
+
+    const xF::XDataBase* database = source.database;
+    XMATRIX44 worldTransform = source.worldTransform;
+
+    if (source.instance) {
+      if (!source.instance->Visible || !source.instance->pBase) {
+        ++m_lastSourceStats.skippedInvisible;
+        continue;
+      }
+      if (source.instance->GetSkinnedMesh()) {
+        ++m_lastSourceStats.skippedSkinned;
+        continue;
+      }
+
+      const RenderMesh* mesh = dynamic_cast<const RenderMesh*>(source.instance->pBase);
+      if (!mesh || !mesh->xFile) {
+        ++m_lastSourceStats.skippedInvalid;
+        continue;
+      }
+      database = mesh->xFile;
+      worldTransform = source.instance->Final;
+    }
+
+    if (!database) {
+      ++m_lastSourceStats.skippedInvalid;
+      continue;
+    }
+
+    const std::size_t indicesBefore = geometry.indices.size();
+    std::string sourceError;
+    if (!AppendGeometryFromXDataBase(*database, worldTransform, geometry, &sourceError) ||
+        geometry.indices.size() == indicesBefore) {
+      ++m_lastSourceStats.skippedInvalid;
+      continue;
+    }
+    ++m_lastSourceStats.included;
+  }
+
+  if (geometry.vertices.empty() || geometry.indices.size() < 3) {
+    SetError(error, "NavigationWorld sources produced no navigation geometry");
+    m_navMesh.Clear();
+    m_dirty = true;
+    return false;
+  }
+
+  m_lastSourceStats.vertexCount = static_cast<int>(geometry.vertices.size());
+  m_lastSourceStats.triangleCount = static_cast<int>(geometry.indices.size() / 3);
+  if (!m_navMesh.Build(geometry, m_settings, error)) {
+    m_dirty = true;
+    return false;
+  }
+
+  m_dirty = false;
+  return true;
+}
+
+} // namespace navigation
+} // namespace t850

--- a/T850/Framework/src/scene/LineRenderer.cpp
+++ b/T850/Framework/src/scene/LineRenderer.cpp
@@ -132,7 +132,7 @@ void LineRenderer::DrawLines(const XMATRIX44& world,
     (m_viewW > 0) ? 1.0f / (float)m_viewW : 1.0f / 1280.0f,
     (m_viewH > 0) ? 1.0f / (float)m_viewH : 1.0f / 720.0f,
     m_farPlane,
-    0.005f);  // proportional depth bias (wireDepth *= 1 - bias)
+    m_depthBias);
 
   ib->Set(*T8DeviceContext, 0, ibFormat);
   vb->Set(*T8DeviceContext, vertexStride, 0);
@@ -143,6 +143,11 @@ void LineRenderer::DrawLines(const XMATRIX44& world,
   shader->Set(*T8DeviceContext);
   m_cb->UpdateFromBuffer(*T8DeviceContext, &cb);
   m_cb->Set(*T8DeviceContext);
+#if defined(USING_VULKAN) || defined(USING_VULKAN_ONLY)
+  // Android offline SPIR-V can auto-map VS/FS cbuffers to different bindings
+  // when the fragment shader also samples depth. Populate both logical slots.
+  m_cb->Set(*T8DeviceContext, 1);
+#endif
 
   // Bind depth texture AFTER shader is set (D3D12 needs active root signature)
   if (m_depthTest && m_depthTex)

--- a/T850/Framework/src/video/vulkan/VulkanRT.cpp
+++ b/T850/Framework/src/video/vulkan/VulkanRT.cpp
@@ -165,7 +165,7 @@ namespace t850 {
       depthTex->x = (unsigned int)w;
       depthTex->y = (unsigned int)h;
       depthTex->m_channels = 1;
-      depthTex->params = CLAMP_TO_BORDER;
+      depthTex->params = CLAMP_TO_BORDER | NEAREST_FILTER;
       depthTex->SetTextureParams();
       pDepthTexture = depthTex;
     }

--- a/T850/T8ditor/T8ditor.vcxproj
+++ b/T850/T8ditor/T8ditor.vcxproj
@@ -157,7 +157,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\debug\lib;$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imguid.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imguid.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;Recast-d.lib;Detour-d.lib;DetourCrowd-d.lib;DetourTileCache-d.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Link>
     <PostBuildEvent>
@@ -191,7 +191,7 @@ call "$(SolutionDir)scripts\CopyFirstExisting.cmd" "$(OutDir)" "$(T8VcpkgDynamic
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\debug\lib;$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imguid.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imguid.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;Recast-d.lib;Detour-d.lib;DetourCrowd-d.lib;DetourTileCache-d.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Link>
     <PostBuildEvent>
@@ -225,7 +225,7 @@ call "$(SolutionDir)scripts\CopyFirstExisting.cmd" "$(OutDir)" "$(T8VcpkgDynamic
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\debug\lib;$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imguid.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Frameworkd.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imguid.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;Recast-d.lib;Detour-d.lib;DetourCrowd-d.lib;DetourTileCache-d.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslangd.lib;SPIRVd.lib;glslang-default-resource-limitsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Link>
     <PostBuildEvent>
@@ -260,7 +260,7 @@ call "$(SolutionDir)scripts\CopyFirstExisting.cmd" "$(OutDir)" "$(T8VcpkgDynamic
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imgui.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imgui.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;Recast.lib;Detour.lib;DetourCrowd.lib;DetourTileCache.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
@@ -298,7 +298,7 @@ call "$(SolutionDir)scripts\CopyFirstExisting.cmd" "$(OutDir)" "$(T8VcpkgDynamic
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imgui.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imgui.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;Recast.lib;Detour.lib;DetourCrowd.lib;DetourTileCache.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
@@ -336,7 +336,7 @@ call "$(SolutionDir)scripts\CopyFirstExisting.cmd" "$(OutDir)" "$(T8VcpkgDynamic
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)Librerias\tinyxml2\lib;$(SolutionDir)Lib\$(Configuration)\$(Platform)\;$(SolutionDir)$(Configuration);$(SolutionDir)Librerias\SDL3\lib\$(T8Arch);$(T8VcpkgStatic)\lib;$(T8VcpkgDynamic)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imgui.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;Framework.lib;SDL3.lib;D3D11.lib;D3DCompiler.lib;imgui.lib;imguizmo.lib;vulkan-1.lib;Jolt.lib;Recast.lib;Detour.lib;DetourCrowd.lib;DetourTileCache.lib;$(T8VcpkgDynamic)\lib\draco.lib;glslang.lib;SPIRV.lib;glslang-default-resource-limits.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>

--- a/T850/cmake/AndroidBuild.cmake
+++ b/T850/cmake/AndroidBuild.cmake
@@ -20,9 +20,11 @@ list(APPEND CMAKE_PREFIX_PATH ${T850_ANDROID_VCPKG_ROOT})
 set(glslang_DIR ${T850_ANDROID_VCPKG_ROOT}/share/glslang)
 set(imgui_DIR ${T850_ANDROID_VCPKG_ROOT}/share/imgui)
 set(Jolt_DIR ${T850_ANDROID_VCPKG_ROOT}/share/Jolt)
+set(recastnavigation_DIR ${T850_ANDROID_VCPKG_ROOT}/share/recastnavigation)
 find_package(imgui CONFIG REQUIRED)
 find_package(glslang CONFIG REQUIRED)
 find_package(Jolt CONFIG REQUIRED)
+find_package(recastnavigation CONFIG REQUIRED)
 function(t850_map_android_imported_release_config)
   foreach(T850_IMPORTED_TARGET IN LISTS ARGN)
     if(TARGET ${T850_IMPORTED_TARGET})
@@ -37,7 +39,11 @@ t850_map_android_imported_release_config(
   glslang::glslang
   glslang::glslang-default-resource-limits
   glslang::SPIRV
-  Jolt::Jolt)
+  Jolt::Jolt
+  RecastNavigation::Recast
+  RecastNavigation::Detour
+  RecastNavigation::DetourCrowd
+  RecastNavigation::DetourTileCache)
 message(STATUS "T850 Android ABI: ${ANDROID_ABI} (${T850_ANDROID_VCPKG_TRIPLET})")
 
 set(T850_ANDROID_API_LEVEL 0)
@@ -77,6 +83,8 @@ set(T850_ANDROID_FRAMEWORK_SOURCES
   ${T850_SOURCE_DIR}/Framework/src/physics/PhysicsDebugRenderer.cpp
   ${T850_SOURCE_DIR}/Framework/src/physics/Q3BspCollision.cpp
   ${T850_SOURCE_DIR}/Framework/src/physics/PhysicsAuthoring.cpp
+  ${T850_SOURCE_DIR}/Framework/src/navigation/NavigationSystem.cpp
+  ${T850_SOURCE_DIR}/Framework/src/navigation/NavigationDebugRenderer.cpp
   ${T850_SOURCE_DIR}/Framework/src/utils/AndroidAssets.cpp
   ${T850_SOURCE_DIR}/Framework/src/utils/Log.cpp
   ${T850_SOURCE_DIR}/Framework/src/utils/InputManager.cpp
@@ -169,6 +177,7 @@ target_compile_definitions(T850Android PRIVATE
   T850_ANDROID_NATIVE_ACTIVITY
   T850_ENABLE_DRACO=1
   T850_ENABLE_JOLT=1
+  T850_ENABLE_RECAST=1
   VMA_STATIC_VULKAN_FUNCTIONS=0
   VMA_DYNAMIC_VULKAN_FUNCTIONS=1)
 if(T850_VULKAN_VALIDATION)
@@ -198,6 +207,10 @@ target_link_libraries(T850Android PRIVATE
   vulkan
   "${T850_ANDROID_DRACO_LIB}"
   Jolt::Jolt
+  RecastNavigation::Recast
+  RecastNavigation::Detour
+  RecastNavigation::DetourCrowd
+  RecastNavigation::DetourTileCache
   imgui::imgui
   glslang::glslang
   glslang::glslang-default-resource-limits

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This directory documents the current engine architecture. Paths are relative to 
 | [Framework](framework.md) | Application lifecycle, core interfaces, platform hosts, services, and ownership. |
 | [Graphics layer](graphics-layer.md) | Driver abstraction, render graph, API backends, shaders, resources, frame pacing, and debugging hooks. |
 | [Scene, meshes, and physics](scene-meshes-physics.md) | Scene file formats, mesh loading, material/asset flow, Jolt physics, collision, and ragdoll synchronization. |
+| [Navigation architecture](navigation-architecture.md) | Recast/Detour wrapper design, scene mesh sources, path queries, source updates, and debug visualization. |
 
 ## High-level map
 

--- a/docs/navigation-architecture.md
+++ b/docs/navigation-architecture.md
@@ -1,0 +1,220 @@
+# Navigation architecture
+
+This document describes the planned Framework navigation layer, how it relates to Recast/Detour, render meshes, scene entities, and how path search and source updates should work.
+
+## Goals
+
+- Keep game and scene code independent from raw Recast/Detour types.
+- Build navmesh data from logical scene mesh instances, not only raw geometry.
+- Preserve a Detour-backed path query implementation for `FindPath`.
+- Allow later dynamic source updates, source removal, and full or partial rebuilds.
+- Keep debug rendering separate from query/build logic.
+
+## Main classes
+
+| Class / struct | Layer | Responsibility |
+| --- | --- | --- |
+| `NavMeshGeometry` | Framework navigation data | Raw triangle soup: world-space vertices and triangle indices used by Recast. |
+| `NavSourceInstance` | Framework navigation source | Logical source entity for navmesh building. Carries entity id, mesh database, optional `PrimitiveInst`, world transform, visibility, and nav flags. |
+| `NavSourceBuildStats` | Framework navigation source | Reports how many runtime instances were considered, included, skipped as invisible, skipped as skinned/dynamic, or skipped as invalid. |
+| `NavMeshBuildSettings` | Framework navigation config | Recast build parameters: cell size/height, agent dimensions, max climb/slope, region settings, and query extents. |
+| `NavMeshBuildStats` | Framework navigation result | Build output counters: input vertices/triangles, Recast grid size, polygon count, detail triangle count. |
+| `NavPathRequest` | Framework navigation query | Engine-facing path query input: start, end, and query extents. |
+| `NavPathResult` | Framework navigation query | Engine-facing path query output: success flag, path points, and error string. |
+| `INavigationMesh` | Framework interface | Common path-query interface. Scene/game code can query this without knowing Detour types. |
+| `NavMesh` | Recast/Detour backend wrapper | Owns Detour `dtNavMesh` and `dtNavMeshQuery`, hides Detour from callers, and implements `INavigationMesh`. |
+| `NavigationWorld` | Scene navigation owner | Owns logical nav sources and a built `NavMesh`. Supports register, remove, update, rebuild, and query operations. |
+| `NavMeshDebugRenderer` | Debug rendering | Converts built navmesh data into debug line buffers. Does not own or mutate the navmesh. |
+
+## Relationship to existing scene/render objects
+
+`PrimitiveInst` is the runtime logical entity for a renderable mesh instance. It already has:
+
+- `EntityId`
+- visibility
+- world transform (`Final`)
+- render primitive pointer (`pBase`)
+- physics/ragdoll handles
+
+Navigation should treat `PrimitiveInst` as the default source of truth for static mesh contributions. `RenderMesh` and `xF::XDataBase` provide the triangle data, but the entity instance provides the transform, visibility, ownership, and future metadata.
+
+```mermaid
+classDiagram
+  class SandboxScene {
+    PrimitiveInst Meshes[]
+    NavigationWorld navigation
+  }
+  class PrimitiveInst {
+    EntityId
+    Visible
+    Final
+    pBase
+  }
+  class RenderMesh {
+    xFile
+  }
+  class NavSourceInstance {
+    entityId
+    instance
+    database
+    worldTransform
+    includeInNavigation
+    navigationStatic
+  }
+  class NavigationWorld
+  class NavMesh
+  class dtNavMesh
+  class dtNavMeshQuery
+
+  SandboxScene --> PrimitiveInst : owns runtime instances
+  PrimitiveInst --> RenderMesh : pBase for static mesh
+  NavSourceInstance --> PrimitiveInst : optional source pointer
+  NavSourceInstance --> RenderMesh : reads xFile through instance
+  NavigationWorld --> NavSourceInstance : owns source list
+  NavigationWorld --> NavMesh : builds and queries
+  NavMesh --> dtNavMesh : owns
+  NavMesh --> dtNavMeshQuery : owns
+```
+
+## Build flow
+
+Navigation build should start from scene/entity sources:
+
+```mermaid
+flowchart TD
+  A[Scene loads PrimitiveInst objects] --> B[Build NavSourceInstance list]
+  B --> C[NavigationWorld::RegisterSource]
+  C --> D[NavigationWorld::Rebuild]
+  D --> E[Resolve PrimitiveInst -> RenderMesh -> XDataBase]
+  E --> F[AppendGeometryFromXDataBase with instance Final transform]
+  F --> G[NavMesh::Build]
+  G --> H[Recast heightfield / compact field / contours / poly mesh / detail mesh]
+  H --> I[Detour dtNavMesh + dtNavMeshQuery]
+```
+
+The initial implementation can rebuild the whole navmesh when sources change. Later, tile-based incremental rebuild can move into `NavigationWorld` using DetourTileCache.
+
+## Finding a path
+
+Scene/game code should call the interface, not raw Detour:
+
+```cpp
+t850::navigation::NavPathRequest request;
+request.start = playerPosition;
+request.end = targetPosition;
+
+t850::navigation::NavPathResult result = navWorld.FindPath(request);
+if (result.success) {
+  // result.points contains straight-path waypoints in world space.
+}
+```
+
+Internally:
+
+```mermaid
+flowchart TD
+  A[FindPath request] --> B[INavigationMesh::FindPath]
+  B --> C[NavMesh::FindPath]
+  C --> D[dtNavMeshQuery::findNearestPoly start/end]
+  D --> E[dtNavMeshQuery::findPath polygon corridor]
+  E --> F[dtNavMeshQuery::findStraightPath]
+  F --> G[Return world-space points]
+```
+
+## Multithreaded path queries
+
+T850 already has a global engine thread pool (`t850::g_threadPool`) created during framework startup. Navigation batch queries use it by default:
+
+```cpp
+std::vector<t850::navigation::NavPathRequest> requests;
+requests.push_back({bot0Position, targetPosition});
+requests.push_back({bot1Position, targetPosition});
+
+std::vector<t850::navigation::NavPathResult> results;
+navWorld.FindPaths(requests, results); // fans out through the global thread pool
+```
+
+The important Detour threading rule is:
+
+- `dtNavMesh` can be shared read-only after build.
+- `dtNavMeshQuery` must not be shared across threads.
+
+`NavMesh::FindPaths()` follows that rule by creating a separate `dtNavMeshQuery` for each batch item when it runs through the thread pool. That means 8 bots can submit 8 path requests, the pool can process them in parallel, and the caller receives all results after the batch joins.
+
+If `FindPaths()` is called from a thread-pool worker, it falls back to sequential execution to avoid nested blocking work, matching the existing `ThreadPool` contract.
+
+## Updating sources and removing nodes
+
+The system should not expose "remove a Detour polygon" directly to scene code. Scene code removes or updates logical sources. The nav world decides whether to rebuild immediately or mark dirty.
+
+### Add or update a source
+
+```cpp
+NavSourceInstance source;
+source.entityId = instance.GetEntityId();
+source.instance = &instance;
+source.navigationStatic = true;
+source.includeInNavigation = true;
+
+navWorld.RegisterSource(source);
+navWorld.Rebuild();
+```
+
+If the entity id already exists, `RegisterSource` replaces the previous source and marks the world dirty.
+
+### Remove a source
+
+```cpp
+navWorld.UnregisterSource(entityId);
+navWorld.Rebuild();
+```
+
+This removes the logical source from the build set. Current full-rebuild behavior regenerates the Detour mesh without that source.
+
+### Update a transform
+
+For static source movement or editor changes:
+
+```cpp
+navWorld.UpdateSourceTransform(entityId, newWorldTransform);
+navWorld.Rebuild();
+```
+
+If sources still point at live `PrimitiveInst` objects, rebuild can also pull the current `Final` transform directly from each instance.
+
+## Dynamic objects and future tile cache
+
+Initial source rules:
+
+- Include visible static `RenderMesh` instances.
+- Skip `RenderSkinnedMesh` for navmesh source geometry by default.
+- Keep dynamic obstacles out of the base navmesh initially.
+
+Future dynamic support:
+
+- Static world geometry stays in `NavigationWorld` as source geometry.
+- Moving blockers become DetourTileCache obstacles or custom runtime avoidance inputs.
+- Agents use DetourCrowd or a higher-level `INavigationCrowd` interface.
+
+## Debug rendering
+
+`NavMeshDebugRenderer` should visualize built navmesh data without owning it:
+
+- Magenta geometry mode: detail/navmesh wireframe.
+- Magenta nodes mode: node markers at polygon centers.
+- Green graph edges: adjacency links between polygon centers.
+- Offset slider: tiny default lift over the model, adjustable at runtime.
+
+Debug draw should remain controlled by scene UI and should not trigger navmesh rebuild unless the navmesh is missing or marked dirty.
+
+## Why this abstraction matters
+
+Detour is the right backend for navmesh queries, but raw `dtNavMesh` references should not leak into gameplay or scene code. The engine-facing interface should talk in terms of:
+
+- entity ids
+- mesh instances
+- world transforms
+- path requests/results
+- agent settings
+
+This keeps the navigation system portable across Windows and Android, and it leaves room for DetourCrowd, DetourTileCache, editor nav annotations, and non-Detour experiments without rewriting scene code.


### PR DESCRIPTION
## Summary
- integrate Recast/Detour navigation into Windows and Android builds
- add navmesh debug rendering, graph visualization, and scene controls
- add threaded pathfinding and skinned-mesh nav agents with follow-player behavior
- add scene-authored nav agent front yaw offsets for Doom and Rewind Cyborg models

## Validation
- `./scripts/build.ps1 -Config Release -Platform x64`
- validated `Assets/Scenes/Q3/q3dm6_mod_3.t8scene` JSON