### PR TITLE
Integrate Q3 navigation, Android rendering, and editor fixes

### DIFF
--- a/T850/Assets/Scenes/Q3/q3dm6_mod_3.t8scene
+++ b/T850/Assets/Scenes/Q3/q3dm6_mod_3.t8scene
@@ -3,14 +3,14 @@
    "collision": "Scenes/Q3/q3dm6.t8q3clip",
    "editor": {
       "camera_target": {
-         "x": -34.10334,
-         "y": 10.842996,
-         "z": 6.820883
+         "x": 6.5882893,
+         "y": 0.27237678,
+         "z": -17.15108
       },
-      "camera_yaw": 4.4899774,
-      "camera_pitch": 0.20500012,
-      "camera_distance": 0.6654993,
-      "show_skybox": true,
+      "camera_yaw": 0.16999967,
+      "camera_pitch": 0.1550003,
+      "camera_distance": 8.027201,
+      "show_skybox": false,
       "show_wireframe": false
    },
    "objects": [
@@ -48,13 +48,13 @@
          },
          "rotation": {
             "x": -179.99924,
-            "y": -61.339775,
+            "y": -61.33975,
             "z": -179.99089
          },
          "scale": {
-            "x": 0.0006204003,
-            "y": 0.0006203996,
-            "z": 0.0006204003
+            "x": 0.00032571016,
+            "y": 0.0003257098,
+            "z": 0.00032571016
          },
          "visible": true,
          "frozen": false,
@@ -77,9 +77,9 @@
             "z": -179.99089
          },
          "scale": {
-            "x": 0.0006204003,
-            "y": 0.0006203996,
-            "z": 0.0006204003
+            "x": 0.0003257102,
+            "y": 0.0003257098,
+            "z": 0.0003257102
          },
          "visible": true,
          "frozen": false,
@@ -228,7 +228,7 @@
          "intensity": 5,
          "radius": 5.59017,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -263,7 +263,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -298,7 +298,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -333,7 +333,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -368,7 +368,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -403,7 +403,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -438,7 +438,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -473,7 +473,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -508,7 +508,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -543,7 +543,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -578,7 +578,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -613,7 +613,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -648,7 +648,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -683,7 +683,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -718,7 +718,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -753,7 +753,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -788,7 +788,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -823,7 +823,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -858,7 +858,7 @@
          "intensity": 0.4,
          "radius": 1.581139,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -893,7 +893,7 @@
          "intensity": 0.4,
          "radius": 1.581139,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -928,7 +928,7 @@
          "intensity": 0.4,
          "radius": 1.581139,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -963,7 +963,7 @@
          "intensity": 0.4,
          "radius": 1.581139,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -998,7 +998,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1033,7 +1033,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1068,7 +1068,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1103,7 +1103,7 @@
          "intensity": 3,
          "radius": 4.330127,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1138,7 +1138,7 @@
          "intensity": 3,
          "radius": 4.330127,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1173,7 +1173,7 @@
          "intensity": 3,
          "radius": 4.330127,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1208,7 +1208,7 @@
          "intensity": 0.1,
          "radius": 0.790569,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1243,7 +1243,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1278,7 +1278,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1313,7 +1313,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1348,7 +1348,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1383,7 +1383,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1418,7 +1418,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1453,7 +1453,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1488,7 +1488,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1523,7 +1523,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1558,7 +1558,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1593,7 +1593,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1628,7 +1628,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1663,7 +1663,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1698,7 +1698,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1733,7 +1733,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1768,7 +1768,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1803,7 +1803,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1838,7 +1838,7 @@
          "intensity": 0.6,
          "radius": 1.936492,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1873,7 +1873,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1908,7 +1908,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1943,7 +1943,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -1978,7 +1978,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2013,7 +2013,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2048,7 +2048,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2083,7 +2083,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2118,7 +2118,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2153,7 +2153,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2188,7 +2188,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2223,7 +2223,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2258,7 +2258,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2293,7 +2293,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2328,7 +2328,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2363,7 +2363,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2398,7 +2398,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2433,7 +2433,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2468,7 +2468,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2503,7 +2503,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2538,7 +2538,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2573,7 +2573,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2608,7 +2608,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2643,7 +2643,7 @@
          "intensity": 0.5,
          "radius": 1.767767,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2678,7 +2678,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2713,7 +2713,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2748,7 +2748,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2783,7 +2783,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2818,7 +2818,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2853,7 +2853,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2888,7 +2888,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2923,7 +2923,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2958,7 +2958,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -2993,7 +2993,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3028,7 +3028,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3063,7 +3063,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3098,7 +3098,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3133,7 +3133,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3168,7 +3168,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3203,7 +3203,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3238,7 +3238,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3273,7 +3273,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3308,7 +3308,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3343,7 +3343,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3378,7 +3378,7 @@
          "intensity": 0.3,
          "radius": 185.7183,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3413,7 +3413,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3448,7 +3448,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3483,7 +3483,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3518,7 +3518,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3553,7 +3553,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3588,7 +3588,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3623,7 +3623,7 @@
          "intensity": 0.4,
          "radius": 1.581139,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3658,7 +3658,7 @@
          "intensity": 0.4,
          "radius": 1.581139,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3693,7 +3693,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3728,7 +3728,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3763,7 +3763,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3798,7 +3798,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3833,7 +3833,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3868,7 +3868,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3903,7 +3903,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3938,7 +3938,7 @@
          "intensity": 0.3,
          "radius": 1.369306,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -3973,7 +3973,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -4008,7 +4008,7 @@
          "intensity": 0.35,
          "radius": 1.47902,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -4043,7 +4043,7 @@
          "intensity": 1.5,
          "radius": 3.061862,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -4078,7 +4078,7 @@
          "intensity": 0.2,
          "radius": 1.118034,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -4113,7 +4113,7 @@
          "intensity": 5,
          "radius": 5.59017,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -4148,7 +4148,7 @@
          "intensity": 5,
          "radius": 5.59017,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false,
          "q3": {
             "source": "bsp_entity_lump",
@@ -4183,7 +4183,7 @@
          "intensity": 2,
          "radius": 6.5,
          "enabled": true,
-         "visible": true,
+         "visible": false,
          "frozen": false
       }
    ],
@@ -4277,6 +4277,10 @@
                "value": 92
             },
             {
+               "name": "cubemap",
+               "value": 3
+            },
+            {
                "name": "luminance_mode",
                "value": 1
             }
@@ -4298,30 +4302,31 @@
                "anim_mode": 0
             }
          ],
+         "cubemap_path": "sky/GraceCathedral.dds",
          "camera": {
             "profile": 5,
             "eye": [
-               3.6418679,
+               6.050058,
                1.6571285,
-               -7.339037
+               -2.3202047
             ],
             "look": [
-               0.32910568,
-               -0.1593183,
-               -0.9307562
+               0.14688289,
+               -0.17902964,
+               -0.9728175
             ],
             "up": [
-               0.05311093,
-               0.98722726,
-               -0.15020502
+               0.02672822,
+               0.9838437,
+               -0.1770232
             ],
             "right": [
-               -0.9427983,
+               -0.9887927,
                0,
-               -0.33336365
+               -0.14929494
             ],
-            "yaw": 40.500835,
-            "pitch": 0.16000009,
+            "yaw": 40.69085,
+            "pitch": 0.18000007,
             "roll": 0,
             "fov": 95,
             "aspect_ratio": 1.7777778,
@@ -4343,9 +4348,9 @@
                   0
                ],
                "eye": [
-                  3.6418679,
+                  6.050058,
                   1.6571285,
-                  -7.339037
+                  -2.3202047
                ],
                "yaw": -1.5757964,
                "pitch": -0.005,
@@ -4364,9 +4369,9 @@
                0
             ],
             "eye": [
-               3.6418679,
+               6.050058,
                1.6571285,
-               -7.339037
+               -2.3202047
             ],
             "yaw": -1.5757964,
             "pitch": -0.005,

--- a/T850/Assets/Scenes/Q3/q3dm6_mod_3.t8scene
+++ b/T850/Assets/Scenes/Q3/q3dm6_mod_3.t8scene
@@ -59,7 +59,8 @@
          "visible": true,
          "frozen": false,
          "show_wire": false,
-         "nav_agent_front_yaw_offset_deg": 270
+         "nav_agent_front_yaw_offset_deg": 270,
+         "nav_agent_face_yaw_sign": -1
       },
       {
          "name": "Models/doomslayer_cine_all_animations_no-damage_double-sided-opaque.glb Clone",
@@ -83,7 +84,8 @@
          "visible": true,
          "frozen": false,
          "show_wire": false,
-         "nav_agent_front_yaw_offset_deg": 270
+         "nav_agent_front_yaw_offset_deg": 270,
+         "nav_agent_face_yaw_sign": -1
       },
       {
          "name": "Models\\rewind_cyborg.glb",
@@ -96,7 +98,7 @@
          },
          "rotation": {
             "x": 0,
-            "y": -0,
+            "y": 0,
             "z": 0
          },
          "scale": {
@@ -120,7 +122,7 @@
          },
          "rotation": {
             "x": 0,
-            "y": -0,
+            "y": 0,
             "z": 0
          },
          "scale": {
@@ -144,7 +146,7 @@
          },
          "rotation": {
             "x": 0,
-            "y": -0,
+            "y": 0,
             "z": 0
          },
          "scale": {
@@ -168,7 +170,7 @@
          },
          "rotation": {
             "x": 0,
-            "y": -0,
+            "y": 0,
             "z": 0
          },
          "scale": {
@@ -4200,11 +4202,11 @@
             },
             {
                "name": "bloom_factor",
-               "value": 1
+               "value": 0.823
             },
             {
                "name": "bloom_threshold",
-               "value": 1
+               "value": 1.5
             },
             {
                "name": "ssao_kernel_size",
@@ -4215,24 +4217,40 @@
                "value": 2.237
             },
             {
+               "name": "fov",
+               "value": 95
+            },
+            {
                "name": "light_intensity_scale",
                "value": 2
             },
             {
                "name": "lightmap_intensity",
-               "value": 2
+               "value": 2.5
             },
             {
                "name": "shadow_min",
                "value": 0
             },
             {
+               "name": "ibl_factor",
+               "value": 1.3
+            },
+            {
                "name": "material_emissive_intensity",
-               "value": 2
+               "value": 0.734
+            },
+            {
+               "name": "material_transmission_multiplier",
+               "value": 3.481
+            },
+            {
+               "name": "nav_agent_speed_multiplier",
+               "value": 4
             },
             {
                "name": "gauss_1_radius",
-               "value": 1.177
+               "value": 1
             },
             {
                "name": "gauss_1_sigma",
@@ -4245,7 +4263,7 @@
                "value": false
             },
             {
-               "name": "debug_luminance",
+               "name": "point_lights_enabled",
                "value": false
             }
          ],
@@ -4255,16 +4273,8 @@
                "value": 27
             },
             {
-               "name": "animation_model",
-               "value": 2
-            },
-            {
                "name": "anim_select",
-               "value": 82
-            },
-            {
-               "name": "cubemap",
-               "value": 3
+               "value": 92
             },
             {
                "name": "luminance_mode",
@@ -4272,32 +4282,48 @@
             }
          ],
          "lights": [],
+         "animations": [
+            {
+               "index": 1,
+               "mesh": "Models/doomslayer_cine_all_animations_no-damage_double-sided-opaque.glb",
+               "anim_speed": 1,
+               "anim_select": 92,
+               "anim_mode": 0
+            },
+            {
+               "index": 2,
+               "mesh": "Models/doomslayer_cine_all_animations_no-damage_double-sided-opaque.glb",
+               "anim_speed": 1,
+               "anim_select": 92,
+               "anim_mode": 0
+            }
+         ],
          "camera": {
             "profile": 5,
             "eye": [
-               -19.226711,
-               9.683158,
-               0.71661586
+               3.6418679,
+               1.6571285,
+               -7.339037
             ],
             "look": [
-               -0.862305,
-               -0.23284249,
-               0.44968265
+               0.32910568,
+               -0.1593183,
+               -0.9307562
             ],
             "up": [
-               -0.20645581,
-               0.9725145,
-               0.10766445
+               0.05311093,
+               0.98722726,
+               -0.15020502
             ],
             "right": [
-               0.46239173,
+               -0.9427983,
                0,
-               0.8866758
+               -0.33336365
             ],
-            "yaw": 30.32582,
-            "pitch": 0.2349995,
+            "yaw": 40.500835,
+            "pitch": 0.16000009,
             "roll": 0,
-            "fov": 99.99999,
+            "fov": 95,
             "aspect_ratio": 1.7777778,
             "near_plane": 0.125,
             "far_plane": 6198.7783,
@@ -4317,9 +4343,9 @@
                   0
                ],
                "eye": [
-                  -19.226711,
-                  9.683158,
-                  0.71661586
+                  3.6418679,
+                  1.6571285,
+                  -7.339037
                ],
                "yaw": -1.5757964,
                "pitch": -0.005,
@@ -4338,9 +4364,9 @@
                0
             ],
             "eye": [
-               -19.226711,
-               9.683158,
-               0.71661586
+               3.6418679,
+               1.6571285,
+               -7.339037
             ],
             "yaw": -1.5757964,
             "pitch": -0.005,
@@ -4361,11 +4387,11 @@
             },
             {
                "name": "bloom_factor",
-               "value": 1
+               "value": 0.823
             },
             {
                "name": "bloom_threshold",
-               "value": 1
+               "value": 1.5
             },
             {
                "name": "ssao_kernel_size",
@@ -4376,24 +4402,40 @@
                "value": 2.237
             },
             {
+               "name": "fov",
+               "value": 95
+            },
+            {
                "name": "light_intensity_scale",
-               "value": 16.256
+               "value": 2
             },
             {
                "name": "lightmap_intensity",
-               "value": 2
+               "value": 2.5
             },
             {
                "name": "shadow_min",
                "value": 0
             },
             {
+               "name": "ibl_factor",
+               "value": 1.3
+            },
+            {
                "name": "material_emissive_intensity",
+               "value": 0.734
+            },
+            {
+               "name": "material_transmission_multiplier",
+               "value": 3.481
+            },
+            {
+               "name": "nav_agent_speed_multiplier",
                "value": 2
             },
             {
                "name": "gauss_1_radius",
-               "value": 1.177
+               "value": 1
             },
             {
                "name": "gauss_1_sigma",
@@ -4408,10 +4450,6 @@
             {
                "name": "point_lights_enabled",
                "value": false
-            },
-            {
-               "name": "debug_luminance",
-               "value": false
             }
          ],
          "selectors": [
@@ -4420,12 +4458,8 @@
                "value": 27
             },
             {
-               "name": "animation_model",
-               "value": 2
-            },
-            {
                "name": "anim_select",
-               "value": 82
+               "value": 92
             },
             {
                "name": "cubemap",
@@ -4437,38 +4471,55 @@
             }
          ],
          "lights": [],
+         "animations": [
+            {
+               "index": 1,
+               "mesh": "Models/doomslayer_cine_all_animations_no-damage_double-sided-opaque.glb",
+               "anim_speed": 1,
+               "anim_select": 92,
+               "anim_mode": 0
+            },
+            {
+               "index": 2,
+               "mesh": "Models/doomslayer_cine_all_animations_no-damage_double-sided-opaque.glb",
+               "anim_speed": 1,
+               "anim_select": 92,
+               "anim_mode": 0
+            }
+         ],
+         "cubemap_path": "sky/GraceCathedral.dds",
          "camera": {
             "profile": 5,
             "eye": [
-               -19.500628,
-               9.683158,
-               9.753779
+               3.6418679,
+               1.6571285,
+               -7.339037
             ],
             "look": [
-               -0.6847219,
-               -0.22337587,
-               0.69372845
+               0.32910568,
+               -0.1593183,
+               -0.9307562
             ],
             "up": [
-               -0.15691522,
-               0.9747324,
-               0.15897922
+               0.05311093,
+               0.98722726,
+               -0.15020502
             ],
             "right": [
-               0.7117117,
+               -0.9427983,
                0,
-               0.7024717
+               -0.33336365
             ],
-            "yaw": 30.637062,
-            "pitch": 0.22527649,
+            "yaw": 40.500835,
+            "pitch": 0.16000009,
             "roll": 0,
-            "fov": 99.99999,
-            "aspect_ratio": 1.6017317,
+            "fov": 95,
+            "aspect_ratio": 1.7777778,
             "near_plane": 0.125,
             "far_plane": 6198.7783,
             "ortho": false,
-            "width": 2960,
-            "height": 1848,
+            "width": 2560,
+            "height": 1440,
             "left_handed": true,
             "orbit": {
                "target": [
@@ -4482,9 +4533,9 @@
                   0
                ],
                "eye": [
-                  -19.500628,
-                  9.683158,
-                  9.753779
+                  3.6418679,
+                  1.6571285,
+                  -7.339037
                ],
                "yaw": -1.5757964,
                "pitch": -0.005,
@@ -4503,9 +4554,9 @@
                0
             ],
             "eye": [
-               -19.500628,
-               9.683158,
-               9.753779
+               3.6418679,
+               1.6571285,
+               -7.339037
             ],
             "yaw": -1.5757964,
             "pitch": -0.005,
@@ -4526,11 +4577,11 @@
             },
             {
                "name": "bloom_factor",
-               "value": 1
+               "value": 0.823
             },
             {
                "name": "bloom_threshold",
-               "value": 1
+               "value": 1.5
             },
             {
                "name": "ssao_kernel_size",
@@ -4541,24 +4592,40 @@
                "value": 2.237
             },
             {
+               "name": "fov",
+               "value": 95
+            },
+            {
                "name": "light_intensity_scale",
-               "value": 16.256
+               "value": 2
             },
             {
                "name": "lightmap_intensity",
-               "value": 2
+               "value": 2.5
             },
             {
                "name": "shadow_min",
                "value": 0
             },
             {
+               "name": "ibl_factor",
+               "value": 1.3
+            },
+            {
                "name": "material_emissive_intensity",
+               "value": 0.734
+            },
+            {
+               "name": "material_transmission_multiplier",
+               "value": 3.481
+            },
+            {
+               "name": "nav_agent_speed_multiplier",
                "value": 2
             },
             {
                "name": "gauss_1_radius",
-               "value": 1.177
+               "value": 1
             },
             {
                "name": "gauss_1_sigma",
@@ -4573,10 +4640,6 @@
             {
                "name": "point_lights_enabled",
                "value": false
-            },
-            {
-               "name": "debug_luminance",
-               "value": false
             }
          ],
          "selectors": [
@@ -4585,12 +4648,8 @@
                "value": 27
             },
             {
-               "name": "animation_model",
-               "value": 2
-            },
-            {
                "name": "anim_select",
-               "value": 82
+               "value": 92
             },
             {
                "name": "cubemap",
@@ -4602,38 +4661,55 @@
             }
          ],
          "lights": [],
+         "animations": [
+            {
+               "index": 1,
+               "mesh": "Models/doomslayer_cine_all_animations_no-damage_double-sided-opaque.glb",
+               "anim_speed": 1,
+               "anim_select": 92,
+               "anim_mode": 0
+            },
+            {
+               "index": 2,
+               "mesh": "Models/doomslayer_cine_all_animations_no-damage_double-sided-opaque.glb",
+               "anim_speed": 1,
+               "anim_select": 92,
+               "anim_mode": 0
+            }
+         ],
+         "cubemap_path": "sky/GraceCathedral.dds",
          "camera": {
             "profile": 5,
             "eye": [
-               -19.500628,
-               9.683158,
-               9.753779
+               3.6418679,
+               1.6571285,
+               -7.339037
             ],
             "look": [
-               -0.6847219,
-               -0.22337587,
-               0.69372845
+               0.32910568,
+               -0.1593183,
+               -0.9307562
             ],
             "up": [
-               -0.15691522,
-               0.9747324,
-               0.15897922
+               0.05311093,
+               0.98722726,
+               -0.15020502
             ],
             "right": [
-               0.7117117,
+               -0.9427983,
                0,
-               0.7024717
+               -0.33336365
             ],
-            "yaw": 30.637062,
-            "pitch": 0.22527649,
+            "yaw": 40.500835,
+            "pitch": 0.16000009,
             "roll": 0,
-            "fov": 99.99999,
-            "aspect_ratio": 1.6017317,
+            "fov": 95,
+            "aspect_ratio": 1.7777778,
             "near_plane": 0.125,
             "far_plane": 6198.7783,
             "ortho": false,
-            "width": 2960,
-            "height": 1848,
+            "width": 2560,
+            "height": 1440,
             "left_handed": true,
             "orbit": {
                "target": [
@@ -4647,9 +4723,9 @@
                   0
                ],
                "eye": [
-                  -19.500628,
-                  9.683158,
-                  9.753779
+                  3.6418679,
+                  1.6571285,
+                  -7.339037
                ],
                "yaw": -1.5757964,
                "pitch": -0.005,
@@ -4668,9 +4744,9 @@
                0
             ],
             "eye": [
-               -19.500628,
-               9.683158,
-               9.753779
+               3.6418679,
+               1.6571285,
+               -7.339037
             ],
             "yaw": -1.5757964,
             "pitch": -0.005,
@@ -4691,11 +4767,11 @@
             },
             {
                "name": "bloom_factor",
-               "value": 1
+               "value": 0.823
             },
             {
                "name": "bloom_threshold",
-               "value": 1
+               "value": 1.5
             },
             {
                "name": "ssao_kernel_size",
@@ -4706,24 +4782,40 @@
                "value": 2.237
             },
             {
+               "name": "fov",
+               "value": 95
+            },
+            {
                "name": "light_intensity_scale",
-               "value": 16.256
+               "value": 2
             },
             {
                "name": "lightmap_intensity",
-               "value": 2
+               "value": 2.5
             },
             {
                "name": "shadow_min",
                "value": 0
             },
             {
+               "name": "ibl_factor",
+               "value": 1.3
+            },
+            {
                "name": "material_emissive_intensity",
+               "value": 0.734
+            },
+            {
+               "name": "material_transmission_multiplier",
+               "value": 3.481
+            },
+            {
+               "name": "nav_agent_speed_multiplier",
                "value": 2
             },
             {
                "name": "gauss_1_radius",
-               "value": 1.177
+               "value": 1
             },
             {
                "name": "gauss_1_sigma",
@@ -4738,10 +4830,6 @@
             {
                "name": "point_lights_enabled",
                "value": false
-            },
-            {
-               "name": "debug_luminance",
-               "value": false
             }
          ],
          "selectors": [
@@ -4750,12 +4838,8 @@
                "value": 27
             },
             {
-               "name": "animation_model",
-               "value": 2
-            },
-            {
                "name": "anim_select",
-               "value": 82
+               "value": 92
             },
             {
                "name": "cubemap",
@@ -4767,38 +4851,55 @@
             }
          ],
          "lights": [],
+         "animations": [
+            {
+               "index": 1,
+               "mesh": "Models/doomslayer_cine_all_animations_no-damage_double-sided-opaque.glb",
+               "anim_speed": 1,
+               "anim_select": 92,
+               "anim_mode": 0
+            },
+            {
+               "index": 2,
+               "mesh": "Models/doomslayer_cine_all_animations_no-damage_double-sided-opaque.glb",
+               "anim_speed": 1,
+               "anim_select": 92,
+               "anim_mode": 0
+            }
+         ],
+         "cubemap_path": "sky/GraceCathedral.dds",
          "camera": {
             "profile": 5,
             "eye": [
-               -19.500628,
-               9.683158,
-               9.753779
+               3.6418679,
+               1.6571285,
+               -7.339037
             ],
             "look": [
-               -0.6847219,
-               -0.22337587,
-               0.69372845
+               0.32910568,
+               -0.1593183,
+               -0.9307562
             ],
             "up": [
-               -0.15691522,
-               0.9747324,
-               0.15897922
+               0.05311093,
+               0.98722726,
+               -0.15020502
             ],
             "right": [
-               0.7117117,
+               -0.9427983,
                0,
-               0.7024717
+               -0.33336365
             ],
-            "yaw": 30.637062,
-            "pitch": 0.22527649,
+            "yaw": 40.500835,
+            "pitch": 0.16000009,
             "roll": 0,
-            "fov": 99.99999,
-            "aspect_ratio": 1.6017317,
+            "fov": 95,
+            "aspect_ratio": 1.7777778,
             "near_plane": 0.125,
             "far_plane": 6198.7783,
             "ortho": false,
-            "width": 2960,
-            "height": 1848,
+            "width": 2560,
+            "height": 1440,
             "left_handed": true,
             "orbit": {
                "target": [
@@ -4812,9 +4913,9 @@
                   0
                ],
                "eye": [
-                  -19.500628,
-                  9.683158,
-                  9.753779
+                  3.6418679,
+                  1.6571285,
+                  -7.339037
                ],
                "yaw": -1.5757964,
                "pitch": -0.005,
@@ -4833,9 +4934,9 @@
                0
             ],
             "eye": [
-               -19.500628,
-               9.683158,
-               9.753779
+               3.6418679,
+               1.6571285,
+               -7.339037
             ],
             "yaw": -1.5757964,
             "pitch": -0.005,

--- a/T850/Assets/Shaders/shader_permutations.json
+++ b/T850/Assets/Shaders/shader_permutations.json
@@ -1792,6 +1792,246 @@
       "vertexShader": "VS_Mesh.hlsl",
       "fragmentShader": "FS_Mesh.hlsl",
       "defines": ["DIFFUSE_MAP", "EMISSIVE_MAP", "GLTF_TANGENT_SPACE", "METALLIC_MAP", "NORMAL_MAP", "RADIAL_DEPTH_PASS", "REFLECT_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1", "USE_TEXCOORD2", "USE_TEXCOORD3"]
+    },
+    "0x000002000800003F": {
+      "key": "0x000002000800003F",
+      "bits": "0x000002000800003F",
+      "pass": 0,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000800013F": {
+      "key": "0x000002000800013F",
+      "bits": "0x000002000800013F",
+      "pass": 0,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000800023F": {
+      "key": "0x000002000800023F",
+      "bits": "0x000002000800023F",
+      "pass": 0,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000800033F": {
+      "key": "0x000002000800033F",
+      "bits": "0x000002000800033F",
+      "pass": 0,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000800093F": {
+      "key": "0x000002000800093F",
+      "bits": "0x000002000800093F",
+      "pass": 0,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "METALLIC_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x0000020008000B3F": {
+      "key": "0x0000020008000B3F",
+      "bits": "0x0000020008000B3F",
+      "pass": 0,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "METALLIC_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000810003F": {
+      "key": "0x000002000810003F",
+      "bits": "0x000002000810003F",
+      "pass": 1,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000810013F": {
+      "key": "0x000002000810013F",
+      "bits": "0x000002000810013F",
+      "pass": 1,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000810023F": {
+      "key": "0x000002000810023F",
+      "bits": "0x000002000810023F",
+      "pass": 1,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000810033F": {
+      "key": "0x000002000810033F",
+      "bits": "0x000002000810033F",
+      "pass": 1,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000810093F": {
+      "key": "0x000002000810093F",
+      "bits": "0x000002000810093F",
+      "pass": 1,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "METALLIC_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x0000020008100B3F": {
+      "key": "0x0000020008100B3F",
+      "bits": "0x0000020008100B3F",
+      "pass": 1,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "METALLIC_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000820003F": {
+      "key": "0x000002000820003F",
+      "bits": "0x000002000820003F",
+      "pass": 2,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "G_BUFFER_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000820013F": {
+      "key": "0x000002000820013F",
+      "bits": "0x000002000820013F",
+      "pass": 2,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "G_BUFFER_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000820023F": {
+      "key": "0x000002000820023F",
+      "bits": "0x000002000820023F",
+      "pass": 2,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "G_BUFFER_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000820033F": {
+      "key": "0x000002000820033F",
+      "bits": "0x000002000820033F",
+      "pass": 2,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "G_BUFFER_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000820093F": {
+      "key": "0x000002000820093F",
+      "bits": "0x000002000820093F",
+      "pass": 2,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "METALLIC_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "G_BUFFER_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x0000020008200B3F": {
+      "key": "0x0000020008200B3F",
+      "bits": "0x0000020008200B3F",
+      "pass": 2,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "METALLIC_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "G_BUFFER_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000830003F": {
+      "key": "0x000002000830003F",
+      "bits": "0x000002000830003F",
+      "pass": 3,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "SHADOW_MAP_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000830013F": {
+      "key": "0x000002000830013F",
+      "bits": "0x000002000830013F",
+      "pass": 3,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "SHADOW_MAP_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000830023F": {
+      "key": "0x000002000830023F",
+      "bits": "0x000002000830023F",
+      "pass": 3,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "SHADOW_MAP_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000830033F": {
+      "key": "0x000002000830033F",
+      "bits": "0x000002000830033F",
+      "pass": 3,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "SHADOW_MAP_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x000002000830093F": {
+      "key": "0x000002000830093F",
+      "bits": "0x000002000830093F",
+      "pass": 3,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "METALLIC_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "SHADOW_MAP_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x0000020008300B3F": {
+      "key": "0x0000020008300B3F",
+      "bits": "0x0000020008300B3F",
+      "pass": 3,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "METALLIC_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "SHADOW_MAP_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x0000020009A0003F": {
+      "key": "0x0000020009A0003F",
+      "bits": "0x0000020009A0003F",
+      "pass": 26,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "RADIAL_DEPTH_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x0000020009A0013F": {
+      "key": "0x0000020009A0013F",
+      "bits": "0x0000020009A0013F",
+      "pass": 26,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "RADIAL_DEPTH_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x0000020009A0023F": {
+      "key": "0x0000020009A0023F",
+      "bits": "0x0000020009A0023F",
+      "pass": 26,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "RADIAL_DEPTH_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x0000020009A0033F": {
+      "key": "0x0000020009A0033F",
+      "bits": "0x0000020009A0033F",
+      "pass": 26,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "RADIAL_DEPTH_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x0000020009A0093F": {
+      "key": "0x0000020009A0093F",
+      "bits": "0x0000020009A0093F",
+      "pass": 26,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "METALLIC_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "RADIAL_DEPTH_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
+    },
+    "0x0000020009A00B3F": {
+      "key": "0x0000020009A00B3F",
+      "bits": "0x0000020009A00B3F",
+      "pass": 26,
+      "vertexShader": "VS_Mesh.hlsl",
+      "fragmentShader": "FS_Mesh.hlsl",
+      "defines": ["DIFFUSE_MAP", "NORMAL_MAP", "EMISSIVE_MAP", "REFLECT_MAP", "METALLIC_MAP", "GLTF_TANGENT_SPACE", "LIGHTMAP_MAP", "RADIAL_DEPTH_PASS", "USE_BINORMALS", "USE_NORMALS", "USE_TANGENTS", "USE_TEXCOORD0", "USE_TEXCOORD1"]
     }
   }
 }

--- a/T850/DayScene/Application.cpp
+++ b/T850/DayScene/Application.cpp
@@ -87,6 +87,22 @@ namespace {
   };
 
 #ifdef OS_WINDOWS
+  uint64_t StoreVkDescriptorSet(VkDescriptorSet descriptor) {
+#if defined(VK_USE_64_BIT_PTR_DEFINES) && VK_USE_64_BIT_PTR_DEFINES
+    return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(descriptor));
+#else
+    return static_cast<uint64_t>(descriptor);
+#endif
+  }
+
+  VkDescriptorSet LoadVkDescriptorSet(uint64_t descriptor) {
+#if defined(VK_USE_64_BIT_PTR_DEFINES) && VK_USE_64_BIT_PTR_DEFINES
+    return reinterpret_cast<VkDescriptorSet>(static_cast<uintptr_t>(descriptor));
+#else
+    return static_cast<VkDescriptorSet>(descriptor);
+#endif
+  }
+
   bool IsSingleChannelFormat(DXGI_FORMAT format) {
     switch (format) {
     case DXGI_FORMAT_R8_UNORM:
@@ -112,8 +128,8 @@ namespace {
 #endif
 
   ImTextureID GetDebugTextureID(t850::BaseDriver* driver, t850::Texture* texture,
-                                std::unordered_map<void*, uintptr_t>& textureDescriptors,
-                                std::unordered_map<void*, uintptr_t>& opaqueTextureDescriptors) {
+                                std::unordered_map<void*, uint64_t>& textureDescriptors,
+                                std::unordered_map<void*, uint64_t>& opaqueTextureDescriptors) {
     if (!driver || !texture) return (ImTextureID)nullptr;
 
 #ifdef OS_WINDOWS
@@ -159,7 +175,7 @@ namespace {
       }
 
       device->CreateShaderResourceView(d3dTexture->pTexResource.Get(), &srvDesc, srvCPU);
-      opaqueTextureDescriptors[texture] = srvGPU.ptr;
+      opaqueTextureDescriptors[texture] = static_cast<uint64_t>(srvGPU.ptr);
       return (ImTextureID)srvGPU.ptr;
     }
 #endif
@@ -182,7 +198,7 @@ namespace {
         vkTexture->m_sampler,
         vkTexture->m_imageView,
         VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-      textureDescriptors[texture] = (uintptr_t)descriptor;
+      textureDescriptors[texture] = StoreVkDescriptorSet(descriptor);
       return (ImTextureID)descriptor;
     }
 #endif
@@ -211,8 +227,8 @@ namespace {
   }
 
   std::vector<DebugRTEntry> BuildDebugRTEntries(t850::BaseDriver* driver,
-                                                std::unordered_map<void*, uintptr_t>& textureDescriptors,
-                                                std::unordered_map<void*, uintptr_t>& opaqueTextureDescriptors) {
+                                                std::unordered_map<void*, uint64_t>& textureDescriptors,
+                                                std::unordered_map<void*, uint64_t>& opaqueTextureDescriptors) {
     std::vector<DebugRTEntry> entries;
     if (!driver) return entries;
 
@@ -250,8 +266,8 @@ namespace {
 
   void PruneDebugTextureDescriptors(t850::BaseDriver* driver,
                                     const std::vector<DebugRTEntry>& entries,
-                                    std::unordered_map<void*, uintptr_t>& textureDescriptors,
-                                    std::unordered_map<void*, uintptr_t>& opaqueTextureDescriptors) {
+                                    std::unordered_map<void*, uint64_t>& textureDescriptors,
+                                    std::unordered_map<void*, uint64_t>& opaqueTextureDescriptors) {
     if (!driver) return;
 
     std::unordered_set<void*> liveTextures;
@@ -263,7 +279,7 @@ namespace {
       for (auto it = textureDescriptors.begin(); it != textureDescriptors.end();) {
         if (liveTextures.find(it->first) == liveTextures.end()) {
 #ifdef OS_WINDOWS
-          ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)it->second);
+          ImGui_ImplVulkan_RemoveTexture(LoadVkDescriptorSet(it->second));
 #endif
           it = textureDescriptors.erase(it);
         } else {
@@ -283,11 +299,11 @@ namespace {
     }
   }
 
-  void ReleaseDebugTextureDescriptors(std::unordered_map<void*, uintptr_t>& textureDescriptors,
-                                      std::unordered_map<void*, uintptr_t>& opaqueTextureDescriptors) {
+  void ReleaseDebugTextureDescriptors(std::unordered_map<void*, uint64_t>& textureDescriptors,
+                                      std::unordered_map<void*, uint64_t>& opaqueTextureDescriptors) {
 #ifdef OS_WINDOWS
     for (auto& entry : textureDescriptors) {
-      ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)entry.second);
+      ImGui_ImplVulkan_RemoveTexture(LoadVkDescriptorSet(entry.second));
     }
 #endif
     textureDescriptors.clear();
@@ -643,38 +659,48 @@ void App::OnUpdate() {
    static uint64_t telemetryFrameIndex = 0;
    t850::RuntimeTelemetry::BeginFrame(telemetryFrameIndex++, DtSecs);
    {
-     T8_TELEMETRY_SCOPE("frame.update");
-     static float timeAccum = 0;
-     timeAccum += DtSecs;
+    T8_TELEMETRY_SCOPE("frame.total");
+    {
+      T8_TELEMETRY_SCOPE("frame.update");
+      static float timeAccum = 0;
+      timeAccum += DtSecs;
 
-     if (timeAccum > 1.0) {
-       m_fpsString = "FPS " + std::to_string((int)(1.0 / DtSecs));
-       m_fpsCol = XVECTOR3(0.2, 0.8, 0.2);
-       timeAccum = 0;
-     }
+      if (timeAccum > 1.0) {
+        T8_TELEMETRY_SCOPE("frame.fps_text_update");
+        m_fpsString = "FPS " + std::to_string((int)(1.0 / DtSecs));
+        m_fpsCol = XVECTOR3(0.2, 0.8, 0.2);
+        timeAccum = 0;
+      }
 
 #ifndef OS_ANDROID
-     {
-       T8_TELEMETRY_SCOPE("scene.update");
-       m_devLayer.Update(DtSecs);
-     }
+      HandleRuntimeGuiToggle("update");
+      if (m_imguiVisible && m_actualScene) {
+        IManager.xDelta = 0;
+        IManager.yDelta = 0;
+        m_actualScene->ResetViewInput();
+      }
+      {
+        T8_TELEMETRY_SCOPE("scene.update");
+        m_devLayer.Update(DtSecs);
+      }
 #else
-    if (m_actualScene && !bPaused) {
-      T8_TELEMETRY_SCOPE("scene.update");
-      m_actualScene->OnUpdate(DtSecs);
-    }
+      if (m_actualScene && !bPaused) {
+        T8_TELEMETRY_SCOPE("scene.update");
+        m_actualScene->OnUpdate(DtSecs);
+      }
 #endif
-     if (t850::GetEngineContext().physics && t850::GetEngineContext().physics->IsInitialized()) {
-       T8_TELEMETRY_SCOPE("physics.update");
-       t850::GetEngineContext().physics->Update(DtSecs);
-     }
+      if (t850::GetEngineContext().physics && t850::GetEngineContext().physics->IsInitialized()) {
+        T8_TELEMETRY_SCOPE("physics.update");
+        t850::GetEngineContext().physics->Update(DtSecs);
+      }
 
-     {
-       T8_TELEMETRY_SCOPE("input.update");
-       OnInput();
-     }
+      {
+        T8_TELEMETRY_SCOPE("input.update");
+        OnInput();
+      }
+    }
+    OnDraw();
    }
-   OnDraw();
    t850::RuntimeTelemetry::EndFrame();
 }
 
@@ -736,13 +762,46 @@ void App::OnDraw() {
   // Skip presenting the first frame (black with only text)
   if (frameCount > 1) {
     T8_LOG_TRACE("[Frame %d] === SwapBuffers ===" , frameCount);
-    pFramework->pVideoDriver->SwapBuffers();
+    {
+      T8_TELEMETRY_SCOPE("frame.swap_buffers");
+      pFramework->pVideoDriver->SwapBuffers();
+    }
   } else {
     T8_LOG_TRACE("[Frame %d] === SKIPPED SwapBuffers (first frame) ===" , frameCount);
   }
 }
 
+bool App::HandleRuntimeGuiToggle(const char* phase) {
+#ifdef OS_ANDROID
+  (void)phase;
+  return false;
+#else
+  if (!m_imguiReady) {
+    return false;
+  }
 
+  const bool imguiConsumesKeyboard =
+      m_imguiVisible && (m_imgui.WantsKeyboard() || m_imgui.WantsTextInput());
+  if (imguiConsumesKeyboard || !IManager.PressedOnceKey(T800K_g)) {
+    return false;
+  }
+
+  const bool oldVisible = m_imguiVisible;
+  m_imguiVisible = !m_imguiVisible;
+  IManager.xDelta = 0;
+  IManager.yDelta = 0;
+  if (m_actualScene) {
+    m_actualScene->ResetViewInput();
+  }
+  T8_LOG_VERBOSE("[MouseMode] G toggle phase=%s gui %d->%d mouse=(%d,%d) delta reset",
+                 phase ? phase : "",
+                 oldVisible ? 1 : 0,
+                 m_imguiVisible ? 1 : 0,
+                 IManager.mouseX,
+                 IManager.mouseY);
+  return true;
+#endif
+}
 
 void App::OnInput() {
 	if (FirstFrame)
@@ -750,10 +809,13 @@ void App::OnInput() {
 #ifndef OS_ANDROID
   const bool imguiConsumesKeyboard =
       m_imguiReady && m_imguiVisible && (m_imgui.WantsKeyboard() || m_imgui.WantsTextInput());
-  if (m_imguiReady && !imguiConsumesKeyboard && IManager.PressedOnceKey(T800K_g)) {
-    m_imguiVisible = !m_imguiVisible;
+  const bool guiToggled = HandleRuntimeGuiToggle("input");
+  if (m_imguiVisible && m_actualScene) {
+    IManager.xDelta = 0;
+    IManager.yDelta = 0;
+    m_actualScene->ResetViewInput();
   }
-  m_devLayer.SetSceneInputBlocked(imguiConsumesKeyboard);
+  m_devLayer.SetSceneInputBlocked(guiToggled || m_imguiVisible || imguiConsumesKeyboard);
   m_devLayer.ProcessInput(&IManager);
 #else
   UpdateAndroidGuiHoldToggle();
@@ -796,6 +858,14 @@ bool App::IsModalActive() const {
   return false;
 #else
   return m_imguiVisible && (m_imgui.WantsKeyboard() || m_imgui.WantsTextInput());
+#endif
+}
+
+bool App::WantsRelativeMouseMode() const {
+#ifdef OS_ANDROID
+  return false;
+#else
+  return m_imguiReady && !m_imguiVisible && !IsModalActive();
 #endif
 }
 

--- a/T850/DayScene/Application.h
+++ b/T850/DayScene/Application.h
@@ -50,6 +50,7 @@ public:
 
   void LoadScene(int id) override;
   void DrawRuntimeGui();
+  bool HandleRuntimeGuiToggle(const char* phase);
 #ifdef OS_ANDROID
   bool HandleAndroidInputEvent(AInputEvent* event) override;
   void OnAndroidNativeWindowChanged(ANativeWindow* window) override;
@@ -62,6 +63,7 @@ public:
 
   // Modal UI state queried by the framework to block Esc-to-quit.
   bool IsModalActive() const override;
+  bool WantsRelativeMouseMode() const override;
 
 
   Timer			DtTimer;
@@ -82,8 +84,8 @@ public:
   t850::DevLayer m_devLayer;
   bool m_debugPanelVisible = false;
   std::unordered_set<std::string> m_debugOpenTargets;
-  std::unordered_map<void*, uintptr_t> m_debugTextureDescriptors;
-  std::unordered_map<void*, uintptr_t> m_debugOpaqueTextureDescriptors;
+  std::unordered_map<void*, uint64_t> m_debugTextureDescriptors;
+  std::unordered_map<void*, uint64_t> m_debugOpaqueTextureDescriptors;
 #else
   float m_androidGuiScale = 1.6f;
   int m_androidGuiPanelMode = 0;

--- a/T850/DayScene/SandboxScene.cpp
+++ b/T850/DayScene/SandboxScene.cpp
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <iomanip>
 #include <string>
+#include <cstdint>
 #include <cmath>
 #include <vector>
 #include <algorithm>
@@ -74,6 +75,172 @@ namespace {
     const float dy = a.y - b.y;
     const float dz = a.z - b.z;
     return dx * dx + dy * dy + dz * dz;
+  }
+
+  float HorizontalDistanceSq3(const XVECTOR3& a, const XVECTOR3& b) {
+    const float dx = a.x - b.x;
+    const float dz = a.z - b.z;
+    return dx * dx + dz * dz;
+  }
+
+  template <typename T>
+  void HashNavCacheValue(uint64_t& hash, const T& value) {
+    const unsigned char* bytes = reinterpret_cast<const unsigned char*>(&value);
+    for (std::size_t i = 0; i < sizeof(T); ++i) {
+      hash ^= bytes[i];
+      hash *= 0x100000001b3ull;
+    }
+  }
+
+  void HashNavCacheString(uint64_t& hash, const std::string& value) {
+    for (unsigned char c : value) {
+      hash ^= c;
+      hash *= 0x100000001b3ull;
+    }
+    const unsigned char terminator = 0;
+    hash ^= terminator;
+    hash *= 0x100000001b3ull;
+  }
+
+  void HashNavCacheMatrix(uint64_t& hash, const XMATRIX44& matrix) {
+    for (int row = 0; row < 4; ++row) {
+      for (int col = 0; col < 4; ++col) {
+        HashNavCacheValue(hash, matrix.m[row][col]);
+      }
+    }
+  }
+
+  void HashNavCacheFileSignature(uint64_t& hash, const std::string& resourcePath) {
+    HashNavCacheString(hash, resourcePath);
+    std::error_code ec;
+    std::filesystem::path path(resourcePath);
+    if (path.empty() || !std::filesystem::is_regular_file(path, ec)) {
+      ec.clear();
+      path = t850::ResourceLocator::Instance().ResolveFilePath(resourcePath);
+    }
+    if (!path.empty() && std::filesystem::is_regular_file(path, ec)) {
+      ec.clear();
+      const uint64_t size = static_cast<uint64_t>(std::filesystem::file_size(path, ec));
+      if (!ec) {
+        HashNavCacheValue(hash, size);
+      }
+      ec.clear();
+      const auto writeTime = std::filesystem::last_write_time(path, ec);
+      if (!ec) {
+        const int64_t ticks = static_cast<int64_t>(writeTime.time_since_epoch().count());
+        HashNavCacheValue(hash, ticks);
+      }
+    }
+  }
+
+  void HashNavCacheSettings(uint64_t& hash, const t850::navigation::NavMeshBuildSettings& settings) {
+    HashNavCacheValue(hash, settings.cellSize);
+    HashNavCacheValue(hash, settings.cellHeight);
+    HashNavCacheValue(hash, settings.agentHeight);
+    HashNavCacheValue(hash, settings.agentRadius);
+    HashNavCacheValue(hash, settings.agentMaxClimb);
+    HashNavCacheValue(hash, settings.agentMaxSlope);
+    HashNavCacheValue(hash, settings.regionMinSize);
+    HashNavCacheValue(hash, settings.regionMergeSize);
+    HashNavCacheValue(hash, settings.edgeMaxLen);
+    HashNavCacheValue(hash, settings.edgeMaxError);
+    HashNavCacheValue(hash, settings.vertsPerPoly);
+    HashNavCacheValue(hash, settings.detailSampleDist);
+    HashNavCacheValue(hash, settings.detailSampleMaxError);
+    HashNavCacheValue(hash, settings.enableAutoDropLinks);
+    HashNavCacheValue(hash, settings.dropLinkMinHeight);
+    HashNavCacheValue(hash, settings.dropLinkMaxHeight);
+    HashNavCacheValue(hash, settings.dropLinkMaxHorizontalDistance);
+    HashNavCacheValue(hash, settings.dropLinkSampleSpacing);
+    HashNavCacheValue(hash, settings.dropLinkRadius);
+    HashNavCacheValue(hash, settings.enableAutoJumpLinks);
+    HashNavCacheValue(hash, settings.jumpLinkMaxHorizontalDistance);
+    HashNavCacheValue(hash, settings.jumpLinkSampleSpacing);
+    HashNavCacheValue(hash, settings.jumpLinkRadius);
+    HashNavCacheValue(hash, settings.enableHybridJumpLinks);
+    HashNavCacheValue(hash, settings.hybridJumpMaxLinks);
+    HashNavCacheValue(hash, settings.offMeshLinkValidationKey);
+  }
+
+  void HashQ3JumpPads(uint64_t& hash, const t850::Q3BspCollisionWorld* q3CollisionWorld) {
+    const uint32_t hasQ3Collision = q3CollisionWorld && q3CollisionWorld->IsLoaded() ? 1u : 0u;
+    HashNavCacheValue(hash, hasQ3Collision);
+    if (!hasQ3Collision) {
+      return;
+    }
+
+    HashNavCacheFileSignature(hash, q3CollisionWorld->GetResourcePath());
+    const std::vector<t850::Q3BspCollisionWorld::JumpPad>& jumpPads = q3CollisionWorld->GetJumpPads();
+    const uint64_t jumpPadCount = static_cast<uint64_t>(jumpPads.size());
+    HashNavCacheValue(hash, jumpPadCount);
+    for (const t850::Q3BspCollisionWorld::JumpPad& jumpPad : jumpPads) {
+      HashNavCacheValue(hash, jumpPad.entityId);
+      HashNavCacheValue(hash, jumpPad.mins.x);
+      HashNavCacheValue(hash, jumpPad.mins.y);
+      HashNavCacheValue(hash, jumpPad.mins.z);
+      HashNavCacheValue(hash, jumpPad.maxs.x);
+      HashNavCacheValue(hash, jumpPad.maxs.y);
+      HashNavCacheValue(hash, jumpPad.maxs.z);
+      HashNavCacheValue(hash, jumpPad.hasTargetPosition);
+      HashNavCacheValue(hash, jumpPad.targetPosition.x);
+      HashNavCacheValue(hash, jumpPad.targetPosition.y);
+      HashNavCacheValue(hash, jumpPad.targetPosition.z);
+      HashNavCacheValue(hash, jumpPad.velocity.x);
+      HashNavCacheValue(hash, jumpPad.velocity.y);
+      HashNavCacheValue(hash, jumpPad.velocity.z);
+    }
+  }
+
+  uint64_t ComputeQ3NavLinkValidationKey(const t850::Q3BspCollisionWorld* q3CollisionWorld) {
+    if (!q3CollisionWorld || !q3CollisionWorld->IsLoaded()) {
+      return 0;
+    }
+
+    uint64_t hash = 0xcbf29ce484222325ull;
+    constexpr uint32_t kQ3NavLinkValidationVersion = 7;
+    HashNavCacheValue(hash, kQ3NavLinkValidationVersion);
+    HashNavCacheFileSignature(hash, q3CollisionWorld->GetResourcePath());
+    const uint64_t brushCount = static_cast<uint64_t>(q3CollisionWorld->GetBrushCount());
+    const uint64_t patchFacetCount = static_cast<uint64_t>(q3CollisionWorld->GetPatchFacetCount());
+    const uint64_t jumpPadCount = static_cast<uint64_t>(q3CollisionWorld->GetJumpPadCount());
+    const uint64_t reachabilityCount = static_cast<uint64_t>(q3CollisionWorld->GetReachabilityCount());
+    HashNavCacheValue(hash, brushCount);
+    HashNavCacheValue(hash, patchFacetCount);
+    HashNavCacheValue(hash, jumpPadCount);
+    HashNavCacheValue(hash, reachabilityCount);
+    return hash;
+  }
+
+  uint64_t ComputeSandboxNavMeshCacheKey(const PrimitiveInst* instances,
+                                         int instanceCount,
+                                         const std::vector<std::string>& meshPaths,
+                                         const std::string& scenePath,
+                                         const t850::navigation::NavMeshBuildSettings& settings,
+                                         const t850::Q3BspCollisionWorld* q3CollisionWorld) {
+    uint64_t hash = 0xcbf29ce484222325ull;
+    constexpr uint32_t kSandboxNavCacheVersion = 3;
+    HashNavCacheValue(hash, kSandboxNavCacheVersion);
+    HashNavCacheFileSignature(hash, scenePath);
+    HashNavCacheSettings(hash, settings);
+    HashQ3JumpPads(hash, q3CollisionWorld);
+    int includedSources = 0;
+    for (int meshIndex = 0; meshIndex < instanceCount; ++meshIndex) {
+      const PrimitiveInst& instance = instances[meshIndex];
+      if (!instance.Visible || !instance.pBase || instance.GetSkinnedMesh()) {
+        continue;
+      }
+
+      ++includedSources;
+      HashNavCacheValue(hash, meshIndex);
+      if (meshIndex >= 0 && meshIndex < static_cast<int>(meshPaths.size())) {
+        HashNavCacheFileSignature(hash, meshPaths[static_cast<std::size_t>(meshIndex)]);
+      } else if (const RenderMesh* mesh = dynamic_cast<const RenderMesh*>(instance.pBase)) {
+        HashNavCacheFileSignature(hash, mesh->m_sourcePath);
+      }
+      HashNavCacheMatrix(hash, instance.Final);
+    }
+    HashNavCacheValue(hash, includedSources);
+    return includedSources > 0 ? hash : 0;
   }
 
   uint32_t NextNavTestRandom(uint32_t& state, uint32_t salt) {
@@ -138,14 +305,15 @@ namespace {
   bool RotateNavTestAgentToFace(PrimitiveInst& instance,
                                 const XVECTOR3& agentPosition,
                                 const XVECTOR3& targetPosition,
-                                float yawOffsetDegrees) {
+                                float yawOffsetDegrees,
+                                float yawSign) {
     const float dx = targetPosition.x - agentPosition.x;
     const float dz = targetPosition.z - agentPosition.z;
     if (dx * dx + dz * dz <= 0.0001f) {
       return false;
     }
 
-    const float yawDegrees = Rad2Deg(std::atan2(dx, dz)) + yawOffsetDegrees;
+    const float yawDegrees = Rad2Deg(std::atan2(dx, dz)) * (yawSign < 0.0f ? -1.0f : 1.0f) + yawOffsetDegrees;
     instance.RotateYAbsolute(yawDegrees);
     return true;
   }
@@ -197,6 +365,438 @@ namespace {
     projectedTarget = playerNavPoint;
     if (error) *error = "slot projection failed, using player nav point: " + projectionError;
     return true;
+  }
+
+  bool SimulateQ3JumpPadLanding(const t850::Q3BspCollisionWorld& collisionWorld,
+                                const XVECTOR3& source,
+                                const XVECTOR3& initialVelocity,
+                                XVECTOR3& outLanding) {
+    const t850::KinematicCharacterSettings q3Settings = t850::MakeQuake3CharacterSettings();
+    const XVECTOR3 halfExtents(
+        q3Settings.capsuleRadius,
+        q3Settings.capsuleHalfHeight + q3Settings.capsuleRadius,
+        q3Settings.capsuleRadius,
+        0.0f);
+
+    XVECTOR3 position = source;
+    position.w = 1.0f;
+    XVECTOR3 velocity = initialVelocity;
+    velocity.w = 0.0f;
+
+    constexpr float kStepSeconds = 1.0f / 60.0f;
+    constexpr float kMaxSimSeconds = 6.0f;
+    constexpr float kMinAirSeconds = 0.08f;
+    constexpr float kMinWalkNormalY = 0.62f;
+    const int maxSteps = static_cast<int>(kMaxSimSeconds / kStepSeconds);
+
+    for (int stepIndex = 0; stepIndex < maxSteps; ++stepIndex) {
+      const float elapsed = static_cast<float>(stepIndex) * kStepSeconds;
+      XVECTOR3 nextVelocity = velocity;
+      nextVelocity.y -= q3Settings.gravity * kStepSeconds;
+
+      XVECTOR3 displacement = (velocity + nextVelocity) * (0.5f * kStepSeconds);
+      displacement.w = 0.0f;
+      if (displacement.Length() <= 0.000001f) {
+        velocity = nextVelocity;
+        continue;
+      }
+
+      t850::CharacterBoxSweep sweep;
+      sweep.startCenter = position;
+      sweep.displacement = displacement;
+      sweep.halfExtents = halfExtents;
+      t850::CharacterCollisionHit hit;
+      if (collisionWorld.SweepBox(sweep, hit) && hit.hit) {
+        position += displacement * (std::max)(0.0f, (std::min)(1.0f, hit.fraction));
+        position.w = 1.0f;
+        if (elapsed >= kMinAirSeconds && hit.normal.y >= kMinWalkNormalY) {
+          outLanding = position;
+          return true;
+        }
+
+        const float intoNormal =
+            velocity.x * hit.normal.x +
+            velocity.y * hit.normal.y +
+            velocity.z * hit.normal.z;
+        velocity = nextVelocity - hit.normal * intoNormal;
+        velocity.w = 0.0f;
+        position += hit.normal * 0.01f;
+        position.w = 1.0f;
+        continue;
+      }
+
+      position += displacement;
+      position.w = 1.0f;
+      velocity = nextVelocity;
+    }
+
+    return false;
+  }
+
+  float Q3CharacterGroundOffsetY(const t850::KinematicCharacterSettings& settings) {
+    return settings.capsuleHalfHeight + settings.capsuleRadius;
+  }
+
+  XVECTOR3 Q3CenterFromGroundPoint(XVECTOR3 groundPoint, const t850::KinematicCharacterSettings& settings) {
+    groundPoint.y += Q3CharacterGroundOffsetY(settings);
+    groundPoint.w = 1.0f;
+    return groundPoint;
+  }
+
+  XVECTOR3 Q3GroundPointFromCenter(XVECTOR3 center, const t850::KinematicCharacterSettings& settings) {
+    center.y -= Q3CharacterGroundOffsetY(settings);
+    center.w = 1.0f;
+    return center;
+  }
+
+  XVECTOR3 HorizontalDirectionTo(const XVECTOR3& from, const XVECTOR3& to, const XVECTOR3& fallback) {
+    XVECTOR3 direction = to - from;
+    direction.y = 0.0f;
+    direction.w = 0.0f;
+    if (direction.Length() <= 0.0001f) {
+      direction = fallback;
+    }
+    direction.y = 0.0f;
+    direction.w = 0.0f;
+    if (direction.Length() <= 0.0001f) {
+      direction = XVECTOR3(0.0f, 0.0f, 1.0f, 0.0f);
+    }
+    direction.Normalize();
+    return direction;
+  }
+
+  t850::KinematicCharacterInput BuildNavAgentPhysicsInput(const XVECTOR3& groundPosition,
+                                                          const XVECTOR3& target,
+                                                          bool jump) {
+    t850::KinematicCharacterInput input;
+    const XVECTOR3 forward = HorizontalDirectionTo(groundPosition, target, XVECTOR3(0.0f, 0.0f, 1.0f, 0.0f));
+    input.forward = forward;
+    input.right = XVECTOR3(forward.z, 0.0f, -forward.x, 0.0f);
+    input.moveForward = true;
+    input.moveForwardAmount = 1.0f;
+    input.jump = jump;
+    input.sprint = false;
+    return input;
+  }
+
+  bool SimulateQ3TraversalLinkLanding(const t850::Q3BspCollisionWorld& collisionWorld,
+                                      const t850::navigation::NavOffMeshLink& link,
+                                      bool jump,
+                                      XVECTOR3& outLanding) {
+    const t850::KinematicCharacterSettings q3Settings = t850::MakeQuake3CharacterSettings();
+    XVECTOR3 horizontal = link.end - link.start;
+    horizontal.y = 0.0f;
+    horizontal.w = 0.0f;
+    const float horizontalDistance = horizontal.Length();
+    if (horizontalDistance <= 0.10f) {
+      return false;
+    }
+    horizontal /= horizontalDistance;
+
+    XVECTOR3 position = Q3CenterFromGroundPoint(link.start, q3Settings);
+    XVECTOR3 velocity = horizontal * q3Settings.walkSpeed;
+    velocity.y = jump ? q3Settings.jumpSpeed : 0.0f;
+    velocity.w = 0.0f;
+
+    const XVECTOR3 halfExtents(
+        q3Settings.capsuleRadius,
+        q3Settings.capsuleHalfHeight + q3Settings.capsuleRadius,
+        q3Settings.capsuleRadius,
+        0.0f);
+
+    constexpr float kStepSeconds = 1.0f / 60.0f;
+    constexpr float kMaxSimSeconds = 3.0f;
+    constexpr float kMinAirSeconds = 0.10f;
+    constexpr float kMinWalkNormalY = 0.62f;
+    const float landingTolerance = (std::max)(1.0f, link.radius * 2.0f);
+    const float landingToleranceSq = landingTolerance * landingTolerance;
+    const int maxSteps = static_cast<int>(kMaxSimSeconds / kStepSeconds);
+
+    for (int stepIndex = 0; stepIndex < maxSteps; ++stepIndex) {
+      const float elapsed = static_cast<float>(stepIndex) * kStepSeconds;
+      XVECTOR3 nextVelocity = velocity;
+      nextVelocity.y -= q3Settings.gravity * kStepSeconds;
+
+      XVECTOR3 displacement = (velocity + nextVelocity) * (0.5f * kStepSeconds);
+      displacement.w = 0.0f;
+      if (displacement.Length() <= 0.000001f) {
+        velocity = nextVelocity;
+        continue;
+      }
+
+      t850::CharacterBoxSweep sweep;
+      sweep.startCenter = position;
+      sweep.displacement = displacement;
+      sweep.halfExtents = halfExtents;
+      t850::CharacterCollisionHit hit;
+      if (collisionWorld.SweepBox(sweep, hit) && hit.hit) {
+        position += displacement * (std::max)(0.0f, (std::min)(1.0f, hit.fraction));
+        position.w = 1.0f;
+        if (elapsed >= kMinAirSeconds && nextVelocity.y <= 0.0f && hit.normal.y >= kMinWalkNormalY) {
+          const XVECTOR3 landing = Q3GroundPointFromCenter(position, q3Settings);
+          if (HorizontalDistanceSq3(landing, link.end) <= landingToleranceSq &&
+              std::fabs(landing.y - link.end.y) <= 1.25f) {
+            outLanding = landing;
+            return true;
+          }
+        }
+        return false;
+      }
+
+      position += displacement;
+      position.w = 1.0f;
+      velocity = nextVelocity;
+    }
+
+    return false;
+  }
+
+  bool ValidateQ3NavLinkSegment(const t850::Q3BspCollisionWorld& collisionWorld,
+                                const t850::navigation::NavOffMeshLink& link) {
+    if (!std::isfinite(link.start.x) || !std::isfinite(link.start.y) || !std::isfinite(link.start.z) ||
+        !std::isfinite(link.end.x) || !std::isfinite(link.end.y) || !std::isfinite(link.end.z)) {
+      return false;
+    }
+
+    XVECTOR3 delta = link.end - link.start;
+    delta.w = 0.0f;
+    const float length = delta.Length();
+    if (length <= 0.05f) {
+      return false;
+    }
+
+    XVECTOR3 horizontalDir(delta.x, 0.0f, delta.z, 0.0f);
+    if (horizontalDir.Length() > 0.0001f) {
+      horizontalDir.Normalize();
+    } else {
+      horizontalDir = XVECTOR3(0.0f, 0.0f, 0.0f, 0.0f);
+    }
+
+    const float endpointInset = (std::min)(0.25f, length * 0.10f);
+    const float radius = (std::max)(0.08f, (std::min)(0.28f, link.radius * 0.35f));
+    const float verticalHalfExtent = (std::max)(0.05f, (std::min)(0.14f, radius * 0.5f));
+    const float lift = (std::max)(0.30f, verticalHalfExtent + 0.18f);
+
+    XVECTOR3 start = link.start + horizontalDir * endpointInset;
+    XVECTOR3 end = link.end - horizontalDir * endpointInset;
+    start.y += lift;
+    end.y += lift;
+    start.w = 1.0f;
+    end.w = 1.0f;
+
+    t850::CharacterBoxSweep sweep;
+    sweep.startCenter = start;
+    sweep.displacement = end - start;
+    sweep.displacement.w = 0.0f;
+    sweep.halfExtents = XVECTOR3(radius, verticalHalfExtent, radius, 0.0f);
+
+    t850::CharacterCollisionHit hit;
+    if (!collisionWorld.SweepBox(sweep, hit) || !hit.hit) {
+      return true;
+    }
+    return hit.fraction >= 0.985f;
+  }
+
+  bool ValidateQ3HybridJumpIntentLink(const t850::Q3BspCollisionWorld& collisionWorld,
+                                      const t850::navigation::NavOffMeshLink& link) {
+    const t850::KinematicCharacterSettings q3Settings = t850::MakeQuake3CharacterSettings();
+    XVECTOR3 delta = link.end - link.start;
+    delta.y = 0.0f;
+    delta.w = 0.0f;
+    const float horizontalDistance = delta.Length();
+    if (horizontalDistance < 1.25f) {
+      return false;
+    }
+
+    const float verticalDelta = link.end.y - link.start.y;
+    if (verticalDelta > q3Settings.stepHeight * 0.75f) {
+      return false;
+    }
+    if (verticalDelta > -0.20f && horizontalDistance < 2.50f) {
+      return false;
+    }
+
+    delta /= horizontalDistance;
+
+    const XVECTOR3 halfExtents(
+        q3Settings.capsuleRadius * 0.85f,
+        q3Settings.capsuleHalfHeight + q3Settings.capsuleRadius * 0.85f,
+        q3Settings.capsuleRadius * 0.85f,
+        0.0f);
+    t850::CharacterBoxSweep corridorSweep;
+    corridorSweep.startCenter = Q3CenterFromGroundPoint(link.start, q3Settings);
+    corridorSweep.startCenter.y += 0.08f;
+    corridorSweep.displacement = delta * (std::min)(2.0f, horizontalDistance * 0.45f);
+    corridorSweep.displacement.w = 0.0f;
+    corridorSweep.halfExtents = halfExtents;
+
+    t850::CharacterCollisionHit corridorHit;
+    if (collisionWorld.SweepBox(corridorSweep, corridorHit) &&
+        corridorHit.hit &&
+        corridorHit.fraction < 0.95f &&
+        corridorHit.normal.y < q3Settings.minWalkNormalY) {
+      return false;
+    }
+
+    const XVECTOR3 probeHalfExtents(
+        q3Settings.capsuleRadius * 0.45f,
+        0.05f,
+        q3Settings.capsuleRadius * 0.45f,
+        0.0f);
+    t850::CharacterBoxSweep supportSweep;
+    supportSweep.startCenter = link.start + delta * (q3Settings.capsuleRadius + 0.45f);
+    supportSweep.startCenter.y += 0.35f;
+    supportSweep.startCenter.w = 1.0f;
+    supportSweep.displacement = XVECTOR3(0.0f, -1.25f, 0.0f, 0.0f);
+    supportSweep.halfExtents = probeHalfExtents;
+
+    t850::CharacterCollisionHit supportHit;
+    if (collisionWorld.SweepBox(supportSweep, supportHit) &&
+        supportHit.hit &&
+        supportHit.normal.y >= q3Settings.minWalkNormalY) {
+      const float supportGroundY = supportHit.position.y - probeHalfExtents.y;
+      const float dropFromStart = link.start.y - supportGroundY;
+      if (dropFromStart < q3Settings.stepHeight * 0.75f) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  bool ValidateQ3NavOffMeshLink(const t850::Q3BspCollisionWorld& collisionWorld,
+                                const t850::navigation::NavOffMeshLink& link) {
+    if (link.type == t850::navigation::NavTraversalType::Walk ||
+        link.type == t850::navigation::NavTraversalType::JumpPad) {
+      return true;
+    }
+    if (link.type == t850::navigation::NavTraversalType::JumpIntent) {
+      return ValidateQ3HybridJumpIntentLink(collisionWorld, link);
+    }
+    if (link.type == t850::navigation::NavTraversalType::Jump) {
+      XVECTOR3 landing;
+      return SimulateQ3TraversalLinkLanding(collisionWorld, link, true, landing);
+    }
+    if (link.type == t850::navigation::NavTraversalType::Drop) {
+      XVECTOR3 landing;
+      return SimulateQ3TraversalLinkLanding(collisionWorld, link, false, landing);
+    }
+    return ValidateQ3NavLinkSegment(collisionWorld, link);
+  }
+
+  std::vector<t850::navigation::NavOffMeshLink> BuildQ3JumpPadNavLinks(const t850::Q3BspCollisionWorld* q3CollisionWorld) {
+    std::vector<t850::navigation::NavOffMeshLink> links;
+    if (!q3CollisionWorld || !q3CollisionWorld->IsLoaded()) {
+      return links;
+    }
+
+    const std::vector<t850::Q3BspCollisionWorld::JumpPad>& jumpPads = q3CollisionWorld->GetJumpPads();
+    links.reserve(jumpPads.size());
+    for (const t850::Q3BspCollisionWorld::JumpPad& jumpPad : jumpPads) {
+      XVECTOR3 source(
+          (jumpPad.mins.x + jumpPad.maxs.x) * 0.5f,
+          (jumpPad.mins.y + jumpPad.maxs.y) * 0.5f,
+          (jumpPad.mins.z + jumpPad.maxs.z) * 0.5f,
+          1.0f);
+      XVECTOR3 landing = jumpPad.targetPosition;
+      const bool hasTargetPosition =
+          jumpPad.hasTargetPosition &&
+          std::isfinite(landing.x) &&
+          std::isfinite(landing.y) &&
+          std::isfinite(landing.z) &&
+          DistanceSquared(landing, source) > 0.25f;
+      if (!hasTargetPosition &&
+          !SimulateQ3JumpPadLanding(*q3CollisionWorld, source, jumpPad.velocity, landing)) {
+        T8_LOG_ERROR("[Navigation] Q3 jump pad %u did not produce a walkable landing link",
+                     jumpPad.entityId);
+        continue;
+      }
+
+      t850::navigation::NavOffMeshLink link;
+      link.start = source;
+      link.end = landing;
+      link.radius = 1.0f;
+      link.bidirectional = false;
+      link.type = t850::navigation::NavTraversalType::JumpPad;
+      link.userId = jumpPad.entityId;
+      links.push_back(link);
+    }
+    return links;
+  }
+
+  t850::navigation::NavTraversalType Q3ReachabilityTravelTypeToNavTraversal(const std::string& travelType) {
+    if (travelType == "walk_off_ledge") {
+      return t850::navigation::NavTraversalType::Drop;
+    }
+    if (travelType == "jump" || travelType == "barrier_jump") {
+      return t850::navigation::NavTraversalType::Jump;
+    }
+    if (travelType == "jump_pad") {
+      return t850::navigation::NavTraversalType::JumpPad;
+    }
+    return t850::navigation::NavTraversalType::Walk;
+  }
+
+  std::vector<t850::navigation::NavOffMeshLink> BuildQ3AasReachabilityNavLinks(
+      const t850::Q3BspCollisionWorld* q3CollisionWorld) {
+    std::vector<t850::navigation::NavOffMeshLink> links;
+    if (!q3CollisionWorld || !q3CollisionWorld->IsLoaded()) {
+      return links;
+    }
+
+    const std::vector<t850::Q3BspCollisionWorld::Reachability>& reachabilities =
+        q3CollisionWorld->GetReachabilities();
+    links.reserve(reachabilities.size());
+    int dropCount = 0;
+    int jumpCount = 0;
+    int jumpPadCount = 0;
+    int ignoredCount = 0;
+    for (const t850::Q3BspCollisionWorld::Reachability& reachability : reachabilities) {
+      const t850::navigation::NavTraversalType traversalType =
+          Q3ReachabilityTravelTypeToNavTraversal(reachability.travelType);
+      if (traversalType == t850::navigation::NavTraversalType::Walk) {
+        ++ignoredCount;
+        continue;
+      }
+      if (!std::isfinite(reachability.start.x) ||
+          !std::isfinite(reachability.start.y) ||
+          !std::isfinite(reachability.start.z) ||
+          !std::isfinite(reachability.end.x) ||
+          !std::isfinite(reachability.end.y) ||
+          !std::isfinite(reachability.end.z) ||
+          DistanceSquared(reachability.start, reachability.end) <= 0.01f) {
+        ++ignoredCount;
+        continue;
+      }
+
+      t850::navigation::NavOffMeshLink link;
+      link.start = reachability.start;
+      link.end = reachability.end;
+      link.radius = traversalType == t850::navigation::NavTraversalType::JumpPad ? 1.0f : 0.75f;
+      link.bidirectional = false;
+      link.type = traversalType;
+      link.userId = reachability.travelTypeId;
+      links.push_back(link);
+
+      if (traversalType == t850::navigation::NavTraversalType::Drop) {
+        ++dropCount;
+      } else if (traversalType == t850::navigation::NavTraversalType::Jump) {
+        ++jumpCount;
+      } else if (traversalType == t850::navigation::NavTraversalType::JumpPad) {
+        ++jumpPadCount;
+      }
+    }
+
+    if (!reachabilities.empty()) {
+      T8_LOG_INFO("[Navigation] Q3 AAS reachability links prepared: total=%zu used=%zu drop=%d jump=%d jumpPad=%d ignored=%d",
+                  reachabilities.size(),
+                  links.size(),
+                  dropCount,
+                  jumpCount,
+                  jumpPadCount,
+                  ignoredCount);
+    }
+    return links;
   }
 
   struct SandboxConsoleLine {
@@ -818,6 +1418,24 @@ namespace {
     for (const auto& value : values)
       if (value.index == index) return &value;
     return nullptr;
+  }
+
+  const t850::SandboxAnimationOverrideDesc* FindAnimationOverride(
+      const std::vector<t850::SandboxAnimationOverrideDesc>& values,
+      int index) {
+    for (const auto& value : values)
+      if (value.index == index) return &value;
+    return nullptr;
+  }
+
+  bool AnimationOverrideNearlyEqual(const t850::SandboxAnimationOverrideDesc& lhs,
+                                    const t850::SandboxAnimationOverrideDesc& rhs) {
+    return lhs.index == rhs.index &&
+           lhs.mesh == rhs.mesh &&
+           NearlyEqual(lhs.anim_speed, rhs.anim_speed) &&
+           lhs.anim_select == rhs.anim_select &&
+           lhs.anim_mode == rhs.anim_mode &&
+           lhs.current_keyframe == rhs.current_keyframe;
   }
 
   std::array<float, 3> ToArray(const XVECTOR3& value) {
@@ -2549,6 +3167,113 @@ namespace {
       if (selector.name == name) return &selector;
     return nullptr;
   }
+
+  struct CubemapSelection {
+    std::string path;
+    int index = -1;
+  };
+
+  std::string CubemapPathForSelectorIndex(const t850::SelectorDesc& selector, int selectedIndex) {
+    if (selectedIndex < 0 || selectedIndex >= static_cast<int>(selector.options.size())) {
+      return {};
+    }
+    return "sky/" + selector.options[static_cast<std::size_t>(selectedIndex)];
+  }
+
+  bool ResourcePathEquals(std::string lhs, std::string rhs) {
+    return ToLowerAscii(NormalizeSceneResourcePath(lhs)) ==
+           ToLowerAscii(NormalizeSceneResourcePath(rhs));
+  }
+
+  int CubemapSelectorIndexForPath(const t850::SelectorDesc& selector, const std::string& resourcePath) {
+    for (int index = 0; index < static_cast<int>(selector.options.size()); ++index) {
+      if (ResourcePathEquals(CubemapPathForSelectorIndex(selector, index), resourcePath)) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  int CubemapSelectorIndexFromProfile(const t850::SandboxProfileDesc& profile) {
+    for (const t850::IntOverrideDesc& selector : profile.selectors) {
+      if (selector.name == "cubemap") {
+        return selector.value;
+      }
+    }
+    return -1;
+  }
+
+  CubemapSelection CubemapSelectionFromProfile(const t850::SelectorDesc& cubemapDesc,
+                                               const t850::SandboxProfileDesc& profile) {
+    CubemapSelection selection;
+    if (profile.cubemap_path.has_value()) {
+      selection.path = NormalizeSceneResourcePath(*profile.cubemap_path);
+      if (!selection.path.empty()) {
+        selection.index = CubemapSelectorIndexForPath(cubemapDesc, selection.path);
+        return selection;
+      }
+    }
+
+    selection.index = CubemapSelectorIndexFromProfile(profile);
+    if (selection.index >= 0 && selection.index < static_cast<int>(cubemapDesc.options.size())) {
+      selection.path = CubemapPathForSelectorIndex(cubemapDesc, selection.index);
+      return selection;
+    }
+
+    selection.index = -1;
+    return selection;
+  }
+
+  CubemapSelection ResolveStartupCubemapSelection(const std::vector<t850::SelectorDesc>& selectors,
+                                                  const std::vector<t850::SandboxProfileDesc>& profiles,
+                                                  bool embeddedInScene,
+                                                  const std::string& modelKey) {
+    const t850::SelectorDesc* cubemapDesc = FindSelectorDesc(selectors, "cubemap");
+    if (!cubemapDesc) {
+      return {};
+    }
+
+    const t850::SandboxProfileDesc* baseProfile = nullptr;
+    const t850::SandboxProfileDesc* runtimeProfile = nullptr;
+    int bestRuntimeScore = -1;
+    for (const t850::SandboxProfileDesc& profile : profiles) {
+      const bool modelSpecific = !profile.model.empty();
+      const bool modelMatches = embeddedInScene
+          ? !modelSpecific
+          : (!modelSpecific || SandboxProfileModelKey(profile.model) == modelKey);
+      if (!modelMatches) {
+        continue;
+      }
+
+      const bool hasTarget = !profile.name.empty() ||
+                             !profile.platform.empty() ||
+                             !profile.architecture.empty() ||
+                             !profile.gpu_family.empty() ||
+                             !profile.gpu_name_contains.empty();
+      if (!hasTarget && (embeddedInScene || modelSpecific)) {
+        baseProfile = &profile;
+        continue;
+      }
+
+      const int score = t850::ScoreSceneProfileMatch(profile, modelKey);
+      if (score > bestRuntimeScore) {
+        bestRuntimeScore = score;
+        runtimeProfile = &profile;
+      }
+    }
+
+    CubemapSelection selection;
+    if (baseProfile) {
+      selection = CubemapSelectionFromProfile(*cubemapDesc, *baseProfile);
+    }
+    if (runtimeProfile && runtimeProfile != baseProfile) {
+      const CubemapSelection runtimeSelection = CubemapSelectionFromProfile(*cubemapDesc, *runtimeProfile);
+      if (!runtimeSelection.path.empty()) {
+        selection = runtimeSelection;
+      }
+    }
+    return selection;
+  }
 }
 
 void SandboxScene::InitVars() {
@@ -2649,6 +3374,7 @@ void SandboxScene::InitVars() {
   m_sceneMeshPaths.clear();
   m_sceneRagdollPaths.clear();
   m_sceneNavAgentFrontYawOffsets.clear();
+  m_sceneNavAgentFaceYawSigns.clear();
   m_sceneRagdolls.clear();
   m_navTestAgents.clear();
   m_navTestCandidatePoints.clear();
@@ -3196,11 +3922,12 @@ bool SandboxScene::LoadEditorSceneAssets(const std::string& scenePath) {
     auto q3CollisionWorld = std::make_unique<t850::Q3BspCollisionWorld>();
     std::string q3CollisionError;
     if (q3CollisionWorld->Load(q3CollisionPath, &q3CollisionError)) {
-      T8_LOG_INFO("[SandboxScene] Q3 collision clip loaded: %s brushes=%zu patchFacets=%zu jumpPads=%zu",
+      T8_LOG_INFO("[SandboxScene] Q3 collision clip loaded: %s brushes=%zu patchFacets=%zu jumpPads=%zu reachabilities=%zu",
                   q3CollisionPath.c_str(),
                   q3CollisionWorld->GetBrushCount(),
                   q3CollisionWorld->GetPatchFacetCount(),
-                  q3CollisionWorld->GetJumpPadCount());
+                  q3CollisionWorld->GetJumpPadCount(),
+                  q3CollisionWorld->GetReachabilityCount());
       m_q3CollisionWorld = std::move(q3CollisionWorld);
     } else {
       T8_LOG_ERROR("[SandboxScene] Failed to load Q3 collision clip '%s': %s",
@@ -3293,8 +4020,11 @@ bool SandboxScene::LoadEditorSceneAssets(const std::string& scenePath) {
     m_sceneRagdollPaths.push_back(ragdollPath);
     const float navAgentFrontYawOffset = object.nav_agent_front_yaw_offset_deg.value_or(0.0f);
     m_sceneNavAgentFrontYawOffsets.push_back(navAgentFrontYawOffset);
-    T8_LOG_INFO("[SandboxScene] Loaded scene object '%s' mesh='%s' ragdoll='%s' slot=%d navFrontYawOffset=%.1f",
-                object.name.c_str(), meshPath.c_str(), ragdollPath.c_str(), m_meshCount, navAgentFrontYawOffset);
+    const float navAgentFaceYawSign = object.nav_agent_face_yaw_sign.value_or(1.0f) < 0.0f ? -1.0f : 1.0f;
+    m_sceneNavAgentFaceYawSigns.push_back(navAgentFaceYawSign);
+    T8_LOG_INFO("[SandboxScene] Loaded scene object '%s' mesh='%s' ragdoll='%s' slot=%d navFrontYawOffset=%.1f navFaceYawSign=%.1f",
+                object.name.c_str(), meshPath.c_str(), ragdollPath.c_str(), m_meshCount,
+                navAgentFrontYawOffset, navAgentFaceYawSign);
     ++m_meshCount;
   }
 
@@ -3322,8 +4052,33 @@ bool SandboxScene::EnsureNavMeshBuilt() {
   }
   m_navMeshBuildAttempted = true;
 
-  t850::navigation::NavMeshGeometry geometry;
   const int meshCount = (std::min)(kMaxSandboxMeshes, (std::max)(m_meshCount, Meshes[0].pBase ? 1 : 0));
+  t850::navigation::NavMeshBuildSettings navBuildSettings;
+  const bool hasQ3Clip = m_q3CollisionWorld && m_q3CollisionWorld->IsLoaded();
+  const bool hasQ3AasReachability = hasQ3Clip && m_q3CollisionWorld->GetReachabilityCount() > 0;
+  navBuildSettings.enableAutoDropLinks = hasQ3Clip && !hasQ3AasReachability;
+  navBuildSettings.enableAutoJumpLinks = hasQ3Clip && !hasQ3AasReachability;
+  navBuildSettings.enableHybridJumpLinks = hasQ3Clip && !hasQ3AasReachability;
+  navBuildSettings.hybridJumpMaxLinks = 192;
+  navBuildSettings.offMeshLinkValidationKey = ComputeQ3NavLinkValidationKey(m_q3CollisionWorld.get());
+  const uint64_t navCacheKey =
+      ComputeSandboxNavMeshCacheKey(
+          Meshes,
+          meshCount,
+          m_sceneMeshPaths,
+          m_loadedEditorScenePath,
+          navBuildSettings,
+          m_q3CollisionWorld.get());
+  if (navCacheKey != 0 && m_navMesh.LoadCached(navCacheKey, navBuildSettings, nullptr)) {
+    m_navMeshDebugRenderer.Invalidate();
+    const t850::navigation::NavMeshBuildStats& stats = m_navMesh.GetStats();
+    T8_LOG_INFO("[Navigation] Sandbox navmesh ready from cache: verts=%d tris=%d polys=%d offMesh=%d drop=%d jump=%d jumpPad=%d",
+                stats.vertexCount, stats.triangleCount, stats.polygonCount,
+                stats.offMeshLinkCount, stats.dropLinkCount, stats.jumpLinkCount, stats.jumpPadLinkCount);
+    return true;
+  }
+
+  t850::navigation::NavMeshGeometry geometry;
   t850::navigation::NavSourceBuildStats sourceStats;
   std::string error;
   if (!t850::navigation::BuildGeometryFromPrimitiveInstances(Meshes, meshCount, geometry, &sourceStats, &error)) {
@@ -3336,17 +4091,37 @@ bool SandboxScene::EnsureNavMeshBuilt() {
                  sourceStats.skippedInvalid);
     return false;
   }
+  geometry.offMeshLinks = hasQ3AasReachability
+      ? BuildQ3AasReachabilityNavLinks(m_q3CollisionWorld.get())
+      : BuildQ3JumpPadNavLinks(m_q3CollisionWorld.get());
+  if (hasQ3Clip) {
+    const t850::Q3BspCollisionWorld* q3CollisionWorld = m_q3CollisionWorld.get();
+    if (!hasQ3AasReachability) {
+      geometry.offMeshLinkValidator = [q3CollisionWorld](const t850::navigation::NavOffMeshLink& link) {
+        return ValidateQ3NavOffMeshLink(*q3CollisionWorld, link);
+      };
+      geometry.offMeshHybridLinkValidator = [q3CollisionWorld](const t850::navigation::NavOffMeshLink& link) {
+        return ValidateQ3HybridJumpIntentLink(*q3CollisionWorld, link);
+      };
+    }
+  }
+  if (!geometry.offMeshLinks.empty()) {
+    T8_LOG_INFO("[Navigation] Q3 nav links prepared: %zu source=%s",
+                geometry.offMeshLinks.size(),
+                hasQ3AasReachability ? "aas" : "heuristic");
+  }
 
-  if (!m_navMesh.Build(geometry, t850::navigation::NavMeshBuildSettings(), &error)) {
+  if (!m_navMesh.BuildCached(geometry, navBuildSettings, navCacheKey, &error)) {
     T8_LOG_ERROR("[Navigation] Sandbox navmesh build failed: %s", error.c_str());
     return false;
   }
 
   m_navMeshDebugRenderer.Invalidate();
   const t850::navigation::NavMeshBuildStats& stats = m_navMesh.GetStats();
-  T8_LOG_INFO("[Navigation] Sandbox navmesh ready: sources=%d skippedSkinned=%d skippedInvalid=%d verts=%d tris=%d polys=%d",
+  T8_LOG_INFO("[Navigation] Sandbox navmesh ready: sources=%d skippedSkinned=%d skippedInvalid=%d verts=%d tris=%d polys=%d offMesh=%d drop=%d jump=%d jumpPad=%d",
               sourceStats.included, sourceStats.skippedSkinned, sourceStats.skippedInvalid,
-              stats.vertexCount, stats.triangleCount, stats.polygonCount);
+              stats.vertexCount, stats.triangleCount, stats.polygonCount,
+              stats.offMeshLinkCount, stats.dropLinkCount, stats.jumpLinkCount, stats.jumpPadLinkCount);
   return true;
 }
 
@@ -3387,6 +4162,9 @@ void SandboxScene::InitializeNavTestAgents() {
     agent.followSlot = followSlot++;
     if (meshIndex < static_cast<int>(m_sceneNavAgentFrontYawOffsets.size())) {
       agent.frontYawOffsetDeg = m_sceneNavAgentFrontYawOffsets[static_cast<std::size_t>(meshIndex)];
+    }
+    if (meshIndex < static_cast<int>(m_sceneNavAgentFaceYawSigns.size())) {
+      agent.faceYawSign = m_sceneNavAgentFaceYawSigns[static_cast<std::size_t>(meshIndex)];
     }
     const XVECTOR3 visualPosition(instance.Final.m41, instance.Final.m42, instance.Final.m43, 1.0f);
     std::string projectionError;
@@ -3432,6 +4210,7 @@ void SandboxScene::InitializeNavTestAgents() {
 }
 
 void SandboxScene::PlanNavTestAgentPaths() {
+  T8_TELEMETRY_SCOPE("navigation.agents.plan_paths");
   if (!m_navMesh.IsReady() || m_navTestAgents.empty()) {
     return;
   }
@@ -3441,7 +4220,7 @@ void SandboxScene::PlanNavTestAgentPaths() {
   std::vector<t850::navigation::NavPathRequest> requests;
   for (int i = 0; i < static_cast<int>(m_navTestAgents.size()); ++i) {
     NavTestAgentRuntime& agent = m_navTestAgents[static_cast<std::size_t>(i)];
-    if (!agent.active || !agent.needsPath || agent.repathCooldownSec > 0.0f ||
+    if (!agent.active || agent.physicsTraversalActive || !agent.needsPath || agent.repathCooldownSec > 0.0f ||
         agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
         !Meshes[agent.meshIndex].pBase) {
       continue;
@@ -3460,11 +4239,26 @@ void SandboxScene::PlanNavTestAgentPaths() {
   }
 
   if (requests.empty()) {
+    if (t850::RuntimeTelemetry::IsFrameActive()) {
+      t850::RuntimeTelemetry::SetCounter("navigation.agents.path_requests", 0.0);
+    }
     return;
+  }
+  if (t850::RuntimeTelemetry::IsFrameActive()) {
+    t850::RuntimeTelemetry::SetCounter("navigation.agents.path_requests", static_cast<double>(requests.size()));
   }
 
   std::vector<t850::navigation::NavPathResult> results;
-  m_navMesh.FindPaths(requests, results);
+  {
+    T8_TELEMETRY_SCOPE("navigation.agents.find_paths");
+    m_navMesh.FindPaths(requests, results);
+  }
+  int successfulPaths = 0;
+  int failedPaths = 0;
+  int totalPathPoints = 0;
+  int dropSegments = 0;
+  int jumpSegments = 0;
+  int jumpPadSegments = 0;
   for (std::size_t i = 0; i < agentIndices.size(); ++i) {
     NavTestAgentRuntime& agent = m_navTestAgents[static_cast<std::size_t>(agentIndices[i])];
     if (i >= requestGenerations.size() || agent.pathGeneration != requestGenerations[i]) {
@@ -3472,12 +4266,14 @@ void SandboxScene::PlanNavTestAgentPaths() {
     }
     agent.needsPath = false;
     if (i >= results.size() || !results[i].success || results[i].points.empty()) {
+      ++failedPaths;
       const PrimitiveInst& instance = Meshes[agent.meshIndex];
       const XVECTOR3 current(instance.Final.m41, instance.Final.m42, instance.Final.m43, 1.0f);
       agent.lastPathSuccess = false;
       agent.lastPathError = i < results.size() ? results[i].error : "missing result";
       agent.repathCooldownSec = kNavTestFailedPathRetrySec;
       agent.path.clear();
+      agent.pathSegmentTypes.clear();
       agent.waypointIndex = 0;
       if (m_navTestMode == kNavTestModeRandom) {
         agent.target = RandomNavTestPoint(m_navTestCandidatePoints,
@@ -3513,6 +4309,8 @@ void SandboxScene::PlanNavTestAgentPaths() {
       continue;
     }
 
+    ++successfulPaths;
+    totalPathPoints += static_cast<int>(results[i].points.size());
     agent.navPosition = results[i].points.front();
     agent.navToOriginOffset = agent.visualOffset;
     agent.lastPathFirst = results[i].points.front();
@@ -3520,11 +4318,41 @@ void SandboxScene::PlanNavTestAgentPaths() {
     agent.lastPathError.clear();
     agent.repathCooldownSec = 0.0f;
     agent.path = results[i].points;
+    agent.pathSegmentTypes.assign(agent.path.size() > 1 ? agent.path.size() - 1 : 0,
+                                  t850::navigation::NavTraversalType::Walk);
+    for (const t850::navigation::NavPathResult::Segment& segment : results[i].segments) {
+      if (segment.startPointIndex < 0 ||
+          segment.endPointIndex <= segment.startPointIndex ||
+          segment.endPointIndex > static_cast<int>(agent.path.size())) {
+        continue;
+      }
+      for (int pointIndex = segment.startPointIndex; pointIndex < segment.endPointIndex; ++pointIndex) {
+        if (pointIndex >= 0 && pointIndex < static_cast<int>(agent.pathSegmentTypes.size())) {
+          agent.pathSegmentTypes[static_cast<std::size_t>(pointIndex)] = segment.type;
+        }
+      }
+      if (segment.type == t850::navigation::NavTraversalType::Drop) {
+        ++dropSegments;
+      } else if (segment.type == t850::navigation::NavTraversalType::Jump) {
+        ++jumpSegments;
+      } else if (segment.type == t850::navigation::NavTraversalType::JumpPad) {
+        ++jumpPadSegments;
+      }
+    }
     agent.waypointIndex = agent.path.size() > 1 ? 1 : 0;
+  }
+  if (t850::RuntimeTelemetry::IsFrameActive()) {
+    t850::RuntimeTelemetry::SetCounter("navigation.agents.path_success", static_cast<double>(successfulPaths));
+    t850::RuntimeTelemetry::SetCounter("navigation.agents.path_fail", static_cast<double>(failedPaths));
+    t850::RuntimeTelemetry::SetCounter("navigation.agents.path_points", static_cast<double>(totalPathPoints));
+    t850::RuntimeTelemetry::SetCounter("navigation.agents.path_segments.drop", static_cast<double>(dropSegments));
+    t850::RuntimeTelemetry::SetCounter("navigation.agents.path_segments.jump", static_cast<double>(jumpSegments));
+    t850::RuntimeTelemetry::SetCounter("navigation.agents.path_segments.jump_pad", static_cast<double>(jumpPadSegments));
   }
 }
 
 void SandboxScene::UpdateNavTestAgents(float dtSecs) {
+  T8_TELEMETRY_SCOPE("navigation.agents.update");
   if (!m_loadedEditorScene) {
     return;
   }
@@ -3541,52 +4369,78 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
   if (m_navTestAgents.empty()) {
     return;
   }
-
-  for (NavTestAgentRuntime& agent : m_navTestAgents) {
-    if (!agent.active ||
-        agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
-        !Meshes[agent.meshIndex].pBase) {
-      continue;
+  if (t850::RuntimeTelemetry::IsFrameActive()) {
+    int activeAgents = 0;
+    int physicsAgents = 0;
+    int needsPathAgents = 0;
+    for (const NavTestAgentRuntime& agent : m_navTestAgents) {
+      if (agent.active) {
+        ++activeAgents;
+      }
+      if (agent.physicsTraversalActive) {
+        ++physicsAgents;
+      }
+      if (agent.needsPath) {
+        ++needsPathAgents;
+      }
     }
+    t850::RuntimeTelemetry::SetCounter("navigation.agents.count", static_cast<double>(m_navTestAgents.size()));
+    t850::RuntimeTelemetry::SetCounter("navigation.agents.active", static_cast<double>(activeAgents));
+    t850::RuntimeTelemetry::SetCounter("navigation.agents.physics_active", static_cast<double>(physicsAgents));
+    t850::RuntimeTelemetry::SetCounter("navigation.agents.needs_path", static_cast<double>(needsPathAgents));
+  }
 
-    agent.repathCooldownSec = (std::max)(0.0f, agent.repathCooldownSec - (std::max)(0.0f, dtSecs));
-    if (m_navTestMode == kNavTestModeFollowPlayer) {
-      XVECTOR3 desiredTarget;
-      XVECTOR3 projectedTarget;
-      std::string targetError;
-      if (ResolveNavTestFollowTarget(m_navMesh, Cam, agent.followSlot, desiredTarget, projectedTarget, &targetError)) {
-        agent.desiredTarget = desiredTarget;
-        if ((!agent.targetInitialized || agent.path.empty() || DistanceSquared(agent.target, projectedTarget) > 1.0f) &&
-            agent.repathCooldownSec <= 0.0f) {
-          agent.target = projectedTarget;
+  {
+    T8_TELEMETRY_SCOPE("navigation.agents.target_update");
+    for (NavTestAgentRuntime& agent : m_navTestAgents) {
+      if (!agent.active ||
+          agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
+          !Meshes[agent.meshIndex].pBase) {
+        continue;
+      }
+
+      agent.repathCooldownSec = (std::max)(0.0f, agent.repathCooldownSec - (std::max)(0.0f, dtSecs));
+      if (agent.physicsTraversalActive) {
+        continue;
+      }
+      if (m_navTestMode == kNavTestModeFollowPlayer) {
+        XVECTOR3 desiredTarget;
+        XVECTOR3 projectedTarget;
+        std::string targetError;
+        if (ResolveNavTestFollowTarget(m_navMesh, Cam, agent.followSlot, desiredTarget, projectedTarget, &targetError)) {
+          agent.desiredTarget = desiredTarget;
+          if ((!agent.targetInitialized || agent.path.empty() || DistanceSquared(agent.target, projectedTarget) > 1.0f) &&
+              agent.repathCooldownSec <= 0.0f) {
+            agent.target = projectedTarget;
+            agent.returning = false;
+            agent.needsPath = true;
+            agent.targetInitialized = true;
+          }
+        } else {
+          agent.desiredTarget = desiredTarget;
+          agent.lastPathSuccess = false;
+          agent.lastPathError = targetError;
+          agent.repathCooldownSec = kNavTestFailedPathRetrySec;
+          agent.needsPath = false;
+        }
+      } else if (m_navTestMode == kNavTestModeRandom) {
+        if (!agent.targetInitialized || (agent.path.empty() && !agent.needsPath)) {
+          agent.target = RandomNavTestPoint(m_navTestCandidatePoints,
+                                            agent.navPosition,
+                                            m_navTestRandomState,
+                                            static_cast<uint32_t>(agent.meshIndex + 17));
+          agent.desiredTarget = agent.target;
           agent.returning = false;
           agent.needsPath = true;
           agent.targetInitialized = true;
         }
-      } else {
-        agent.desiredTarget = desiredTarget;
-        agent.lastPathSuccess = false;
-        agent.lastPathError = targetError;
-        agent.repathCooldownSec = kNavTestFailedPathRetrySec;
-        agent.needsPath = false;
-      }
-    } else if (m_navTestMode == kNavTestModeRandom) {
-      if (!agent.targetInitialized || (agent.path.empty() && !agent.needsPath)) {
-        agent.target = RandomNavTestPoint(m_navTestCandidatePoints,
-                                          agent.navPosition,
-                                          m_navTestRandomState,
-                                          static_cast<uint32_t>(agent.meshIndex + 17));
+      } else if (!agent.targetInitialized) {
+        agent.target = FurthestNavTestPoint(m_navTestCandidatePoints, agent.home);
         agent.desiredTarget = agent.target;
         agent.returning = false;
         agent.needsPath = true;
         agent.targetInitialized = true;
       }
-    } else if (!agent.targetInitialized) {
-      agent.target = FurthestNavTestPoint(m_navTestCandidatePoints, agent.home);
-      agent.desiredTarget = agent.target;
-      agent.returning = false;
-      agent.needsPath = true;
-      agent.targetInitialized = true;
     }
   }
 
@@ -3595,20 +4449,328 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
   const float maxStep = (std::max)(0.0f, dtSecs) * m_navTestSpeed;
   std::vector<XVECTOR3> proposedPositions(m_navTestAgents.size());
   std::vector<unsigned char> movedAgents(m_navTestAgents.size(), 0);
+  std::vector<unsigned char> physicsMovedAgents(m_navTestAgents.size(), 0);
+  std::vector<unsigned char> suppressProjection(m_navTestAgents.size(), 0);
+  std::vector<unsigned char> jumpPadQueuedAgents(m_navTestAgents.size(), 0);
+  auto isJumpPadBaseOccupied = [&](std::size_t currentAgentIndex, const XVECTOR3& base) {
+    constexpr float kJumpPadBaseOccupiedRadiusSq = 4.0f;
+    float currentDistanceSq = 1.0e30f;
+    if (currentAgentIndex < m_navTestAgents.size()) {
+      currentDistanceSq = HorizontalDistanceSq3(m_navTestAgents[currentAgentIndex].navPosition, base);
+    }
+    for (std::size_t otherIndex = 0; otherIndex < m_navTestAgents.size(); ++otherIndex) {
+      if (otherIndex == currentAgentIndex) {
+        continue;
+      }
+      const NavTestAgentRuntime& other = m_navTestAgents[otherIndex];
+      if (!other.active) {
+        continue;
+      }
+
+      bool otherOwnsBase = false;
+      float otherDistanceSq = 1.0e30f;
+      if (other.physicsTraversalActive &&
+          other.physicsTraversalType == t850::navigation::NavTraversalType::JumpPad &&
+          !other.physicsWasAirborne &&
+          DistanceSquared(other.physicsTraversalStart, base) <= kJumpPadBaseOccupiedRadiusSq) {
+        otherOwnsBase = true;
+        otherDistanceSq = 0.0f;
+      } else if (!other.physicsTraversalActive &&
+                 !other.needsPath &&
+                 !other.path.empty() &&
+                 other.waypointIndex > 0 &&
+                 other.waypointIndex < static_cast<int>(other.path.size())) {
+        const int otherSegmentIndex = other.waypointIndex - 1;
+        const t850::navigation::NavTraversalType otherSegmentType =
+            otherSegmentIndex >= 0 && otherSegmentIndex < static_cast<int>(other.pathSegmentTypes.size())
+                ? other.pathSegmentTypes[static_cast<std::size_t>(otherSegmentIndex)]
+                : t850::navigation::NavTraversalType::Walk;
+        const XVECTOR3 otherBase = other.path[static_cast<std::size_t>(otherSegmentIndex)];
+        if (otherSegmentType == t850::navigation::NavTraversalType::JumpPad &&
+            DistanceSquared(otherBase, base) <= kJumpPadBaseOccupiedRadiusSq) {
+          otherDistanceSq = HorizontalDistanceSq3(other.navPosition, base);
+          otherOwnsBase =
+              otherDistanceSq + 0.01f < currentDistanceSq ||
+              (std::fabs(otherDistanceSq - currentDistanceSq) <= 0.01f && otherIndex < currentAgentIndex);
+        }
+      }
+
+      if (otherOwnsBase) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  auto findJumpPadForBase = [&](const XVECTOR3& base) -> const t850::Q3BspCollisionWorld::JumpPad* {
+    if (!m_q3CollisionWorld) {
+      return nullptr;
+    }
+
+    const t850::Q3BspCollisionWorld::JumpPad* bestJumpPad = nullptr;
+    float bestDistanceSq = 1.0e30f;
+    for (const t850::Q3BspCollisionWorld::JumpPad& jumpPad : m_q3CollisionWorld->GetJumpPads()) {
+      const bool insideHorizontal =
+          base.x >= jumpPad.mins.x - 1.0f && base.x <= jumpPad.maxs.x + 1.0f &&
+          base.z >= jumpPad.mins.z - 1.0f && base.z <= jumpPad.maxs.z + 1.0f;
+      const XVECTOR3 center(
+          (jumpPad.mins.x + jumpPad.maxs.x) * 0.5f,
+          (jumpPad.mins.y + jumpPad.maxs.y) * 0.5f,
+          (jumpPad.mins.z + jumpPad.maxs.z) * 0.5f,
+          1.0f);
+      const float distanceSq = HorizontalDistanceSq3(center, base);
+      if ((insideHorizontal || distanceSq <= 16.0f) && distanceSq < bestDistanceSq) {
+        bestDistanceSq = distanceSq;
+        bestJumpPad = &jumpPad;
+      }
+    }
+    return bestJumpPad;
+  };
+
+  auto jumpPadQueuePosition = [&](const NavTestAgentRuntime& agent,
+                                  const XVECTOR3& base,
+                                  std::size_t agentIndex) {
+    XVECTOR3 retreat(0.0f, 0.0f, 0.0f, 0.0f);
+    const int previousIndex = agent.waypointIndex - 2;
+    if (previousIndex >= 0 && previousIndex < static_cast<int>(agent.path.size())) {
+      retreat = agent.path[static_cast<std::size_t>(previousIndex)] - base;
+    }
+    retreat.y = 0.0f;
+    retreat.w = 0.0f;
+    if (retreat.Length() <= 0.0001f) {
+      retreat = agent.navPosition - base;
+      retreat.y = 0.0f;
+      retreat.w = 0.0f;
+    }
+    if (retreat.Length() <= 0.0001f) {
+      retreat = XVECTOR3(0.0f, 0.0f, -1.0f, 0.0f);
+    }
+    retreat.Normalize();
+
+    const t850::KinematicCharacterSettings q3Settings = t850::MakeQuake3CharacterSettings();
+    const float triggerMargin = q3Settings.capsuleRadius + 0.20f;
+    float queueDistance = 2.25f;
+    if (const t850::Q3BspCollisionWorld::JumpPad* jumpPad = findJumpPadForBase(base)) {
+      const float minX = jumpPad->mins.x - triggerMargin;
+      const float maxX = jumpPad->maxs.x + triggerMargin;
+      const float minZ = jumpPad->mins.z - triggerMargin;
+      const float maxZ = jumpPad->maxs.z + triggerMargin;
+      const bool baseInsideExpanded =
+          base.x >= minX && base.x <= maxX &&
+          base.z >= minZ && base.z <= maxZ;
+      if (baseInsideExpanded) {
+        float exitDistance = 1.0e30f;
+        if (std::fabs(retreat.x) > 0.0001f) {
+          const float boundary = retreat.x > 0.0f ? maxX : minX;
+          const float candidate = (boundary - base.x) / retreat.x;
+          if (candidate >= 0.0f) {
+            exitDistance = (std::min)(exitDistance, candidate);
+          }
+        }
+        if (std::fabs(retreat.z) > 0.0001f) {
+          const float boundary = retreat.z > 0.0f ? maxZ : minZ;
+          const float candidate = (boundary - base.z) / retreat.z;
+          if (candidate >= 0.0f) {
+            exitDistance = (std::min)(exitDistance, candidate);
+          }
+        }
+        if (exitDistance < 1.0e29f) {
+          queueDistance = (std::max)(queueDistance, exitDistance + q3Settings.capsuleRadius + 0.30f);
+        }
+      }
+    }
+
+    XVECTOR3 side(retreat.z, 0.0f, -retreat.x, 0.0f);
+    if (side.Length() > 0.0001f) {
+      side.Normalize();
+    }
+    const int laneIndex = static_cast<int>((agent.followSlot + static_cast<int>(agentIndex)) % 5) - 2;
+    const float laneOffset = static_cast<float>(laneIndex) * (q3Settings.capsuleRadius * 2.35f);
+    XVECTOR3 queued = base + retreat * queueDistance + side * laneOffset;
+
+    if (const t850::Q3BspCollisionWorld::JumpPad* jumpPad = findJumpPadForBase(base)) {
+      const float minX = jumpPad->mins.x - triggerMargin;
+      const float maxX = jumpPad->maxs.x + triggerMargin;
+      const float minZ = jumpPad->mins.z - triggerMargin;
+      const float maxZ = jumpPad->maxs.z + triggerMargin;
+      for (int guard = 0; guard < 8 &&
+          queued.x >= minX && queued.x <= maxX &&
+          queued.z >= minZ && queued.z <= maxZ; ++guard) {
+        queued += retreat * 0.50f;
+      }
+    }
+
+    queued.w = 1.0f;
+    return queued;
+  };
+
+  auto isJumpPadTraversalProtected = [&](std::size_t agentIndex) {
+    if (agentIndex >= m_navTestAgents.size()) {
+      return false;
+    }
+    const NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
+    return agent.active &&
+        agent.physicsTraversalActive &&
+        agent.physicsTraversalType == t850::navigation::NavTraversalType::JumpPad;
+  };
+
   for (std::size_t agentIndex = 0; agentIndex < m_navTestAgents.size(); ++agentIndex) {
     NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
-    if (!agent.active || agent.needsPath || agent.path.empty() ||
+    if (!agent.active ||
         agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
         !Meshes[agent.meshIndex].pBase) {
       continue;
     }
 
+    if (agent.physicsTraversalActive) {
+      T8_TELEMETRY_SCOPE("navigation.agents.physics_traversal");
+      if (t850::RuntimeTelemetry::IsFrameActive()) {
+        t850::RuntimeTelemetry::AddCounter("navigation.agents.physics_traversal.count", 1.0);
+        if (agent.physicsTraversalType == t850::navigation::NavTraversalType::Drop) {
+          t850::RuntimeTelemetry::AddCounter("navigation.agents.physics_traversal.drop", 1.0);
+        } else if (agent.physicsTraversalType == t850::navigation::NavTraversalType::Jump) {
+          t850::RuntimeTelemetry::AddCounter("navigation.agents.physics_traversal.jump", 1.0);
+        } else if (agent.physicsTraversalType == t850::navigation::NavTraversalType::JumpPad) {
+          t850::RuntimeTelemetry::AddCounter("navigation.agents.physics_traversal.jump_pad", 1.0);
+        }
+      }
+      const t850::KinematicCharacterSettings q3Settings = t850::MakeQuake3CharacterSettings();
+      agent.physicsController.SetSettings(q3Settings);
+      const XVECTOR3 physicsGround = Q3GroundPointFromCenter(agent.physicsController.GetPosition(), q3Settings);
+      XVECTOR3 steeringTarget = agent.physicsTarget;
+      if (m_navTestMode == kNavTestModeFollowPlayer) {
+        steeringTarget = agent.desiredTarget;
+      }
+      const bool jumpInput =
+          agent.physicsTraversalType == t850::navigation::NavTraversalType::Jump &&
+          agent.physicsTraversalTimeSec < 0.18f;
+      agent.physicsController.UpdateQuake3(
+          (std::max)(0.0f, dtSecs),
+          BuildNavAgentPhysicsInput(physicsGround, steeringTarget, jumpInput),
+          t850::CharacterControllerContext{this});
+      agent.physicsTraversalTimeSec += (std::max)(0.0f, dtSecs);
+      if (!agent.physicsController.IsGrounded()) {
+        agent.physicsWasAirborne = true;
+      }
+
+      XVECTOR3 navPosition = Q3GroundPointFromCenter(agent.physicsController.GetPosition(), q3Settings);
+      agent.navPosition = navPosition;
+      proposedPositions[agentIndex] = navPosition;
+      movedAgents[agentIndex] = 1;
+      physicsMovedAgents[agentIndex] = 1;
+
+      const float minTraversalTime = agent.physicsTraversalType == t850::navigation::NavTraversalType::JumpPad
+          ? 0.20f
+          : 0.35f;
+      const bool canReattach =
+          agent.physicsWasAirborne &&
+          agent.physicsTraversalTimeSec >= minTraversalTime &&
+          agent.physicsController.IsGrounded();
+      if (canReattach) {
+        XVECTOR3 projected;
+        if (m_navMesh.ProjectPoint(navPosition, projected, NavTestAgentProjectionExtents(), nullptr)) {
+          agent.navPosition = projected;
+          proposedPositions[agentIndex] = projected;
+        }
+        agent.physicsTraversalActive = false;
+        agent.physicsWasAirborne = false;
+        agent.physicsTraversalType = t850::navigation::NavTraversalType::Walk;
+        agent.physicsTraversalTimeSec = 0.0f;
+        agent.needsPath = true;
+        agent.repathCooldownSec = 0.0f;
+        agent.path.clear();
+        agent.pathSegmentTypes.clear();
+        agent.waypointIndex = 0;
+      } else if (agent.physicsTraversalTimeSec > 6.0f || navPosition.y < -64.0f) {
+        agent.physicsTraversalActive = false;
+        agent.physicsWasAirborne = false;
+        agent.physicsTraversalType = t850::navigation::NavTraversalType::Walk;
+        agent.physicsTraversalTimeSec = 0.0f;
+        agent.needsPath = true;
+        agent.repathCooldownSec = kNavTestFailedPathRetrySec;
+        agent.path.clear();
+        agent.pathSegmentTypes.clear();
+        agent.waypointIndex = 0;
+      }
+      continue;
+    }
+
+    if (agent.needsPath || agent.path.empty()) {
+      continue;
+    }
+
+    T8_TELEMETRY_SCOPE("navigation.agents.walk_follow");
+    if (t850::RuntimeTelemetry::IsFrameActive()) {
+      t850::RuntimeTelemetry::AddCounter("navigation.agents.walk_follow.count", 1.0);
+    }
     XVECTOR3 current = agent.navPosition;
     float remaining = maxStep;
     while (remaining > 0.0f && agent.waypointIndex < static_cast<int>(agent.path.size())) {
+      const int segmentIndex = agent.waypointIndex - 1;
+      const t850::navigation::NavTraversalType segmentType =
+          (segmentIndex >= 0 && segmentIndex < static_cast<int>(agent.pathSegmentTypes.size()))
+              ? agent.pathSegmentTypes[static_cast<std::size_t>(segmentIndex)]
+              : t850::navigation::NavTraversalType::Walk;
+      const XVECTOR3 segmentStart =
+          (segmentIndex >= 0 && segmentIndex < static_cast<int>(agent.path.size()))
+              ? agent.path[static_cast<std::size_t>(segmentIndex)]
+              : current;
       const XVECTOR3 target = agent.path[static_cast<std::size_t>(agent.waypointIndex)];
       XVECTOR3 delta = target - current;
       const float distance = delta.Length();
+      if (segmentType != t850::navigation::NavTraversalType::Walk) {
+        if (segmentType == t850::navigation::NavTraversalType::JumpPad) {
+          const XVECTOR3 jumpPadBase = segmentStart;
+          if (isJumpPadBaseOccupied(agentIndex, jumpPadBase)) {
+            if (t850::RuntimeTelemetry::IsFrameActive()) {
+              t850::RuntimeTelemetry::AddCounter("navigation.agents.jump_pad_wait", 1.0);
+            }
+            current = jumpPadQueuePosition(agent, jumpPadBase, agentIndex);
+            jumpPadQueuedAgents[agentIndex] = 1;
+            proposedPositions[agentIndex] = current;
+            movedAgents[agentIndex] = 1;
+            remaining = 0.0f;
+            break;
+          }
+
+          XVECTOR3 toBase = jumpPadBase - current;
+          const float baseDistance = toBase.Length();
+          if (baseDistance > 0.05f) {
+            if (baseDistance <= remaining) {
+              current = jumpPadBase;
+              remaining -= baseDistance;
+            } else {
+              toBase /= baseDistance;
+              current += toBase * remaining;
+              proposedPositions[agentIndex] = current;
+              movedAgents[agentIndex] = 1;
+              remaining = 0.0f;
+              break;
+            }
+          } else {
+            current = jumpPadBase;
+          }
+        }
+        const t850::KinematicCharacterSettings q3Settings = t850::MakeQuake3CharacterSettings();
+        agent.physicsController.SetSettings(q3Settings);
+        agent.physicsController.Reset();
+        agent.physicsController.SetPosition(Q3CenterFromGroundPoint(current, q3Settings));
+        agent.physicsTraversalStart = current;
+        agent.physicsTarget = target;
+        agent.physicsTargetWaypointIndex = agent.waypointIndex;
+        agent.physicsTraversalType = segmentType;
+        agent.physicsTraversalTimeSec = 0.0f;
+        agent.physicsTraversalActive = true;
+        agent.physicsWasAirborne = false;
+        if (t850::RuntimeTelemetry::IsFrameActive()) {
+          t850::RuntimeTelemetry::AddCounter("navigation.agents.physics_traversal.start", 1.0);
+        }
+        proposedPositions[agentIndex] = current;
+        movedAgents[agentIndex] = 1;
+        physicsMovedAgents[agentIndex] = 1;
+        remaining = 0.0f;
+        break;
+      }
       if (distance <= 0.0001f) {
         current = target;
         ++agent.waypointIndex;
@@ -3653,6 +4815,7 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
       }
       agent.needsPath = true;
       agent.path.clear();
+      agent.pathSegmentTypes.clear();
       agent.waypointIndex = 0;
     }
 
@@ -3660,48 +4823,147 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
       movedAgents[agentIndex] = 1;
   }
 
-  constexpr float kAgentSeparation = 1.2f;
-  constexpr float kAgentSeparationSq = kAgentSeparation * kAgentSeparation;
-  for (std::size_t a = 0; a < m_navTestAgents.size(); ++a) {
-      if (!movedAgents[a]) continue;
-      for (std::size_t b = a + 1; b < m_navTestAgents.size(); ++b) {
-        if (!movedAgents[b]) continue;
-        XVECTOR3 delta = proposedPositions[b] - proposedPositions[a];
-        delta.y = 0.0f;
-        const float distanceSq = delta.x * delta.x + delta.z * delta.z;
-        if (distanceSq <= 0.0001f || distanceSq >= kAgentSeparationSq) {
+  {
+    T8_TELEMETRY_SCOPE("navigation.agents.separation");
+    const t850::KinematicCharacterSettings q3Settings = t850::MakeQuake3CharacterSettings();
+    const float agentHalfX = q3Settings.capsuleRadius;
+    const float agentHalfZ = q3Settings.capsuleRadius;
+    const float playerHalfX = q3Settings.capsuleRadius;
+    const float playerHalfZ = q3Settings.capsuleRadius;
+    XVECTOR3 playerGround = Cam.Eye;
+    playerGround.y -= q3Settings.eyeHeight;
+    playerGround.w = 1.0f;
+
+    auto resolveAabbOverlap = [](XVECTOR3& first,
+                                 float firstHalfX,
+                                 float firstHalfZ,
+                                 XVECTOR3& second,
+                                 float secondHalfX,
+                                 float secondHalfZ,
+                                 bool moveFirst,
+                                 bool moveSecond) {
+      const float dx = second.x - first.x;
+      const float dz = second.z - first.z;
+      const float overlapX = firstHalfX + secondHalfX - std::fabs(dx);
+      const float overlapZ = firstHalfZ + secondHalfZ - std::fabs(dz);
+      if (overlapX <= 0.0f || overlapZ <= 0.0f) {
+        return false;
+      }
+
+      const bool pushX = overlapX < overlapZ;
+      const float direction = pushX
+          ? (dx >= 0.0f ? 1.0f : -1.0f)
+          : (dz >= 0.0f ? 1.0f : -1.0f);
+      const float amount = (pushX ? overlapX : overlapZ) + 0.01f;
+      const float firstShare = moveFirst && moveSecond ? 0.5f : (moveFirst ? 1.0f : 0.0f);
+      const float secondShare = moveFirst && moveSecond ? 0.5f : (moveSecond ? 1.0f : 0.0f);
+      if (pushX) {
+        first.x -= direction * amount * firstShare;
+        second.x += direction * amount * secondShare;
+      } else {
+        first.z -= direction * amount * firstShare;
+        second.z += direction * amount * secondShare;
+      }
+      return true;
+    };
+
+    for (std::size_t iteration = 0; iteration < 3; ++iteration) {
+      for (std::size_t agentIndex = 0; agentIndex < m_navTestAgents.size(); ++agentIndex) {
+        NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
+        if (!agent.active ||
+            agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
+            !Meshes[agent.meshIndex].pBase) {
           continue;
         }
-        const float distance = std::sqrt(distanceSq);
-        const float push = (kAgentSeparation - distance) * 0.5f;
-        delta /= distance;
-        proposedPositions[a] -= delta * push;
-        proposedPositions[b] += delta * push;
+        if (!movedAgents[agentIndex]) {
+          proposedPositions[agentIndex] = agent.navPosition;
+          movedAgents[agentIndex] = 1;
+        }
+        const bool agentProtected = isJumpPadTraversalProtected(agentIndex);
+        if (resolveAabbOverlap(playerGround,
+                               playerHalfX,
+                               playerHalfZ,
+                               proposedPositions[agentIndex],
+                               agentHalfX,
+                               agentHalfZ,
+                               false,
+                               !agentProtected)) {
+          if (t850::RuntimeTelemetry::IsFrameActive()) {
+            t850::RuntimeTelemetry::AddCounter("navigation.agents.aabb.player_overlaps", 1.0);
+          }
+        }
       }
+
+    for (std::size_t a = 0; a < m_navTestAgents.size(); ++a) {
+        if (!movedAgents[a]) continue;
+      for (std::size_t b = a + 1; b < m_navTestAgents.size(); ++b) {
+          if (!movedAgents[b]) continue;
+          const bool protectA = isJumpPadTraversalProtected(a);
+          const bool protectB = isJumpPadTraversalProtected(b);
+          if (protectA && protectB) {
+            continue;
+          }
+          if (resolveAabbOverlap(proposedPositions[a],
+                                 agentHalfX,
+                                 agentHalfZ,
+                                 proposedPositions[b],
+                                 agentHalfX,
+                                 agentHalfZ,
+                                 !protectA,
+                                 !protectB)) {
+            if (t850::RuntimeTelemetry::IsFrameActive()) {
+              t850::RuntimeTelemetry::AddCounter("navigation.agents.aabb.agent_overlaps", 1.0);
+            }
+          }
+        }
+
+        for (std::size_t agentIndex = 0; agentIndex < m_navTestAgents.size(); ++agentIndex) {
+          if (!jumpPadQueuedAgents[agentIndex]) {
+            continue;
+          }
+          NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
+          const int segmentIndex = agent.waypointIndex - 1;
+          if (segmentIndex >= 0 && segmentIndex < static_cast<int>(agent.path.size())) {
+            const XVECTOR3 base = agent.path[static_cast<std::size_t>(segmentIndex)];
+            proposedPositions[agentIndex] = jumpPadQueuePosition(agent, base, agentIndex);
+            movedAgents[agentIndex] = 1;
+          }
+        }
+      }
+    }
   }
 
-  for (std::size_t agentIndex = 0; agentIndex < m_navTestAgents.size(); ++agentIndex) {
-    NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
-    if (!agent.active ||
-        agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
-        !Meshes[agent.meshIndex].pBase) {
-      continue;
-    }
-
-    PrimitiveInst& instance = Meshes[agent.meshIndex];
-    if (movedAgents[agentIndex]) {
-      XVECTOR3 navPosition = proposedPositions[agentIndex];
-      if (!m_navMesh.ProjectPoint(navPosition, navPosition, NavTestAgentProjectionExtents(), nullptr)) {
-        navPosition = agent.navPosition;
+  {
+    T8_TELEMETRY_SCOPE("navigation.agents.apply_transforms");
+    for (std::size_t agentIndex = 0; agentIndex < m_navTestAgents.size(); ++agentIndex) {
+      NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
+      if (!agent.active ||
+          agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
+          !Meshes[agent.meshIndex].pBase) {
+        continue;
       }
-      agent.navPosition = navPosition;
-      agent.navToOriginOffset = agent.visualOffset;
-    }
 
-    const XVECTOR3 visualPosition = NavTestVisualPosition(agent.navPosition, agent.visualOffset);
-    instance.TranslateAbsolute(visualPosition.x, visualPosition.y, visualPosition.z);
-    RotateNavTestAgentToFace(instance, visualPosition, Cam.Eye, agent.frontYawOffsetDeg);
-    instance.Update();
+      PrimitiveInst& instance = Meshes[agent.meshIndex];
+      if (movedAgents[agentIndex]) {
+        XVECTOR3 navPosition = proposedPositions[agentIndex];
+        if (!physicsMovedAgents[agentIndex] && !jumpPadQueuedAgents[agentIndex] &&
+            !suppressProjection[agentIndex] &&
+            !m_navMesh.ProjectPoint(navPosition, navPosition, NavTestAgentProjectionExtents(), nullptr)) {
+          navPosition = agent.navPosition;
+        }
+        agent.navPosition = navPosition;
+        agent.navToOriginOffset = agent.visualOffset;
+        if (agent.physicsTraversalActive) {
+          const t850::KinematicCharacterSettings q3Settings = t850::MakeQuake3CharacterSettings();
+          agent.physicsController.SetPosition(Q3CenterFromGroundPoint(agent.navPosition, q3Settings));
+        }
+      }
+
+      const XVECTOR3 visualPosition = NavTestVisualPosition(agent.navPosition, agent.visualOffset);
+      instance.TranslateAbsolute(visualPosition.x, visualPosition.y, visualPosition.z);
+      RotateNavTestAgentToFace(instance, visualPosition, Cam.Eye, agent.frontYawOffsetDeg, agent.faceYawSign);
+      instance.Update();
+    }
   }
 
   if (m_navTestMode == kNavTestModeFollowPlayer) {
@@ -3775,11 +5037,53 @@ void SandboxScene::CreateAssets() {
 
   SceneProp.SSAOKernel.InitTexture();
 
-  EnvMapTexIndex = g_pBaseDriver->CreateTexture(string("sky/Ennis.dds"));
-  EnvMaps.SetFallback(EnvMapTexIndex);
   if (m_controlSetup.descriptor.name.empty()) {
     m_controlSetup.Load("Scenes/SandboxScene.json");
   }
+
+  const t850::SelectorDesc* cubemapDesc = FindSelectorDesc(m_controlSetup.descriptor.selectors, "cubemap");
+  const bool embeddedSceneProfile = !g_config.sceneFilePath.empty();
+  const std::string startupModelKey = embeddedSceneProfile ? std::string{} : SandboxProfileModelKey(g_config.modelPath);
+  std::vector<t850::SandboxProfileDesc> startupSceneProfiles;
+  const std::vector<t850::SandboxProfileDesc>* startupProfiles = &m_controlSetup.descriptor.profiles;
+  if (embeddedSceneProfile) {
+    t850::scene::EditorSceneFile startupScene;
+    std::string startupSceneError;
+    if (t850::scene::LoadEditorSceneFile(g_config.sceneFilePath, startupScene, &startupSceneError)) {
+      startupSceneProfiles = startupScene.profiles;
+      startupProfiles = &startupSceneProfiles;
+    } else {
+      T8_LOG_ERROR("[SandboxScene] Could not pre-read scene profiles from '%s': %s",
+                   g_config.sceneFilePath.c_str(), startupSceneError.c_str());
+    }
+  }
+  const CubemapSelection startupProfileCubemap =
+      ResolveStartupCubemapSelection(
+          m_controlSetup.descriptor.selectors,
+          *startupProfiles,
+          embeddedSceneProfile,
+          startupModelKey);
+  std::string startupCubemapPath = NormalizeSceneResourcePath(m_controlSetup.environmentMap);
+  if (startupCubemapPath.empty()) {
+    startupCubemapPath = "sky/Ennis.dds";
+  }
+  if (cubemapDesc && !startupProfileCubemap.path.empty()) {
+    startupCubemapPath = startupProfileCubemap.path;
+    const int startupCubemapIndex = startupProfileCubemap.index >= 0
+        ? startupProfileCubemap.index
+        : CubemapSelectorIndexForPath(*cubemapDesc, startupCubemapPath);
+    if (startupCubemapIndex >= 0) {
+      m_currentCubemapIndex = startupCubemapIndex;
+    }
+  } else if (cubemapDesc) {
+    const int environmentIndex = CubemapSelectorIndexForPath(*cubemapDesc, startupCubemapPath);
+    m_currentCubemapIndex = environmentIndex >= 0
+        ? environmentIndex
+        : (std::max)(0, (std::min)(cubemapDesc->default_index, static_cast<int>(cubemapDesc->options.size()) - 1));
+  }
+  EnvMapTexIndex = g_pBaseDriver->CreateTexture(startupCubemapPath);
+  m_currentCubemapPath = startupCubemapPath;
+  EnvMaps.SetFallback(EnvMapTexIndex);
   LoadEnvironmentIBLResources(
     g_pBaseDriver,
     {m_controlSetup.environmentDiffuseIBL, m_controlSetup.environmentSpecularIBL, m_controlSetup.environmentBrdfLUT,
@@ -3947,6 +5251,10 @@ void SandboxScene::OnDestoryScene() {
   UninstallSandboxConsoleLogCapture();
 }
 
+void SandboxScene::ResetViewInput() {
+  m_cameraController.ClearInput();
+}
+
 void SandboxScene::DestroyAssets() {
   SceneProp.SSAOKernel.Destroy();
   bool hasPhysicsLinks = m_floorBody.IsValid();
@@ -4016,12 +5324,16 @@ void SandboxScene::DestroyAssets() {
   m_sceneMeshPaths.clear();
   m_sceneRagdollPaths.clear();
   m_sceneNavAgentFrontYawOffsets.clear();
+  m_sceneNavAgentFaceYawSigns.clear();
   m_sceneRagdolls.clear();
   m_navTestAgents.clear();
   m_navTestCandidatePoints.clear();
   m_navTestInitialized = false;
   m_selectedSkinningMeshIndex = 0;
   m_selectedAnimationMeshIndex = 0;
+  m_currentCubemapIndex = 0;
+  m_currentCubemapPath.clear();
+  m_pendingCubemap.clear();
   m_debugText.Destroy();
   m_debugSphere.Destroy();
   if (m_lightArrowVB) m_lightArrowVB->release();
@@ -4041,59 +5353,63 @@ void SandboxScene::DestroyAssets() {
 }
 
 void SandboxScene::OnUpdate(float _DtSecs) {
+  T8_TELEMETRY_SCOPE("sandbox.update");
   DtSecs = _DtSecs;
   SceneProp.FrameDeltaSec = DtSecs;
-  if (!m_ragdollConfigSpeedApplied && g_config.ragdollSimulationSpeedIndex >= 0) {
-    m_ragdollSimulationSpeedIndex = ClampRagdollSimulationSpeedIndex(g_config.ragdollSimulationSpeedIndex);
-    m_ragdollConfigSpeedApplied = true;
-  }
-  m_ragdollSimulationSpeedIndex = ClampRagdollSimulationSpeedIndex(m_ragdollSimulationSpeedIndex);
-  t850::EngineContext* updateEngineContext = GetEngineContext();
-  if (!updateEngineContext) updateEngineContext = &t850::GetEngineContext();
-  if (updateEngineContext && updateEngineContext->physics) {
-    updateEngineContext->physics->SetSimulationSpeedScale(
-        RagdollSimulationSpeedScaleForIndex(m_ragdollSimulationSpeedIndex));
-    updateEngineContext->physics->SetUseFixedSimulationDelta(m_ragdollUseFixedSimulationDelta);
-  }
+  {
+    T8_TELEMETRY_SCOPE("sandbox.update.ragdoll_admin");
+    if (!m_ragdollConfigSpeedApplied && g_config.ragdollSimulationSpeedIndex >= 0) {
+      m_ragdollSimulationSpeedIndex = ClampRagdollSimulationSpeedIndex(g_config.ragdollSimulationSpeedIndex);
+      m_ragdollConfigSpeedApplied = true;
+    }
+    m_ragdollSimulationSpeedIndex = ClampRagdollSimulationSpeedIndex(m_ragdollSimulationSpeedIndex);
+    t850::EngineContext* updateEngineContext = GetEngineContext();
+    if (!updateEngineContext) updateEngineContext = &t850::GetEngineContext();
+    if (updateEngineContext && updateEngineContext->physics) {
+      updateEngineContext->physics->SetSimulationSpeedScale(
+          RagdollSimulationSpeedScaleForIndex(m_ragdollSimulationSpeedIndex));
+      updateEngineContext->physics->SetUseFixedSimulationDelta(m_ragdollUseFixedSimulationDelta);
+    }
 
-  if (m_ragdollClearRequested) {
-    BeginRagdollUndoScope("Clear all bodies");
-    ClearRagdollCapsules();
-    EndRagdollUndoScope(false);
-  }
-  if (m_ragdollEditRebuildRequested && !m_ragdollClearRequested) {
-    m_ragdollEditRebuildRequested = false;
-    ApplyRagdollEditPose(true);
-  }
-  if (g_config.flags.autoStartRagdoll &&
-      !m_ragdollAutoStartAttempted &&
-      ((Meshes[0].HasPhysicsRagdoll() && !m_ragdollPhysicsDriven) || !m_sceneRagdolls.empty())) {
-    m_ragdollAutoStartAttempted = true;
-    T8_LOG_INFO("[SandboxScene] Auto-starting ragdoll simulation at %s",
-                RagdollSimulationSpeedLabelForIndex(m_ragdollSimulationSpeedIndex));
-    SwitchRagdollToPhysics();
-  }
-  if (!m_ragdollSyncCliAttempted && HasCommandLineFlag("--ragdollSyncOnce")) {
-    ++m_ragdollSyncCliWaitFrames;
-    if (Meshes[0].pBase && !m_ragdollAnimationBinding.referencePose.bones.empty()) {
-      m_ragdollSyncCliAttempted = true;
-      T8_LOG_INFO("[RagdollEdit] --ragdollSyncOnce running for '%s'", g_config.modelPath.c_str());
-      if (!m_skeletonEditMode) {
-        EnterSkeletonEditMode();
-      }
-      if (m_skeletonEditMode) {
-        SyncRagdollCapsuleSymmetry();
-      } else {
-        T8_LOG_ERROR("[RagdollEdit] --ragdollSyncOnce could not enter edit mode");
-      }
-    } else if (m_ragdollSyncCliWaitFrames == 1 || (m_ragdollSyncCliWaitFrames % 120) == 0) {
-      T8_LOG_INFO("[RagdollEdit] --ragdollSyncOnce waiting: mesh=%s capsules=%zu model='%s'",
-                  Meshes[0].pBase ? "ready" : "not-ready",
-                  m_ragdollAnimationBinding.referencePose.bones.size(),
-                  g_config.modelPath.c_str());
-      if (m_ragdollSyncCliWaitFrames >= 1200) {
+    if (m_ragdollClearRequested) {
+      BeginRagdollUndoScope("Clear all bodies");
+      ClearRagdollCapsules();
+      EndRagdollUndoScope(false);
+    }
+    if (m_ragdollEditRebuildRequested && !m_ragdollClearRequested) {
+      m_ragdollEditRebuildRequested = false;
+      ApplyRagdollEditPose(true);
+    }
+    if (g_config.flags.autoStartRagdoll &&
+        !m_ragdollAutoStartAttempted &&
+        ((Meshes[0].HasPhysicsRagdoll() && !m_ragdollPhysicsDriven) || !m_sceneRagdolls.empty())) {
+      m_ragdollAutoStartAttempted = true;
+      T8_LOG_INFO("[SandboxScene] Auto-starting ragdoll simulation at %s",
+                  RagdollSimulationSpeedLabelForIndex(m_ragdollSimulationSpeedIndex));
+      SwitchRagdollToPhysics();
+    }
+    if (!m_ragdollSyncCliAttempted && HasCommandLineFlag("--ragdollSyncOnce")) {
+      ++m_ragdollSyncCliWaitFrames;
+      if (Meshes[0].pBase && !m_ragdollAnimationBinding.referencePose.bones.empty()) {
         m_ragdollSyncCliAttempted = true;
-        T8_LOG_ERROR("[RagdollEdit] --ragdollSyncOnce gave up after %d frames", m_ragdollSyncCliWaitFrames);
+        T8_LOG_INFO("[RagdollEdit] --ragdollSyncOnce running for '%s'", g_config.modelPath.c_str());
+        if (!m_skeletonEditMode) {
+          EnterSkeletonEditMode();
+        }
+        if (m_skeletonEditMode) {
+          SyncRagdollCapsuleSymmetry();
+        } else {
+          T8_LOG_ERROR("[RagdollEdit] --ragdollSyncOnce could not enter edit mode");
+        }
+      } else if (m_ragdollSyncCliWaitFrames == 1 || (m_ragdollSyncCliWaitFrames % 120) == 0) {
+        T8_LOG_INFO("[RagdollEdit] --ragdollSyncOnce waiting: mesh=%s capsules=%zu model='%s'",
+                    Meshes[0].pBase ? "ready" : "not-ready",
+                    m_ragdollAnimationBinding.referencePose.bones.size(),
+                    g_config.modelPath.c_str());
+        if (m_ragdollSyncCliWaitFrames >= 1200) {
+          m_ragdollSyncCliAttempted = true;
+          T8_LOG_ERROR("[RagdollEdit] --ragdollSyncOnce gave up after %d frames", m_ragdollSyncCliWaitFrames);
+        }
       }
     }
   }
@@ -4102,6 +5418,7 @@ void SandboxScene::OnUpdate(float _DtSecs) {
   // D3D12 texture upload submits a temp command list + fence wait, which
   // conflicts with the main command list if done mid-frame.
   if (!m_pendingCubemap.empty()) {
+    T8_TELEMETRY_SCOPE("sandbox.update.pending_cubemap");
     T8_LOG_INFO("[SandboxScene] Loading cubemap '%s' (old slot=%d)",
                 m_pendingCubemap.c_str(), EnvMapTexIndex);
     // Flush GPU before destroying — D3D12 may still reference the old
@@ -4112,6 +5429,7 @@ void SandboxScene::OnUpdate(float _DtSecs) {
       if (EnvMapTexIndex >= 0 && EnvMapTexIndex != newEnvMapTexIndex)
         g_pBaseDriver->DestroyTexture(EnvMapTexIndex);
       EnvMapTexIndex = newEnvMapTexIndex;
+      m_currentCubemapPath = m_pendingCubemap;
       if (m_controlSetup.environmentDiffuseIBL.empty() && DiffuseIBLTexIndex >= 0) {
         g_pBaseDriver->DestroyTexture(DiffuseIBLTexIndex);
         DiffuseIBLTexIndex = -1;
@@ -4159,6 +5477,7 @@ void SandboxScene::OnUpdate(float _DtSecs) {
 
   // Replay snapshot: load and apply (one-time)
   if (m_dumper.HasPendingReplay()) {
+    T8_TELEMETRY_SCOPE("sandbox.update.replay_snapshot");
     if (m_dumper.LoadReplaySnapshot()) {
       m_dumper.ApplySnapshot(Cam, LightCam, SceneProp);
       if (const t850::SnapshotSkinnedJson* skinnedSnap = m_dumper.GetReplaySkinnedState()) {
@@ -4170,26 +5489,42 @@ void SandboxScene::OnUpdate(float _DtSecs) {
       VP = Cam.VP;
     }
   }
-  m_dumper.UpdateReplayState();
+  {
+    T8_TELEMETRY_SCOPE("sandbox.update.dumper_state");
+    m_dumper.UpdateReplayState();
+  }
 
   if (!m_dumper.SkipCameraUpdates()) {
+    T8_TELEMETRY_SCOPE("sandbox.update.camera_and_lights");
     if (m_cameraController.GetActiveProfileType() == t850::CameraProfileType::Orbit) {
+      T8_TELEMETRY_SCOPE("sandbox.update.camera.sync_orbit_profile");
       SyncOrbitProfileFromSandbox();
     }
-    t850::CameraUpdateContext cameraContext;
-    cameraContext.collisionWorld = this;
-    m_cameraController.Update(DtSecs, cameraContext);
+    {
+      T8_TELEMETRY_SCOPE("sandbox.update.camera_controller");
+      t850::CameraUpdateContext cameraContext;
+      cameraContext.collisionWorld = this;
+      m_cameraController.Update(DtSecs, cameraContext);
+    }
     if (m_cameraController.GetActiveProfileType() == t850::CameraProfileType::Orbit) {
+      T8_TELEMETRY_SCOPE("sandbox.update.camera.sync_sandbox_orbit");
       SyncSandboxOrbitFromProfile();
     }
     VP = Cam.VP;
-    UpdateAttachedLights();
-    SyncLightCameraFromDirectionalLight();
+    {
+      T8_TELEMETRY_SCOPE("sandbox.update.attached_lights");
+      UpdateAttachedLights();
+      SyncLightCameraFromDirectionalLight();
+    }
   }
-  UpdateNavTestAgents(DtSecs);
+  {
+    T8_TELEMETRY_SCOPE("sandbox.update.nav_agents");
+    UpdateNavTestAgents(DtSecs);
+  }
 
   // --dumpMatrices: log all camera matrices per frame, then exit
   if (g_config.flags.dumpMatrices) {
+    T8_TELEMETRY_SCOPE("sandbox.update.dump_matrices");
     static int s_matDumpFrame = 0;
     static std::ofstream s_matFile;
     if (s_matDumpFrame == 0) {
@@ -4244,23 +5579,36 @@ void SandboxScene::OnUpdate(float _DtSecs) {
     }
   }
 
-  const int updateMeshCount = (std::max)(m_meshCount, Meshes[0].pBase ? 1 : 0);
-  for (int meshIndex = 0; meshIndex < updateMeshCount; ++meshIndex) {
-    if (!Meshes[meshIndex].pBase) continue;
-    RenderSkinnedMesh* skinned = Meshes[meshIndex].GetSkinnedMesh();
-    if (!skinned || !skinned->HasSkinData()) continue;
-    const bool sceneRagdollPhysicsDriven = IsSceneRagdollPhysicsDriven(meshIndex);
-    if (sceneRagdollPhysicsDriven) {
-      continue;
-    }
-    if (meshIndex == 0 && !m_ragdollPhysicsDriven) {
-      skinned->UpdateAnimationPose();
-      DriveRagdollFromAnimation(DtSecs);
-    } else if (meshIndex != 0) {
-      skinned->UpdateAnimationPose();
+  {
+    T8_TELEMETRY_SCOPE("sandbox.update.skinned_animation");
+    const int updateMeshCount = (std::max)(m_meshCount, Meshes[0].pBase ? 1 : 0);
+    for (int meshIndex = 0; meshIndex < updateMeshCount; ++meshIndex) {
+      if (!Meshes[meshIndex].pBase) continue;
+      RenderSkinnedMesh* skinned = Meshes[meshIndex].GetSkinnedMesh();
+      if (!skinned || !skinned->HasSkinData()) continue;
+      const bool sceneRagdollPhysicsDriven = IsSceneRagdollPhysicsDriven(meshIndex);
+      if (sceneRagdollPhysicsDriven) {
+        continue;
+      }
+      if (meshIndex == 0 && !m_ragdollPhysicsDriven) {
+        {
+          T8_TELEMETRY_SCOPE("sandbox.update.skinned_animation.primary_pose");
+          skinned->UpdateAnimationPose();
+        }
+        {
+          T8_TELEMETRY_SCOPE("sandbox.update.drive_primary_ragdoll");
+          DriveRagdollFromAnimation(DtSecs);
+        }
+      } else if (meshIndex != 0) {
+        T8_TELEMETRY_SCOPE("sandbox.update.skinned_animation.agent_pose");
+        skinned->UpdateAnimationPose();
+      }
     }
   }
-  DriveSceneRagdollsFromAnimation(DtSecs);
+  {
+    T8_TELEMETRY_SCOPE("sandbox.update.drive_scene_ragdolls");
+    DriveSceneRagdollsFromAnimation(DtSecs);
+  }
 }
 
 void SandboxScene::DriveRagdollFromAnimation(float deltaSeconds) {
@@ -13015,6 +14363,16 @@ void SandboxScene::CaptureSandboxProfileState(t850::SandboxProfileDesc& state) {
       ? std::string{}
       : (m_profileModelKey.empty() ? SandboxProfileModelKey(g_config.modelPath) : m_profileModelKey);
 
+  auto profileMeshPath = [&](int meshIndex) -> std::string {
+    if (meshIndex >= 0 && meshIndex < static_cast<int>(m_sceneMeshPaths.size())) {
+      return m_sceneMeshPaths[static_cast<std::size_t>(meshIndex)];
+    }
+    if (!m_profileModelKey.empty()) {
+      return m_profileModelKey;
+    }
+    return SandboxProfileModelKey(g_config.modelPath);
+  };
+
   auto addFloat = [&](const char* name, float value) {
     state.sliders.push_back({name, value});
   };
@@ -13024,6 +14382,15 @@ void SandboxScene::CaptureSandboxProfileState(t850::SandboxProfileDesc& state) {
   auto addInt = [&](const char* name, int value) {
     state.selectors.push_back({name, value});
   };
+
+  const t850::SelectorDesc* cubemapDesc = FindSelectorDesc(m_controlSetup.descriptor.selectors, "cubemap");
+  std::string selectedCubemapPath = NormalizeSceneResourcePath(m_pendingCubemap.empty() ? m_currentCubemapPath : m_pendingCubemap);
+  if (selectedCubemapPath.empty() && cubemapDesc) {
+    selectedCubemapPath = CubemapPathForSelectorIndex(*cubemapDesc, m_currentCubemapIndex);
+  }
+  if (!selectedCubemapPath.empty()) {
+    state.cubemap_path = selectedCubemapPath;
+  }
 
   addFloat("exposure", SceneProp.Exposure);
   addFloat("bloom_factor", SceneProp.BloomFactor);
@@ -13049,6 +14416,9 @@ void SandboxScene::CaptureSandboxProfileState(t850::SandboxProfileDesc& state) {
   addFloat("shadow_min", SceneProp.ShadowMin);
   addFloat("env_factor", SceneProp.EnvFactor);
   addFloat("ibl_factor", SceneProp.IBLFactor);
+  addFloat("ibl_mip_count", SceneProp.IBLMipCount);
+  addFloat("ibl_diffuse_mip_level", SceneProp.IBLDiffuseMipLevel);
+  addFloat("ibl_brdf_lut_enabled", SceneProp.IBLBRDFLUTEnabled);
   addFloat("material_emissive_intensity", SceneProp.MaterialEmissiveIntensity);
   addFloat("material_transmission_multiplier", SceneProp.MaterialTransmissionMultiplier);
   addFloat("material_refraction_strength", SceneProp.MaterialRefractionStrength);
@@ -13077,6 +14447,25 @@ void SandboxScene::CaptureSandboxProfileState(t850::SandboxProfileDesc& state) {
     addFloat("anim_speed", 1.0f);
     addInt("anim_select", 0);
     addInt("anim_mode", 0);
+  }
+
+  const int meshCount = GetRuntimeMeshCount();
+  for (int meshIndex = 0; meshIndex < meshCount && meshIndex < kMaxSandboxMeshes; ++meshIndex) {
+    RenderSkinnedMesh* skinned = GetSkinnedMeshForIndex(meshIndex);
+    if (!skinned) {
+      continue;
+    }
+
+    t850::SandboxAnimationOverrideDesc animation;
+    animation.index = meshIndex;
+    animation.mesh = profileMeshPath(meshIndex);
+    animation.anim_speed = skinned->GetAnimSpeed();
+    animation.anim_select = skinned->GetCurrentAnimSet();
+    animation.anim_mode = skinned->GetKeyframeMode() ? 1 : 0;
+    if (skinned->GetKeyframeMode()) {
+      animation.current_keyframe = skinned->GetCurrentKeyframe();
+    }
+    state.animations.push_back(animation);
   }
 
   addBool("shadow_toggle", SceneProp.ToogleShadow != 0);
@@ -13151,6 +14540,98 @@ void SandboxScene::CaptureSandboxProfileState(t850::SandboxProfileDesc& state) {
 }
 
 void SandboxScene::ApplySandboxProfileState(const t850::SandboxProfileDesc& state) {
+  auto applyCubemapPath = [&](const std::string& cubemapPath) {
+    const std::string normalizedPath = NormalizeSceneResourcePath(cubemapPath);
+    if (normalizedPath.empty()) {
+      return;
+    }
+
+    const t850::SelectorDesc* cubemapDesc = FindSelectorDesc(m_controlSetup.descriptor.selectors, "cubemap");
+    if (cubemapDesc) {
+      const int pathIndex = CubemapSelectorIndexForPath(*cubemapDesc, normalizedPath);
+      if (pathIndex >= 0) {
+        m_currentCubemapIndex = pathIndex;
+      }
+    }
+
+    if (!ResourcePathEquals(normalizedPath, m_currentCubemapPath)) {
+      m_pendingCubemap = normalizedPath;
+    }
+  };
+
+  const bool hasCubemapPath = state.cubemap_path.has_value() &&
+      !NormalizeSceneResourcePath(*state.cubemap_path).empty();
+  if (hasCubemapPath) {
+    applyCubemapPath(*state.cubemap_path);
+  }
+
+  auto profileMeshPath = [&](int meshIndex) -> std::string {
+    if (meshIndex >= 0 && meshIndex < static_cast<int>(m_sceneMeshPaths.size())) {
+      return m_sceneMeshPaths[static_cast<std::size_t>(meshIndex)];
+    }
+    if (!m_profileModelKey.empty()) {
+      return m_profileModelKey;
+    }
+    return SandboxProfileModelKey(g_config.modelPath);
+  };
+
+  auto resolveAnimationMeshIndex = [&](const t850::SandboxAnimationOverrideDesc& animation) -> int {
+    if (GetSkinnedMeshForIndex(animation.index) &&
+        (animation.mesh.empty() || ResourcePathEquals(animation.mesh, profileMeshPath(animation.index)))) {
+      return animation.index;
+    }
+    if (animation.mesh.empty()) {
+      return -1;
+    }
+
+    int matchedMeshIndex = -1;
+    const int meshCount = GetRuntimeMeshCount();
+    for (int meshIndex = 0; meshIndex < meshCount && meshIndex < kMaxSandboxMeshes; ++meshIndex) {
+      if (!GetSkinnedMeshForIndex(meshIndex) || !ResourcePathEquals(animation.mesh, profileMeshPath(meshIndex))) {
+        continue;
+      }
+      if (matchedMeshIndex >= 0) {
+        return -1;
+      }
+      matchedMeshIndex = meshIndex;
+    }
+    return matchedMeshIndex;
+  };
+
+  auto applyAnimationToMesh = [&](RenderSkinnedMesh* skinned,
+                                  const t850::SandboxAnimationOverrideDesc& animation) {
+    if (!skinned) {
+      return;
+    }
+    skinned->SetAnimSpeed(animation.anim_speed);
+    if (animation.anim_select >= 0 && animation.anim_select < skinned->GetNumAnimSets()) {
+      int guard = skinned->GetNumAnimSets() + 1;
+      while (skinned->GetCurrentAnimSet() != animation.anim_select && guard-- > 0) {
+        skinned->NextAnimation();
+      }
+    }
+
+    const bool keyframeMode = (animation.anim_mode == 1);
+    skinned->SetKeyframeMode(keyframeMode);
+    if (keyframeMode) {
+      skinned->StepKeyframe(0);
+    }
+    if (animation.current_keyframe.has_value()) {
+      const int targetKeyframe = *animation.current_keyframe;
+      int guard = skinned->GetTotalKeyframes() + 1;
+      while (skinned->GetCurrentKeyframe() != targetKeyframe && guard-- > 0) {
+        const int direction = targetKeyframe > skinned->GetCurrentKeyframe() ? 1 : -1;
+        skinned->StepKeyframe(direction);
+      }
+    }
+  };
+
+  for (const auto& value : state.selectors) {
+    if (value.name == "animation_model" && GetSkinnedMeshForIndex(value.value)) {
+      m_selectedAnimationMeshIndex = value.value;
+    }
+  }
+
   for (const auto& value : state.sliders) {
     if (value.name == "exposure") SceneProp.Exposure = value.value;
     else if (value.name == "bloom_factor") SceneProp.BloomFactor = value.value;
@@ -13177,6 +14658,9 @@ void SandboxScene::ApplySandboxProfileState(const t850::SandboxProfileDesc& stat
     else if (value.name == "shadow_min") SceneProp.ShadowMin = value.value;
     else if (value.name == "env_factor") SceneProp.EnvFactor = value.value;
     else if (value.name == "ibl_factor") SceneProp.IBLFactor = value.value;
+    else if (value.name == "ibl_mip_count") SceneProp.IBLMipCount = (std::max)(0.0f, value.value);
+    else if (value.name == "ibl_diffuse_mip_level") SceneProp.IBLDiffuseMipLevel = (std::max)(0.0f, value.value);
+    else if (value.name == "ibl_brdf_lut_enabled") SceneProp.IBLBRDFLUTEnabled = value.value > 0.5f ? 1.0f : 0.0f;
     else if (value.name == "material_emissive_intensity") SceneProp.MaterialEmissiveIntensity = value.value;
     else if (value.name == "material_transmission_multiplier") SceneProp.MaterialTransmissionMultiplier = value.value;
     else if (value.name == "material_refraction_strength") SceneProp.MaterialRefractionStrength = value.value;
@@ -13219,10 +14703,15 @@ void SandboxScene::ApplySandboxProfileState(const t850::SandboxProfileDesc& stat
     else if (value.name == "luminance_mode") SceneProp.LuminanceMode = value.value;
     else if (value.name == "active_light") m_selectedLightIndex = value.value;
     else if (value.name == "cubemap") {
-      const t850::SelectorDesc* cubemapDesc = FindSelectorDesc(m_controlSetup.descriptor.selectors, "cubemap");
+      const t850::SelectorDesc* cubemapDesc = hasCubemapPath
+          ? nullptr
+          : FindSelectorDesc(m_controlSetup.descriptor.selectors, "cubemap");
       if (cubemapDesc && value.value >= 0 && value.value < (int)cubemapDesc->options.size()) {
+        const std::string profileCubemapPath = CubemapPathForSelectorIndex(*cubemapDesc, value.value);
         m_currentCubemapIndex = value.value;
-        m_pendingCubemap = "sky/" + cubemapDesc->options[value.value];
+        if (!profileCubemapPath.empty() && !ResourcePathEquals(profileCubemapPath, m_currentCubemapPath)) {
+          m_pendingCubemap = profileCubemapPath;
+        }
       }
     }
     else if (value.name == "active_gauss_kernel") ChangeActiveGaussSelection = value.value;
@@ -13351,6 +14840,17 @@ void SandboxScene::ApplySandboxProfileState(const t850::SandboxProfileDesc& stat
       }
     }
   }
+
+  for (const auto& animation : state.animations) {
+    const int meshIndex = resolveAnimationMeshIndex(animation);
+    if (meshIndex < 0) {
+      T8_LOG_INFO("[SandboxScene] Skipped profile animation for mesh slot %d path='%s'",
+                  animation.index,
+                  animation.mesh.c_str());
+      continue;
+    }
+    applyAnimationToMesh(GetSkinnedMeshForIndex(meshIndex), animation);
+  }
 }
 
 t850::SandboxProfileDesc SandboxScene::BuildSparseSandboxProfile(const t850::SandboxProfileDesc& current) const {
@@ -13401,6 +14901,13 @@ t850::SandboxProfileDesc SandboxScene::BuildSparseSandboxProfile(const t850::San
       sparse.lights.push_back(lightSparse);
     }
   }
+  for (const auto& value : current.animations) {
+    const auto* baseline = FindAnimationOverride(m_profileBaselineState.animations, value.index);
+    if (!baseline || !AnimationOverrideNearlyEqual(value, *baseline)) {
+      sparse.animations.push_back(value);
+    }
+  }
+  if (current.cubemap_path != m_profileBaselineState.cubemap_path) sparse.cubemap_path = current.cubemap_path;
   if (current.frustum_culling != m_profileBaselineState.frustum_culling) sparse.frustum_culling = current.frustum_culling;
   if (current.show_culling_debug != m_profileBaselineState.show_culling_debug) sparse.show_culling_debug = current.show_culling_debug;
   if (current.current_keyframe != m_profileBaselineState.current_keyframe) sparse.current_keyframe = current.current_keyframe;
@@ -13422,15 +14929,19 @@ t850::SandboxProfileDesc SandboxScene::BuildSparseSandboxProfile(const t850::San
 }
 
 bool SandboxScene::SandboxProfileStatesEqual(const t850::SandboxProfileDesc& lhs, const t850::SandboxProfileDesc& rhs) const {
-  return BuildSparseSandboxProfile(lhs).sliders == BuildSparseSandboxProfile(rhs).sliders &&
-         BuildSparseSandboxProfile(lhs).checkboxes == BuildSparseSandboxProfile(rhs).checkboxes &&
-         BuildSparseSandboxProfile(lhs).selectors == BuildSparseSandboxProfile(rhs).selectors &&
-         BuildSparseSandboxProfile(lhs).lights == BuildSparseSandboxProfile(rhs).lights &&
-         BuildSparseSandboxProfile(lhs).camera == BuildSparseSandboxProfile(rhs).camera &&
-         BuildSparseSandboxProfile(lhs).orbit_camera == BuildSparseSandboxProfile(rhs).orbit_camera &&
-         BuildSparseSandboxProfile(lhs).frustum_culling == BuildSparseSandboxProfile(rhs).frustum_culling &&
-         BuildSparseSandboxProfile(lhs).show_culling_debug == BuildSparseSandboxProfile(rhs).show_culling_debug &&
-         BuildSparseSandboxProfile(lhs).current_keyframe == BuildSparseSandboxProfile(rhs).current_keyframe;
+  const t850::SandboxProfileDesc lhsSparse = BuildSparseSandboxProfile(lhs);
+  const t850::SandboxProfileDesc rhsSparse = BuildSparseSandboxProfile(rhs);
+  return lhsSparse.sliders == rhsSparse.sliders &&
+         lhsSparse.checkboxes == rhsSparse.checkboxes &&
+         lhsSparse.selectors == rhsSparse.selectors &&
+         lhsSparse.lights == rhsSparse.lights &&
+         lhsSparse.animations == rhsSparse.animations &&
+         lhsSparse.cubemap_path == rhsSparse.cubemap_path &&
+         lhsSparse.camera == rhsSparse.camera &&
+         lhsSparse.orbit_camera == rhsSparse.orbit_camera &&
+         lhsSparse.frustum_culling == rhsSparse.frustum_culling &&
+         lhsSparse.show_culling_debug == rhsSparse.show_culling_debug &&
+         lhsSparse.current_keyframe == rhsSparse.current_keyframe;
 }
 
 void SandboxScene::LoadSandboxProfile(bool embeddedInScene) {
@@ -13504,7 +15015,8 @@ void SandboxScene::SaveSandboxProfile() {
   auto existing = std::find_if(profiles.begin(), profiles.end(), profileMatchesSaveTarget);
 
   bool hasOverrides = !sparse.sliders.empty() || !sparse.checkboxes.empty() || !sparse.selectors.empty() ||
-                      !sparse.lights.empty() ||
+                      !sparse.lights.empty() || !sparse.animations.empty() ||
+                      sparse.cubemap_path.has_value() ||
                       sparse.camera.has_value() || sparse.orbit_camera.has_value() || sparse.frustum_culling.has_value() ||
                       sparse.show_culling_debug.has_value() || sparse.current_keyframe.has_value();
   if (hasOverrides) {
@@ -14183,10 +15695,14 @@ void SandboxScene::DrawDevGui(t850::DevGuiContext& gui) {
     switch (settingIndex) {
     case CHANGE_DEBUG_RT: m_debugRTSelection = selectedIndex; break;
     case CHANGE_CUBEMAP:
-      if (selectedIndex != m_currentCubemapIndex) {
-        m_currentCubemapIndex = selectedIndex;
-        m_pendingCubemap = "sky/" + sourceOptions[selectedIndex];
-        T8_LOG_INFO("[SandboxScene] Cubemap change queued: '%s'", m_pendingCubemap.c_str());
+      {
+        const std::string selectedCubemapPath = "sky/" + sourceOptions[selectedIndex];
+        const bool pathChanged = !ResourcePathEquals(selectedCubemapPath, m_currentCubemapPath);
+        if (selectedIndex != m_currentCubemapIndex || pathChanged) {
+          m_currentCubemapIndex = selectedIndex;
+          m_pendingCubemap = selectedCubemapPath;
+          T8_LOG_INFO("[SandboxScene] Cubemap change queued: '%s'", m_pendingCubemap.c_str());
+        }
       }
       break;
     case CHANGE_GAUSS_KERNEL_SAMPLE_COUNT: {

--- a/T850/DayScene/SandboxScene.cpp
+++ b/T850/DayScene/SandboxScene.cpp
@@ -4452,8 +4452,73 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
   std::vector<unsigned char> physicsMovedAgents(m_navTestAgents.size(), 0);
   std::vector<unsigned char> suppressProjection(m_navTestAgents.size(), 0);
   std::vector<unsigned char> jumpPadQueuedAgents(m_navTestAgents.size(), 0);
+  static std::vector<float> s_navProjectionDebugCooldownSec;
+  if (s_navProjectionDebugCooldownSec.size() != m_navTestAgents.size()) {
+    s_navProjectionDebugCooldownSec.assign(m_navTestAgents.size(), 0.0f);
+  }
+  for (float& cooldown : s_navProjectionDebugCooldownSec) {
+    cooldown = (std::max)(0.0f, cooldown - (std::max)(0.0f, dtSecs));
+  }
+
+  const t850::KinematicCharacterSettings jumpPadDebugSettings = t850::MakeQuake3CharacterSettings();
+  const XVECTOR3 jumpPadAgentHalfExtents(
+      jumpPadDebugSettings.capsuleRadius,
+      jumpPadDebugSettings.capsuleHalfHeight + jumpPadDebugSettings.capsuleRadius,
+      jumpPadDebugSettings.capsuleRadius,
+      0.0f);
+
+  auto findJumpPadForBase = [&](const XVECTOR3& base) -> const t850::Q3BspCollisionWorld::JumpPad* {
+    if (!m_q3CollisionWorld) {
+      return nullptr;
+    }
+
+    const t850::Q3BspCollisionWorld::JumpPad* bestJumpPad = nullptr;
+    float bestDistanceSq = 1.0e30f;
+    for (const t850::Q3BspCollisionWorld::JumpPad& jumpPad : m_q3CollisionWorld->GetJumpPads()) {
+      const bool insideHorizontal =
+          base.x >= jumpPad.mins.x - 1.0f && base.x <= jumpPad.maxs.x + 1.0f &&
+          base.z >= jumpPad.mins.z - 1.0f && base.z <= jumpPad.maxs.z + 1.0f;
+      const XVECTOR3 center(
+          (jumpPad.mins.x + jumpPad.maxs.x) * 0.5f,
+          (jumpPad.mins.y + jumpPad.maxs.y) * 0.5f,
+          (jumpPad.mins.z + jumpPad.maxs.z) * 0.5f,
+          1.0f);
+      const float distanceSq = HorizontalDistanceSq3(center, base);
+      if ((insideHorizontal || distanceSq <= 16.0f) && distanceSq < bestDistanceSq) {
+        bestDistanceSq = distanceSq;
+        bestJumpPad = &jumpPad;
+      }
+    }
+    return bestJumpPad;
+  };
+
+  auto agentAabbOverlapsJumpPad = [&](const XVECTOR3& position,
+                                      const t850::Q3BspCollisionWorld::JumpPad& jumpPad,
+                                      float margin) {
+    const XVECTOR3 min = position - jumpPadAgentHalfExtents;
+    const XVECTOR3 max = position + jumpPadAgentHalfExtents;
+    return max.x >= jumpPad.mins.x - margin &&
+        min.x <= jumpPad.maxs.x + margin &&
+        max.y >= jumpPad.mins.y - margin &&
+        min.y <= jumpPad.maxs.y + margin &&
+        max.z >= jumpPad.mins.z - margin &&
+        min.z <= jumpPad.maxs.z + margin;
+  };
+
+  auto traversalName = [](t850::navigation::NavTraversalType type) {
+    switch (type) {
+      case t850::navigation::NavTraversalType::Drop: return "Drop";
+      case t850::navigation::NavTraversalType::Jump: return "Jump";
+      case t850::navigation::NavTraversalType::JumpPad: return "JumpPad";
+      case t850::navigation::NavTraversalType::JumpIntent: return "JumpIntent";
+      case t850::navigation::NavTraversalType::Walk:
+      default: return "Walk";
+    }
+  };
+
   auto isJumpPadBaseOccupied = [&](std::size_t currentAgentIndex, const XVECTOR3& base) {
     constexpr float kJumpPadBaseOccupiedRadiusSq = 4.0f;
+    const t850::Q3BspCollisionWorld::JumpPad* jumpPad = findJumpPadForBase(base);
     float currentDistanceSq = 1.0e30f;
     if (currentAgentIndex < m_navTestAgents.size()) {
       currentDistanceSq = HorizontalDistanceSq3(m_navTestAgents[currentAgentIndex].navPosition, base);
@@ -4469,7 +4534,10 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
 
       bool otherOwnsBase = false;
       float otherDistanceSq = 1.0e30f;
-      if (other.physicsTraversalActive &&
+      if (jumpPad && agentAabbOverlapsJumpPad(other.navPosition, *jumpPad, 0.05f)) {
+        otherOwnsBase = true;
+        otherDistanceSq = HorizontalDistanceSq3(other.navPosition, base);
+      } else if (other.physicsTraversalActive &&
           other.physicsTraversalType == t850::navigation::NavTraversalType::JumpPad &&
           !other.physicsWasAirborne &&
           DistanceSquared(other.physicsTraversalStart, base) <= kJumpPadBaseOccupiedRadiusSq) {
@@ -4500,31 +4568,6 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
       }
     }
     return false;
-  };
-
-  auto findJumpPadForBase = [&](const XVECTOR3& base) -> const t850::Q3BspCollisionWorld::JumpPad* {
-    if (!m_q3CollisionWorld) {
-      return nullptr;
-    }
-
-    const t850::Q3BspCollisionWorld::JumpPad* bestJumpPad = nullptr;
-    float bestDistanceSq = 1.0e30f;
-    for (const t850::Q3BspCollisionWorld::JumpPad& jumpPad : m_q3CollisionWorld->GetJumpPads()) {
-      const bool insideHorizontal =
-          base.x >= jumpPad.mins.x - 1.0f && base.x <= jumpPad.maxs.x + 1.0f &&
-          base.z >= jumpPad.mins.z - 1.0f && base.z <= jumpPad.maxs.z + 1.0f;
-      const XVECTOR3 center(
-          (jumpPad.mins.x + jumpPad.maxs.x) * 0.5f,
-          (jumpPad.mins.y + jumpPad.maxs.y) * 0.5f,
-          (jumpPad.mins.z + jumpPad.maxs.z) * 0.5f,
-          1.0f);
-      const float distanceSq = HorizontalDistanceSq3(center, base);
-      if ((insideHorizontal || distanceSq <= 16.0f) && distanceSq < bestDistanceSq) {
-        bestDistanceSq = distanceSq;
-        bestJumpPad = &jumpPad;
-      }
-    }
-    return bestJumpPad;
   };
 
   auto jumpPadQueuePosition = [&](const NavTestAgentRuntime& agent,
@@ -4614,6 +4657,35 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
         agent.physicsTraversalType == t850::navigation::NavTraversalType::JumpPad;
   };
 
+  auto startJumpPadPhysicsTraversal = [&](std::size_t agentIndex,
+                                          NavTestAgentRuntime& agent,
+                                          const XVECTOR3& groundPosition,
+                                          const t850::Q3BspCollisionWorld::JumpPad& jumpPad,
+                                          const XVECTOR3& fallbackTarget) {
+    const t850::KinematicCharacterSettings q3Settings = t850::MakeQuake3CharacterSettings();
+    agent.physicsController.SetSettings(q3Settings);
+    agent.physicsController.Reset();
+    agent.physicsController.SetPosition(Q3CenterFromGroundPoint(groundPosition, q3Settings));
+    agent.physicsController.SetVelocity(jumpPad.velocity);
+    agent.physicsTraversalStart = groundPosition;
+    agent.physicsTarget = jumpPad.hasTargetPosition ? jumpPad.targetPosition : fallbackTarget;
+    agent.physicsTargetWaypointIndex = agent.waypointIndex;
+    agent.physicsTraversalType = t850::navigation::NavTraversalType::JumpPad;
+    agent.physicsTraversalTimeSec = 0.0f;
+    agent.physicsTraversalActive = true;
+    agent.physicsWasAirborne = false;
+    proposedPositions[agentIndex] = groundPosition;
+    movedAgents[agentIndex] = 1;
+    physicsMovedAgents[agentIndex] = 1;
+    T8_LOG_INFO("[JumpPadDebug] forced-trigger pad=%u agent=%zu mesh=%d pos=(%.2f,%.2f,%.2f) velocity=(%.2f,%.2f,%.2f) target=(%.2f,%.2f,%.2f)",
+                jumpPad.entityId,
+                agentIndex,
+                agent.meshIndex,
+                groundPosition.x, groundPosition.y, groundPosition.z,
+                jumpPad.velocity.x, jumpPad.velocity.y, jumpPad.velocity.z,
+                agent.physicsTarget.x, agent.physicsTarget.y, agent.physicsTarget.z);
+  };
+
   for (std::size_t agentIndex = 0; agentIndex < m_navTestAgents.size(); ++agentIndex) {
     NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
     if (!agent.active ||
@@ -4695,6 +4767,22 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
       continue;
     }
 
+    bool forcedJumpPadTrigger = false;
+    if (m_q3CollisionWorld) {
+      const XVECTOR3 currentPosition = agent.navPosition;
+      for (const t850::Q3BspCollisionWorld::JumpPad& jumpPad : m_q3CollisionWorld->GetJumpPads()) {
+        if (!agentAabbOverlapsJumpPad(currentPosition, jumpPad, 0.05f)) {
+          continue;
+        }
+        startJumpPadPhysicsTraversal(agentIndex, agent, currentPosition, jumpPad, agent.target);
+        forcedJumpPadTrigger = true;
+        break;
+      }
+    }
+    if (forcedJumpPadTrigger) {
+      continue;
+    }
+
     if (agent.needsPath || agent.path.empty()) {
       continue;
     }
@@ -4718,8 +4806,28 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
       const XVECTOR3 target = agent.path[static_cast<std::size_t>(agent.waypointIndex)];
       XVECTOR3 delta = target - current;
       const float distance = delta.Length();
-      if (segmentType != t850::navigation::NavTraversalType::Walk) {
-        if (segmentType == t850::navigation::NavTraversalType::JumpPad) {
+      t850::navigation::NavTraversalType effectiveSegmentType = segmentType;
+      if (effectiveSegmentType == t850::navigation::NavTraversalType::Walk && m_q3CollisionWorld) {
+        const t850::KinematicCharacterSettings q3Settings = t850::MakeQuake3CharacterSettings();
+        const float verticalDrop = current.y - target.y;
+        const float horizontalDistanceSq = HorizontalDistanceSq3(current, target);
+        const float forcedDropHeight = (std::max)(1.25f, q3Settings.stepHeight * 2.0f);
+        if (verticalDrop >= forcedDropHeight &&
+            horizontalDistanceSq >= q3Settings.capsuleRadius * q3Settings.capsuleRadius) {
+          effectiveSegmentType = t850::navigation::NavTraversalType::Drop;
+          T8_LOG_INFO("[NavTraversalDebug] forced_drop mesh=%d agent=%zu current=(%.2f,%.2f,%.2f) target=(%.2f,%.2f,%.2f) verticalDrop=%.2f horizontal=%.2f wp=%d path=%zu",
+                      agent.meshIndex,
+                      agentIndex,
+                      current.x, current.y, current.z,
+                      target.x, target.y, target.z,
+                      verticalDrop,
+                      std::sqrt(horizontalDistanceSq),
+                      agent.waypointIndex,
+                      agent.path.size());
+        }
+      }
+      if (effectiveSegmentType != t850::navigation::NavTraversalType::Walk) {
+        if (effectiveSegmentType == t850::navigation::NavTraversalType::JumpPad) {
           const XVECTOR3 jumpPadBase = segmentStart;
           if (isJumpPadBaseOccupied(agentIndex, jumpPadBase)) {
             if (t850::RuntimeTelemetry::IsFrameActive()) {
@@ -4758,7 +4866,7 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
         agent.physicsTraversalStart = current;
         agent.physicsTarget = target;
         agent.physicsTargetWaypointIndex = agent.waypointIndex;
-        agent.physicsTraversalType = segmentType;
+        agent.physicsTraversalType = effectiveSegmentType;
         agent.physicsTraversalTimeSec = 0.0f;
         agent.physicsTraversalActive = true;
         agent.physicsWasAirborne = false;
@@ -4917,16 +5025,176 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
           }
         }
 
+      }
+    }
+  }
+
+  for (std::size_t agentIndex = 0; agentIndex < m_navTestAgents.size(); ++agentIndex) {
+    if (!jumpPadQueuedAgents[agentIndex]) {
+      continue;
+    }
+    NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
+    const int segmentIndex = agent.waypointIndex - 1;
+    if (segmentIndex >= 0 && segmentIndex < static_cast<int>(agent.path.size())) {
+      const XVECTOR3 base = agent.path[static_cast<std::size_t>(segmentIndex)];
+      proposedPositions[agentIndex] = jumpPadQueuePosition(agent, base, agentIndex);
+      movedAgents[agentIndex] = 1;
+    }
+  }
+
+  {
+    static float s_jumpPadDebugLogTimerSec = 0.0f;
+    s_jumpPadDebugLogTimerSec += (std::max)(0.0f, dtSecs);
+    if (m_q3CollisionWorld && s_jumpPadDebugLogTimerSec >= 0.75f) {
+      s_jumpPadDebugLogTimerSec = 0.0f;
+      auto agentDebugPosition = [&](std::size_t agentIndex) {
+        return movedAgents[agentIndex] ? proposedPositions[agentIndex] : m_navTestAgents[agentIndex].navPosition;
+      };
+      auto agentMeshLabel = [&](const NavTestAgentRuntime& agent) -> const char* {
+        if (agent.meshIndex >= 0 && agent.meshIndex < static_cast<int>(m_sceneMeshPaths.size())) {
+          return m_sceneMeshPaths[static_cast<std::size_t>(agent.meshIndex)].c_str();
+        }
+        return "";
+      };
+      auto segmentTypeForAgent = [&](const NavTestAgentRuntime& agent) {
+        const int segmentIndex = agent.waypointIndex - 1;
+        return segmentIndex >= 0 && segmentIndex < static_cast<int>(agent.pathSegmentTypes.size())
+            ? agent.pathSegmentTypes[static_cast<std::size_t>(segmentIndex)]
+            : t850::navigation::NavTraversalType::Walk;
+      };
+      auto segmentBaseForAgent = [&](const NavTestAgentRuntime& agent) {
+        const int segmentIndex = agent.waypointIndex - 1;
+        return segmentIndex >= 0 && segmentIndex < static_cast<int>(agent.path.size())
+            ? agent.path[static_cast<std::size_t>(segmentIndex)]
+            : agent.navPosition;
+      };
+      auto segmentTargetForAgent = [&](const NavTestAgentRuntime& agent) {
+        return agent.waypointIndex >= 0 && agent.waypointIndex < static_cast<int>(agent.path.size())
+            ? agent.path[static_cast<std::size_t>(agent.waypointIndex)]
+            : agent.target;
+      };
+
+      for (const t850::Q3BspCollisionWorld::JumpPad& jumpPad : m_q3CollisionWorld->GetJumpPads()) {
+        const XVECTOR3 padCenter(
+            (jumpPad.mins.x + jumpPad.maxs.x) * 0.5f,
+            (jumpPad.mins.y + jumpPad.maxs.y) * 0.5f,
+            (jumpPad.mins.z + jumpPad.maxs.z) * 0.5f,
+            1.0f);
+        std::vector<std::size_t> relevantAgents;
+        int insideCount = 0;
+        int queuedCount = 0;
+        int attemptingCount = 0;
+        int physicsCount = 0;
+
         for (std::size_t agentIndex = 0; agentIndex < m_navTestAgents.size(); ++agentIndex) {
-          if (!jumpPadQueuedAgents[agentIndex]) {
+          const NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
+          if (!agent.active ||
+              agent.meshIndex < 0 || agent.meshIndex >= kMaxSandboxMeshes ||
+              !Meshes[agent.meshIndex].pBase) {
             continue;
           }
-          NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
-          const int segmentIndex = agent.waypointIndex - 1;
-          if (segmentIndex >= 0 && segmentIndex < static_cast<int>(agent.path.size())) {
-            const XVECTOR3 base = agent.path[static_cast<std::size_t>(segmentIndex)];
-            proposedPositions[agentIndex] = jumpPadQueuePosition(agent, base, agentIndex);
-            movedAgents[agentIndex] = 1;
+
+          const XVECTOR3 position = agentDebugPosition(agentIndex);
+          const bool inside = agentAabbOverlapsJumpPad(position, jumpPad, 0.05f);
+          const bool physicsJumpPad =
+              agent.physicsTraversalActive &&
+              agent.physicsTraversalType == t850::navigation::NavTraversalType::JumpPad;
+          const t850::navigation::NavTraversalType segmentType = segmentTypeForAgent(agent);
+          const XVECTOR3 segmentBase = segmentBaseForAgent(agent);
+          const bool attempting =
+              segmentType == t850::navigation::NavTraversalType::JumpPad &&
+              findJumpPadForBase(segmentBase) == &jumpPad;
+          const bool queued = jumpPadQueuedAgents[agentIndex] != 0 && attempting;
+          const bool physicsForPad =
+              physicsJumpPad &&
+              (findJumpPadForBase(agent.physicsTraversalStart) == &jumpPad || inside);
+          const bool nearby = HorizontalDistanceSq3(position, padCenter) <= 36.0f;
+
+          insideCount += inside ? 1 : 0;
+          queuedCount += queued ? 1 : 0;
+          attemptingCount += attempting ? 1 : 0;
+          physicsCount += physicsForPad ? 1 : 0;
+          if (inside || queued || attempting || physicsForPad || nearby) {
+            relevantAgents.push_back(agentIndex);
+          }
+        }
+
+        const bool shouldLog =
+            queuedCount > 0 ||
+            insideCount > 1 ||
+            attemptingCount > 1 ||
+            physicsCount > 0;
+        if (!shouldLog) {
+          continue;
+        }
+
+        T8_LOG_INFO("[JumpPadDebug] pad=%u bounds=(%.2f,%.2f,%.2f)-(%.2f,%.2f,%.2f) center=(%.2f,%.2f,%.2f) vel=(%.2f,%.2f,%.2f) inside=%d queued=%d attempting=%d physics=%d relevant=%zu",
+                    jumpPad.entityId,
+                    jumpPad.mins.x, jumpPad.mins.y, jumpPad.mins.z,
+                    jumpPad.maxs.x, jumpPad.maxs.y, jumpPad.maxs.z,
+                    padCenter.x, padCenter.y, padCenter.z,
+                    jumpPad.velocity.x, jumpPad.velocity.y, jumpPad.velocity.z,
+                    insideCount, queuedCount, attemptingCount, physicsCount, relevantAgents.size());
+
+        for (std::size_t agentIndex : relevantAgents) {
+          const NavTestAgentRuntime& agent = m_navTestAgents[agentIndex];
+          const XVECTOR3 position = agentDebugPosition(agentIndex);
+          const XVECTOR3 aabbMin = position - jumpPadAgentHalfExtents;
+          const XVECTOR3 aabbMax = position + jumpPadAgentHalfExtents;
+          const t850::navigation::NavTraversalType segmentType = segmentTypeForAgent(agent);
+          const XVECTOR3 segmentBase = segmentBaseForAgent(agent);
+          const XVECTOR3 segmentTarget = segmentTargetForAgent(agent);
+          const bool inside = agentAabbOverlapsJumpPad(position, jumpPad, 0.05f);
+          const bool attempting =
+              segmentType == t850::navigation::NavTraversalType::JumpPad &&
+              findJumpPadForBase(segmentBase) == &jumpPad;
+          const bool queued = jumpPadQueuedAgents[agentIndex] != 0 && attempting;
+          const bool physicsForPad =
+              agent.physicsTraversalActive &&
+              agent.physicsTraversalType == t850::navigation::NavTraversalType::JumpPad &&
+              (findJumpPadForBase(agent.physicsTraversalStart) == &jumpPad || inside);
+          T8_LOG_INFO("[JumpPadDebug] pad=%u agent=%zu mesh=%d '%s' pos=(%.2f,%.2f,%.2f) aabb=(%.2f,%.2f,%.2f)-(%.2f,%.2f,%.2f) inside=%d queued=%d attempting=%d physics=%d type=%s airborne=%d wp=%d path=%zu base=(%.2f,%.2f,%.2f) segTarget=(%.2f,%.2f,%.2f) distBase=%.2f target=(%.2f,%.2f,%.2f) desired=(%.2f,%.2f,%.2f) cooldown=%.3f",
+                      jumpPad.entityId,
+                      agentIndex,
+                      agent.meshIndex,
+                      agentMeshLabel(agent),
+                      position.x, position.y, position.z,
+                      aabbMin.x, aabbMin.y, aabbMin.z,
+                      aabbMax.x, aabbMax.y, aabbMax.z,
+                      inside ? 1 : 0,
+                      queued ? 1 : 0,
+                      attempting ? 1 : 0,
+                      physicsForPad ? 1 : 0,
+                      traversalName(segmentType),
+                      agent.physicsWasAirborne ? 1 : 0,
+                      agent.waypointIndex,
+                      agent.path.size(),
+                      segmentBase.x, segmentBase.y, segmentBase.z,
+                      segmentTarget.x, segmentTarget.y, segmentTarget.z,
+                      std::sqrt(HorizontalDistanceSq3(position, segmentBase)),
+                      agent.target.x, agent.target.y, agent.target.z,
+                      agent.desiredTarget.x, agent.desiredTarget.y, agent.desiredTarget.z,
+                      agent.repathCooldownSec);
+        }
+
+        for (std::size_t i = 0; i < relevantAgents.size(); ++i) {
+          for (std::size_t j = i + 1; j < relevantAgents.size(); ++j) {
+            const std::size_t a = relevantAgents[i];
+            const std::size_t b = relevantAgents[j];
+            const XVECTOR3 posA = agentDebugPosition(a);
+            const XVECTOR3 posB = agentDebugPosition(b);
+            const float overlapX = jumpPadAgentHalfExtents.x * 2.0f - std::fabs(posB.x - posA.x);
+            const float overlapZ = jumpPadAgentHalfExtents.z * 2.0f - std::fabs(posB.z - posA.z);
+            if (overlapX > 0.0f && overlapZ > 0.0f) {
+              T8_LOG_INFO("[JumpPadDebug] pad=%u overlap agents=%zu/%zu overlap=(%.3f,%.3f) posA=(%.2f,%.2f,%.2f) posB=(%.2f,%.2f,%.2f)",
+                          jumpPad.entityId,
+                          a,
+                          b,
+                          overlapX,
+                          overlapZ,
+                          posA.x, posA.y, posA.z,
+                          posB.x, posB.y, posB.z);
+            }
           }
         }
       }
@@ -4946,10 +5214,76 @@ void SandboxScene::UpdateNavTestAgents(float dtSecs) {
       PrimitiveInst& instance = Meshes[agent.meshIndex];
       if (movedAgents[agentIndex]) {
         XVECTOR3 navPosition = proposedPositions[agentIndex];
-        if (!physicsMovedAgents[agentIndex] && !jumpPadQueuedAgents[agentIndex] &&
-            !suppressProjection[agentIndex] &&
-            !m_navMesh.ProjectPoint(navPosition, navPosition, NavTestAgentProjectionExtents(), nullptr)) {
-          navPosition = agent.navPosition;
+        if (!physicsMovedAgents[agentIndex] &&
+            !jumpPadQueuedAgents[agentIndex] &&
+            !suppressProjection[agentIndex]) {
+          const XVECTOR3 requestedNavPosition = navPosition;
+          XVECTOR3 projectedNavPosition = navPosition;
+          std::string projectionError;
+          const bool projected = m_navMesh.ProjectPoint(
+              requestedNavPosition,
+              projectedNavPosition,
+              NavTestAgentProjectionExtents(),
+              &projectionError);
+
+          const float correctionSq = projected
+              ? DistanceSquared(requestedNavPosition, projectedNavPosition)
+              : 0.0f;
+          const bool largeCorrection = projected && correctionSq > 0.25f;
+          const bool shouldLogProjection =
+              (!projected || largeCorrection) &&
+              agentIndex < s_navProjectionDebugCooldownSec.size() &&
+              s_navProjectionDebugCooldownSec[agentIndex] <= 0.0f;
+
+          if (shouldLogProjection) {
+            s_navProjectionDebugCooldownSec[agentIndex] = 0.50f;
+            const int segmentIndex = agent.waypointIndex - 1;
+            const t850::navigation::NavTraversalType segmentType =
+                (segmentIndex >= 0 && segmentIndex < static_cast<int>(agent.pathSegmentTypes.size()))
+                    ? agent.pathSegmentTypes[static_cast<std::size_t>(segmentIndex)]
+                    : t850::navigation::NavTraversalType::Walk;
+            const XVECTOR3 segmentBase =
+                (segmentIndex >= 0 && segmentIndex < static_cast<int>(agent.path.size()))
+                    ? agent.path[static_cast<std::size_t>(segmentIndex)]
+                    : agent.navPosition;
+            const XVECTOR3 nextPoint =
+                (agent.waypointIndex >= 0 && agent.waypointIndex < static_cast<int>(agent.path.size()))
+                    ? agent.path[static_cast<std::size_t>(agent.waypointIndex)]
+                    : agent.target;
+            const float requestedMove = std::sqrt(HorizontalDistanceSq3(agent.navPosition, requestedNavPosition));
+            const float distToNext = std::sqrt(HorizontalDistanceSq3(agent.navPosition, nextPoint));
+            const float correction = projected ? std::sqrt(correctionSq) : 0.0f;
+            T8_LOG_INFO("[NavProjectionDebug] mesh=%d agent=%zu projected=%d largeCorrection=%d old=(%.2f,%.2f,%.2f) requested=(%.2f,%.2f,%.2f) projectedPos=(%.2f,%.2f,%.2f) requestedMoveXZ=%.3f correction=%.3f segment=%s wp=%d path=%zu base=(%.2f,%.2f,%.2f) next=(%.2f,%.2f,%.2f) distNext=%.3f target=(%.2f,%.2f,%.2f) desired=(%.2f,%.2f,%.2f) physics=%d queued=%d suppressed=%d err='%s'",
+                        agent.meshIndex,
+                        agentIndex,
+                        projected ? 1 : 0,
+                        largeCorrection ? 1 : 0,
+                        agent.navPosition.x, agent.navPosition.y, agent.navPosition.z,
+                        requestedNavPosition.x, requestedNavPosition.y, requestedNavPosition.z,
+                        projected ? projectedNavPosition.x : requestedNavPosition.x,
+                        projected ? projectedNavPosition.y : requestedNavPosition.y,
+                        projected ? projectedNavPosition.z : requestedNavPosition.z,
+                        requestedMove,
+                        correction,
+                        traversalName(segmentType),
+                        agent.waypointIndex,
+                        agent.path.size(),
+                        segmentBase.x, segmentBase.y, segmentBase.z,
+                        nextPoint.x, nextPoint.y, nextPoint.z,
+                        distToNext,
+                        agent.target.x, agent.target.y, agent.target.z,
+                        agent.desiredTarget.x, agent.desiredTarget.y, agent.desiredTarget.z,
+                        agent.physicsTraversalActive ? 1 : 0,
+                        jumpPadQueuedAgents[agentIndex] ? 1 : 0,
+                        suppressProjection[agentIndex] ? 1 : 0,
+                        projectionError.c_str());
+          }
+
+          if (projected) {
+            navPosition = projectedNavPosition;
+          } else {
+            navPosition = agent.navPosition;
+          }
         }
         agent.navPosition = navPosition;
         agent.navToOriginOffset = agent.visualOffset;

--- a/T850/DayScene/SandboxScene.h
+++ b/T850/DayScene/SandboxScene.h
@@ -108,6 +108,7 @@ public:
   void ResetAndroidVirtualControls();
 #endif
   void RequestDump() override { m_dumper.RequestDump(); }
+  void ResetViewInput() override;
 
   float DtSecs = 0.0f;
   t850::PrimitiveManager PrimitiveMgr;
@@ -167,6 +168,7 @@ public:
   int AdaptedLumPrevPass = -1;
 
   int m_currentCubemapIndex = 0;
+  std::string m_currentCubemapPath;
   std::string m_pendingCubemap; // deferred load — set in SyncFromGUI, applied in OnUpdate
 
   t850::TextRenderer m_debugText;
@@ -206,6 +208,7 @@ public:
   std::vector<std::string> m_sceneMeshPaths;
   std::vector<std::string> m_sceneRagdollPaths;
   std::vector<float> m_sceneNavAgentFrontYawOffsets;
+  std::vector<float> m_sceneNavAgentFaceYawSigns;
   std::vector<uint32_t> m_q3StaticCollisionEntityIds;
   struct SceneRagdollRuntime {
     int meshIndex = -1;
@@ -231,16 +234,26 @@ public:
     XVECTOR3 lastPathEnd = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
     XVECTOR3 lastPathFirst = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
     XVECTOR3 navToOriginOffset = XVECTOR3(0.0f, 0.0f, 0.0f, 0.0f);
+    t850::KinematicCharacterController physicsController;
+    XVECTOR3 physicsTraversalStart = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+    XVECTOR3 physicsTarget = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
     std::vector<XVECTOR3> path;
+    std::vector<t850::navigation::NavTraversalType> pathSegmentTypes;
     std::string lastPathError;
     int waypointIndex = 0;
+    int physicsTargetWaypointIndex = 0;
     int followSlot = 0;
     unsigned int pathGeneration = 0;
     float repathCooldownSec = 0.0f;
+    float physicsTraversalTimeSec = 0.0f;
     float frontYawOffsetDeg = 0.0f;
+    float faceYawSign = 1.0f;
+    t850::navigation::NavTraversalType physicsTraversalType = t850::navigation::NavTraversalType::Walk;
     bool returning = false;
     bool active = false;
     bool needsPath = false;
+    bool physicsTraversalActive = false;
+    bool physicsWasAirborne = false;
     bool targetInitialized = false;
     bool lastPathSuccess = false;
   };

--- a/T850/Framework/include/core/Core.h
+++ b/T850/Framework/include/core/Core.h
@@ -49,6 +49,7 @@ namespace t850 {
     // Return true if the app is currently showing a modal UI (e.g. a line-edit popup).
     // Frameworks use this to suppress global keys like Escape-to-quit while modal.
     virtual bool IsModalActive() const { return false; }
+    virtual bool WantsRelativeMouseMode() const { return false; }
 #ifdef OS_ANDROID
     virtual bool HandleAndroidInputEvent(AInputEvent* /*event*/) { return false; }
     virtual void OnAndroidNativeWindowChanged(ANativeWindow* /*window*/) {}
@@ -83,6 +84,8 @@ namespace t850 {
 
     // Request a frame dump (spacebar snapshot)
     virtual void RequestDump() {}
+
+    virtual void ResetViewInput() {}
 
     void SetEngineContext(EngineContext* context) { pEngineContext = context; }
     EngineContext* GetEngineContext() const { return pEngineContext; }

--- a/T850/Framework/include/core/windows/Win32Framework.h
+++ b/T850/Framework/include/core/windows/Win32Framework.h
@@ -45,6 +45,10 @@ namespace t850 {
     SDL_Window* m_pWindow;
     SDL_GLContext m_glContext;
   private:
+    void UpdateMouseMode();
+    void ReleaseMouseMode();
+    bool m_cursorConfined = false;
+    bool m_relativeMouseMode = false;
   };
 }
 

--- a/T850/Framework/include/navigation/NavigationDebugRenderer.h
+++ b/T850/Framework/include/navigation/NavigationDebugRenderer.h
@@ -38,12 +38,27 @@ private:
   IndexBuffer* m_indexBuffer = nullptr;
   VertexBuffer* m_graphVertexBuffer = nullptr;
   IndexBuffer* m_graphIndexBuffer = nullptr;
+  VertexBuffer* m_dropLinkVertexBuffer = nullptr;
+  IndexBuffer* m_dropLinkIndexBuffer = nullptr;
+  VertexBuffer* m_jumpLinkVertexBuffer = nullptr;
+  IndexBuffer* m_jumpLinkIndexBuffer = nullptr;
+  VertexBuffer* m_jumpPadLinkVertexBuffer = nullptr;
+  IndexBuffer* m_jumpPadLinkIndexBuffer = nullptr;
   unsigned m_vertexCapacity = 0;
   unsigned m_indexCapacity = 0;
   unsigned m_graphVertexCapacity = 0;
   unsigned m_graphIndexCapacity = 0;
+  unsigned m_dropLinkVertexCapacity = 0;
+  unsigned m_dropLinkIndexCapacity = 0;
+  unsigned m_jumpLinkVertexCapacity = 0;
+  unsigned m_jumpLinkIndexCapacity = 0;
+  unsigned m_jumpPadLinkVertexCapacity = 0;
+  unsigned m_jumpPadLinkIndexCapacity = 0;
   unsigned m_indexCount = 0;
   unsigned m_graphIndexCount = 0;
+  unsigned m_dropLinkIndexCount = 0;
+  unsigned m_jumpLinkIndexCount = 0;
+  unsigned m_jumpPadLinkIndexCount = 0;
   Texture* m_depthTexture = nullptr;
   int m_viewWidth = 1280;
   int m_viewHeight = 720;
@@ -53,6 +68,7 @@ private:
   const NavMesh* m_uploadedNavMesh = nullptr;
   int m_uploadedPolygonCount = 0;
   int m_uploadedDetailTriangleCount = 0;
+  int m_uploadedOffMeshLinkCount = 0;
   float m_uploadedVerticalOffset = -1.0f;
   float m_uploadedGraphVerticalOffset = -1.0f;
   NavMeshDebugShapeMode m_shapeMode = NavMeshDebugShapeMode::Geometry;
@@ -64,6 +80,15 @@ private:
   std::vector<XVECTOR3> m_graphPoints;
   std::vector<unsigned int> m_graphIndices;
   std::vector<float> m_graphVertices;
+  std::vector<XVECTOR3> m_dropLinkPoints;
+  std::vector<unsigned int> m_dropLinkIndices;
+  std::vector<float> m_dropLinkVertices;
+  std::vector<XVECTOR3> m_jumpLinkPoints;
+  std::vector<unsigned int> m_jumpLinkIndices;
+  std::vector<float> m_jumpLinkVertices;
+  std::vector<XVECTOR3> m_jumpPadLinkPoints;
+  std::vector<unsigned int> m_jumpPadLinkIndices;
+  std::vector<float> m_jumpPadLinkVertices;
 };
 
 } // namespace navigation

--- a/T850/Framework/include/navigation/NavigationSystem.h
+++ b/T850/Framework/include/navigation/NavigationSystem.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -41,11 +43,44 @@ struct NavMeshBuildSettings {
   float detailSampleDist = 6.0f;
   float detailSampleMaxError = 1.0f;
   XVECTOR3 queryExtents = XVECTOR3(2.0f, 4.0f, 2.0f, 0.0f);
+  bool enableAutoDropLinks = false;
+  float dropLinkMinHeight = 1.0f;
+  float dropLinkMaxHeight = 24.0f;
+  float dropLinkMaxHorizontalDistance = 2.4f;
+  float dropLinkSampleSpacing = 1.2f;
+  float dropLinkRadius = 0.75f;
+  bool enableAutoJumpLinks = false;
+  float jumpLinkMaxHorizontalDistance = 7.0f;
+  float jumpLinkSampleSpacing = 1.2f;
+  float jumpLinkRadius = 0.75f;
+  bool enableHybridJumpLinks = false;
+  int hybridJumpMaxLinks = 256;
+  uint64_t offMeshLinkValidationKey = 0;
+};
+
+enum class NavTraversalType : uint8_t {
+  Walk = 0,
+  Drop = 1,
+  Jump = 2,
+  JumpPad = 3,
+  JumpIntent = 4
+};
+
+struct NavOffMeshLink {
+  XVECTOR3 start = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+  XVECTOR3 end = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+  float radius = 0.75f;
+  bool bidirectional = false;
+  NavTraversalType type = NavTraversalType::Walk;
+  uint32_t userId = 0;
 };
 
 struct NavMeshGeometry {
   std::vector<XVECTOR3> vertices;
   std::vector<int> indices;
+  std::vector<NavOffMeshLink> offMeshLinks;
+  std::function<bool(const NavOffMeshLink&)> offMeshLinkValidator;
+  std::function<bool(const NavOffMeshLink&)> offMeshHybridLinkValidator;
 };
 
 struct NavMeshBuildStats {
@@ -55,6 +90,10 @@ struct NavMeshBuildStats {
   int height = 0;
   int polygonCount = 0;
   int detailTriangleCount = 0;
+  int offMeshLinkCount = 0;
+  int dropLinkCount = 0;
+  int jumpLinkCount = 0;
+  int jumpPadLinkCount = 0;
 };
 
 struct NavSourceBuildStats {
@@ -90,6 +129,12 @@ struct NavPathRequest {
 struct NavPathResult {
   bool success = false;
   std::vector<XVECTOR3> points;
+  struct Segment {
+    int startPointIndex = 0;
+    int endPointIndex = 0;
+    NavTraversalType type = NavTraversalType::Walk;
+  };
+  std::vector<Segment> segments;
   std::string error;
 };
 
@@ -124,6 +169,13 @@ public:
   bool Build(const NavMeshGeometry& geometry,
              const NavMeshBuildSettings& settings = NavMeshBuildSettings(),
              std::string* error = nullptr);
+  bool BuildCached(const NavMeshGeometry& geometry,
+                   const NavMeshBuildSettings& settings,
+                   uint64_t cacheKey,
+                   std::string* error = nullptr);
+  bool LoadCached(uint64_t cacheKey,
+                  const NavMeshBuildSettings& settings = NavMeshBuildSettings(),
+                  std::string* error = nullptr);
   bool BuildFromXDataBase(const xF::XDataBase& database,
                           const NavMeshBuildSettings& settings = NavMeshBuildSettings(),
                           std::string* error = nullptr);
@@ -151,6 +203,10 @@ public:
   bool GetDebugGraphEdges(std::vector<XVECTOR3>& outVertices,
                           std::vector<unsigned int>& outIndices,
                           float verticalOffset = 0.015f) const;
+  bool GetDebugOffMeshLinks(NavTraversalType type,
+                           std::vector<XVECTOR3>& outVertices,
+                           std::vector<unsigned int>& outIndices,
+                           float verticalOffset = 0.025f) const;
 
   const NavMeshBuildStats& GetStats() const override { return m_stats; }
 

--- a/T850/Framework/include/physics/Q3BspCollision.h
+++ b/T850/Framework/include/physics/Q3BspCollision.h
@@ -17,6 +17,7 @@ public:
   std::size_t GetBrushCount() const { return m_brushes.size(); }
   std::size_t GetPatchFacetCount() const { return m_patchFacets.size(); }
   std::size_t GetJumpPadCount() const { return m_jumpPads.size(); }
+  std::size_t GetReachabilityCount() const { return m_reachabilities.size(); }
 
   bool SweepCapsule(const CharacterCollisionSweep& sweep, CharacterCollisionHit& outHit) const override;
   bool SweepBox(const CharacterBoxSweep& sweep, CharacterCollisionHit& outHit) const override;
@@ -42,14 +43,32 @@ public:
     uint32_t entityId = 0;
     XVECTOR3 mins = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
     XVECTOR3 maxs = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+    XVECTOR3 targetPosition = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
     XVECTOR3 velocity = XVECTOR3(0.0f, 0.0f, 0.0f, 0.0f);
+    bool hasTargetPosition = false;
   };
+  const std::vector<JumpPad>& GetJumpPads() const { return m_jumpPads; }
+
+  struct Reachability {
+    uint32_t sourceArea = 0;
+    uint32_t targetArea = 0;
+    int face = 0;
+    int edge = 0;
+    XVECTOR3 start = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+    XVECTOR3 end = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+    std::string travelType;
+    uint32_t travelTypeId = 0;
+    uint32_t travelFlags = 0;
+    uint32_t travelTime = 0;
+  };
+  const std::vector<Reachability>& GetReachabilities() const { return m_reachabilities; }
 
 private:
   std::string m_resourcePath;
   std::vector<Brush> m_brushes;
   std::vector<PatchFacet> m_patchFacets;
   std::vector<JumpPad> m_jumpPads;
+  std::vector<Reachability> m_reachabilities;
   float m_surfaceClipEpsilon = 0.125f / 32.0f;
   float m_triggerTouchSlop = 1.0f / 32.0f;
 };

--- a/T850/Framework/include/scene/EditorSceneFile.h
+++ b/T850/Framework/include/scene/EditorSceneFile.h
@@ -25,6 +25,7 @@ struct SceneObjectDesc {
   bool frozen = false;
   bool show_wire = false;
   std::optional<float> nav_agent_front_yaw_offset_deg;
+  std::optional<float> nav_agent_face_yaw_sign;
 };
 
 struct SceneCameraDesc {

--- a/T850/Framework/include/scene/SceneDescriptor.h
+++ b/T850/Framework/include/scene/SceneDescriptor.h
@@ -193,6 +193,16 @@ namespace t850 {
     bool operator==(const SandboxLightOverrideDesc&) const = default;
   };
 
+  struct SandboxAnimationOverrideDesc {
+    int index = 0;
+    std::string mesh;
+    float anim_speed = 1.0f;
+    int anim_select = 0;
+    int anim_mode = 0;
+    std::optional<int> current_keyframe;
+    bool operator==(const SandboxAnimationOverrideDesc&) const = default;
+  };
+
   struct SandboxProfileDesc {
     std::string name;
     std::string platform;
@@ -204,6 +214,8 @@ namespace t850 {
     std::vector<BoolOverrideDesc> checkboxes;
     std::vector<IntOverrideDesc> selectors;
     std::vector<SandboxLightOverrideDesc> lights;
+    std::vector<SandboxAnimationOverrideDesc> animations;
+    std::optional<std::string> cubemap_path;
     std::optional<SandboxCameraDesc> camera;
     std::optional<SandboxOrbitCameraDesc> orbit_camera;
     std::optional<bool> frustum_culling;

--- a/T850/Framework/include/utils/CameraProfiles.h
+++ b/T850/Framework/include/utils/CameraProfiles.h
@@ -178,6 +178,7 @@ public:
   const OrbitCameraProfile* GetOrbitProfile() const;
 
   void HandleInput(const CameraInputState& input);
+  void ClearInput();
   void Update(float deltaSeconds, const CameraUpdateContext& context);
 
 private:

--- a/T850/Framework/include/video/vulkan/VulkanDriver.h
+++ b/T850/Framework/include/video/vulkan/VulkanDriver.h
@@ -58,6 +58,7 @@ namespace t850 {
     void SetWindow(void* window) override;
     void SetDimensions(int w, int h) override;
     void Clear() override;
+    void ClearWithColor(float r, float g, float b, float a) override;
     void SwapBuffers() override;
     void SetBlendState(BlendStates state) override;
     void SetDepthStencilState(DepthStencilStates state) override;

--- a/T850/Framework/src/core/windows/Win32Framework.cpp
+++ b/T850/Framework/src/core/windows/Win32Framework.cpp
@@ -31,6 +31,87 @@
 #include <debug/RuntimeTelemetry.h>
 #include <navigation/NavigationSystem.h>
 namespace t850 {
+  void Win32Framework::ReleaseMouseMode() {
+    if (m_pWindow && m_relativeMouseMode) {
+      SDL_SetWindowRelativeMouseMode(m_pWindow, false);
+    }
+    SDL_ShowCursor();
+    ClipCursor(nullptr);
+    m_cursorConfined = false;
+    m_relativeMouseMode = false;
+  }
+
+  void Win32Framework::UpdateMouseMode() {
+    if (!m_pWindow) {
+      ReleaseMouseMode();
+      return;
+    }
+
+    HWND hwnd = (HWND)SDL_GetPointerProperty(
+        SDL_GetWindowProperties(m_pWindow),
+        SDL_PROP_WINDOW_WIN32_HWND_POINTER,
+        NULL);
+    if (!hwnd || GetForegroundWindow() != hwnd || IsIconic(hwnd) || !IsWindowVisible(hwnd)) {
+      ReleaseMouseMode();
+      return;
+    }
+
+    const bool wantsRelativeMouse = pBaseApp && pBaseApp->WantsRelativeMouseMode();
+    if (wantsRelativeMouse) {
+      ClipCursor(nullptr);
+      m_cursorConfined = false;
+      if (!m_relativeMouseMode) {
+        SDL_SetWindowRelativeMouseMode(m_pWindow, true);
+        float discardX = 0.0f;
+        float discardY = 0.0f;
+        SDL_GetRelativeMouseState(&discardX, &discardY);
+      }
+      SDL_HideCursor();
+      m_relativeMouseMode = true;
+      return;
+    }
+
+    if (m_relativeMouseMode) {
+      SDL_SetWindowRelativeMouseMode(m_pWindow, false);
+      float discardX = 0.0f;
+      float discardY = 0.0f;
+      SDL_GetRelativeMouseState(&discardX, &discardY);
+      m_relativeMouseMode = false;
+    }
+    SDL_ShowCursor();
+
+    if (!pBaseApp || !pBaseApp->IsModalActive()) {
+      ClipCursor(nullptr);
+      m_cursorConfined = false;
+      return;
+    }
+
+    RECT clientRect = {};
+    if (!GetClientRect(hwnd, &clientRect) ||
+        clientRect.right <= clientRect.left ||
+        clientRect.bottom <= clientRect.top) {
+      ClipCursor(nullptr);
+      m_cursorConfined = false;
+      return;
+    }
+
+    POINT topLeft = { clientRect.left, clientRect.top };
+    POINT bottomRight = { clientRect.right, clientRect.bottom };
+    if (!ClientToScreen(hwnd, &topLeft) || !ClientToScreen(hwnd, &bottomRight)) {
+      ClipCursor(nullptr);
+      m_cursorConfined = false;
+      return;
+    }
+
+    RECT clipRect = { topLeft.x, topLeft.y, bottomRight.x, bottomRight.y };
+    if (ClipCursor(&clipRect)) {
+      m_cursorConfined = true;
+    } else if (m_cursorConfined) {
+      ClipCursor(nullptr);
+      m_cursorConfined = false;
+    }
+  }
+
   void Win32Framework::InitGlobalVars() {
 
 
@@ -56,6 +137,7 @@ namespace t850 {
     m_inited = true;
   }
   void Win32Framework::OnDestroyApplication() {
+    ReleaseMouseMode();
     pVideoDriver->FlushGPUResources();  // release cmd buffer/descriptor refs before scene cleanup
     pBaseApp->DestroyAssets();
     RuntimeTelemetry::Shutdown();
@@ -85,6 +167,7 @@ namespace t850 {
       ProcessInput();
       pBaseApp->OnUpdate();
     }
+    ReleaseMouseMode();
   }
   void Win32Framework::ProcessInput() {
     pBaseApp->IManager.scrollDelta = 0.0f;
@@ -111,8 +194,21 @@ namespace t850 {
       }break;
 
 	  case SDL_EVENT_QUIT: {
+      ReleaseMouseMode();
 		  m_alive = false;
 	  }break;
+
+      case SDL_EVENT_WINDOW_FOCUS_LOST:
+      case SDL_EVENT_WINDOW_MINIMIZED:
+      case SDL_EVENT_WINDOW_HIDDEN: {
+        ReleaseMouseMode();
+      } break;
+
+      case SDL_EVENT_WINDOW_FOCUS_GAINED:
+      case SDL_EVENT_WINDOW_RESTORED:
+      case SDL_EVENT_WINDOW_SHOWN: {
+        UpdateMouseMode();
+      } break;
 
       case SDL_EVENT_MOUSE_BUTTON_DOWN: {
         int btn = evento.button.button - 1; // SDL buttons are 1-based
@@ -141,10 +237,17 @@ namespace t850 {
 
       }
     }
+    UpdateMouseMode();
     static int xDelta = 0;
     static int yDelta = 0;
     static bool firstCall = true;
     int x = 0, y = 0;
+    float relativeX = 0.0f;
+    float relativeY = 0.0f;
+    const bool useRelativeMouse = m_relativeMouseMode && m_pWindow && SDL_GetWindowRelativeMouseMode(m_pWindow);
+    if (useRelativeMouse) {
+      SDL_GetRelativeMouseState(&relativeX, &relativeY);
+    }
 
 	POINT point;
 	GetCursorPos(&point);
@@ -160,6 +263,24 @@ namespace t850 {
     pBaseApp->IManager.mouseX = clientPt.x;
     pBaseApp->IManager.mouseY = clientPt.y;
 
+    if (useRelativeMouse) {
+      pBaseApp->IManager.xDelta = static_cast<int>(relativeX);
+      pBaseApp->IManager.yDelta = static_cast<int>(relativeY);
+      T8_LOG_VERBOSE("[MouseInput] mode=relative abs=(%d,%d) client=(%d,%d) rel=(%.3f,%.3f) delta=(%d,%d)",
+                     x,
+                     y,
+                     clientPt.x,
+                     clientPt.y,
+                     relativeX,
+                     relativeY,
+                     pBaseApp->IManager.xDelta,
+                     pBaseApp->IManager.yDelta);
+      xDelta = x;
+      yDelta = y;
+      firstCall = false;
+      return;
+    }
+
     if (firstCall) {
       firstCall = false;
       xDelta = x;
@@ -171,6 +292,15 @@ namespace t850 {
 
     pBaseApp->IManager.xDelta = xDelta;
     pBaseApp->IManager.yDelta = yDelta;
+    T8_LOG_VERBOSE("[MouseInput] mode=absolute abs=(%d,%d) client=(%d,%d) delta=(%d,%d) confined=%d relative=%d",
+                   x,
+                   y,
+                   clientPt.x,
+                   clientPt.y,
+                   pBaseApp->IManager.xDelta,
+                   pBaseApp->IManager.yDelta,
+                   m_cursorConfined ? 1 : 0,
+                   m_relativeMouseMode ? 1 : 0);
 
     xDelta = x;
     yDelta = y;
@@ -186,6 +316,7 @@ namespace t850 {
     }
 #endif
     if (m_inited) {
+      ReleaseMouseMode();
       pVideoDriver->FlushGPUResources();  // release cmd buffer/descriptor refs before scene cleanup
       pBaseApp->DestroyAssets();
       pVideoDriver->DestroyDriver();
@@ -201,6 +332,7 @@ namespace t850 {
       m_glContext = nullptr;
     }
     if (m_pWindow) {
+      ReleaseMouseMode();
       SDL_DestroyWindow(m_pWindow);
       m_pWindow = nullptr;
     }

--- a/T850/Framework/src/navigation/NavigationDebugRenderer.cpp
+++ b/T850/Framework/src/navigation/NavigationDebugRenderer.cpp
@@ -14,6 +14,89 @@ namespace t850 {
 namespace t850 {
 namespace navigation {
 
+namespace {
+
+void ReleaseLineBuffers(VertexBuffer*& vertexBuffer,
+                        IndexBuffer*& indexBuffer,
+                        unsigned& vertexCapacity,
+                        unsigned& indexCapacity,
+                        unsigned& indexCount) {
+  if (vertexBuffer) {
+    vertexBuffer->release();
+    vertexBuffer = nullptr;
+  }
+  if (indexBuffer) {
+    indexBuffer->release();
+    indexBuffer = nullptr;
+  }
+  vertexCapacity = 0;
+  indexCapacity = 0;
+  indexCount = 0;
+}
+
+bool UploadLineBuffers(const char* debugName,
+                       const std::vector<XVECTOR3>& points,
+                       std::vector<unsigned int>& indices,
+                       std::vector<float>& vertices,
+                       VertexBuffer*& vertexBuffer,
+                       IndexBuffer*& indexBuffer,
+                       unsigned& vertexCapacity,
+                       unsigned& indexCapacity,
+                       unsigned& indexCount) {
+  vertices.clear();
+  vertices.reserve(points.size() * 4u);
+  for (const XVECTOR3& point : points) {
+    vertices.push_back(point.x);
+    vertices.push_back(point.y);
+    vertices.push_back(point.z);
+    vertices.push_back(1.0f);
+  }
+
+  const unsigned vertexCount = static_cast<unsigned>(vertices.size() / 4u);
+  const unsigned newIndexCount = static_cast<unsigned>(indices.size());
+  if (vertexCount == 0 || newIndexCount == 0) {
+    indexCount = 0;
+    return true;
+  }
+
+  if (!vertexBuffer || !indexBuffer ||
+      vertexCount > vertexCapacity ||
+      newIndexCount > indexCapacity) {
+    ReleaseLineBuffers(vertexBuffer, indexBuffer, vertexCapacity, indexCapacity, indexCount);
+
+    vertexBuffer = LineRenderer::CreatePositionVB(vertices.data(), vertexCount, BufferUsage::DINAMIC);
+
+    BufferDesc indexDesc;
+    indexDesc.byteWidth = static_cast<int>(sizeof(unsigned int) * newIndexCount);
+    indexDesc.usage = BufferUsage::DINAMIC;
+    indexBuffer = T8Device ? static_cast<IndexBuffer*>(
+        T8Device->CreateBuffer(BufferType::INDEX, indexDesc, indices.data())) : nullptr;
+
+    if (!vertexBuffer || !indexBuffer) {
+      T8_LOG_ERROR("[NavigationDebugRenderer] Failed to create %s line buffers", debugName);
+      ReleaseLineBuffers(vertexBuffer, indexBuffer, vertexCapacity, indexCapacity, indexCount);
+      return false;
+    }
+
+    vertexCapacity = vertexCount;
+    indexCapacity = newIndexCount;
+  } else {
+    if (!T8DeviceContext) {
+      return false;
+    }
+    vertices.resize(static_cast<std::size_t>(vertexCapacity) * 4u, 0.0f);
+    std::vector<unsigned int> paddedIndices = indices;
+    paddedIndices.resize(indexCapacity, 0u);
+    vertexBuffer->UpdateFromBuffer(*T8DeviceContext, vertices.data());
+    indexBuffer->UpdateFromBuffer(*T8DeviceContext, paddedIndices.data());
+  }
+
+  indexCount = newIndexCount;
+  return true;
+}
+
+} // namespace
+
 bool NavMeshDebugRenderer::Create() {
   return m_lineRenderer.Create();
 }
@@ -27,11 +110,15 @@ void NavMeshDebugRenderer::Invalidate() {
   m_uploadedNavMesh = nullptr;
   m_uploadedPolygonCount = 0;
   m_uploadedDetailTriangleCount = 0;
+  m_uploadedOffMeshLinkCount = 0;
   m_uploadedVerticalOffset = -1.0f;
   m_uploadedGraphVerticalOffset = -1.0f;
   m_uploadedShapeMode = m_shapeMode;
   m_indexCount = 0;
   m_graphIndexCount = 0;
+  m_dropLinkIndexCount = 0;
+  m_jumpLinkIndexCount = 0;
+  m_jumpPadLinkIndexCount = 0;
 }
 
 void NavMeshDebugRenderer::ReleaseGeometryBuffers() {
@@ -51,10 +138,40 @@ void NavMeshDebugRenderer::ReleaseGeometryBuffers() {
     m_graphIndexBuffer->release();
     m_graphIndexBuffer = nullptr;
   }
+  if (m_dropLinkVertexBuffer) {
+    m_dropLinkVertexBuffer->release();
+    m_dropLinkVertexBuffer = nullptr;
+  }
+  if (m_dropLinkIndexBuffer) {
+    m_dropLinkIndexBuffer->release();
+    m_dropLinkIndexBuffer = nullptr;
+  }
+  if (m_jumpLinkVertexBuffer) {
+    m_jumpLinkVertexBuffer->release();
+    m_jumpLinkVertexBuffer = nullptr;
+  }
+  if (m_jumpLinkIndexBuffer) {
+    m_jumpLinkIndexBuffer->release();
+    m_jumpLinkIndexBuffer = nullptr;
+  }
+  if (m_jumpPadLinkVertexBuffer) {
+    m_jumpPadLinkVertexBuffer->release();
+    m_jumpPadLinkVertexBuffer = nullptr;
+  }
+  if (m_jumpPadLinkIndexBuffer) {
+    m_jumpPadLinkIndexBuffer->release();
+    m_jumpPadLinkIndexBuffer = nullptr;
+  }
   m_vertexCapacity = 0;
   m_indexCapacity = 0;
   m_graphVertexCapacity = 0;
   m_graphIndexCapacity = 0;
+  m_dropLinkVertexCapacity = 0;
+  m_dropLinkIndexCapacity = 0;
+  m_jumpLinkVertexCapacity = 0;
+  m_jumpLinkIndexCapacity = 0;
+  m_jumpPadLinkVertexCapacity = 0;
+  m_jumpPadLinkIndexCapacity = 0;
   Invalidate();
 }
 
@@ -64,6 +181,7 @@ bool NavMeshDebugRenderer::UploadGeometry(const NavMesh& navMesh) {
       m_uploadedNavMesh == &navMesh &&
       m_uploadedPolygonCount == stats.polygonCount &&
       m_uploadedDetailTriangleCount == stats.detailTriangleCount &&
+      m_uploadedOffMeshLinkCount == stats.offMeshLinkCount &&
       m_uploadedVerticalOffset == m_verticalOffset &&
       m_uploadedGraphVerticalOffset == m_graphVerticalOffset &&
       m_uploadedShapeMode == m_shapeMode) {
@@ -137,78 +255,69 @@ bool NavMeshDebugRenderer::UploadGeometry(const NavMesh& navMesh) {
   }
 
   navMesh.GetDebugGraphEdges(m_graphPoints, m_graphIndices, m_graphVerticalOffset);
-  m_graphVertices.clear();
-  m_graphVertices.reserve(m_graphPoints.size() * 4u);
-  for (const XVECTOR3& point : m_graphPoints) {
-    m_graphVertices.push_back(point.x);
-    m_graphVertices.push_back(point.y);
-    m_graphVertices.push_back(point.z);
-    m_graphVertices.push_back(1.0f);
+  if (!UploadLineBuffers("navmesh graph edge",
+                         m_graphPoints,
+                         m_graphIndices,
+                         m_graphVertices,
+                         m_graphVertexBuffer,
+                         m_graphIndexBuffer,
+                         m_graphVertexCapacity,
+                         m_graphIndexCapacity,
+                         m_graphIndexCount)) {
+    return false;
   }
 
-  const unsigned graphVertexCount = static_cast<unsigned>(m_graphVertices.size() / 4u);
-  const unsigned graphIndexCount = static_cast<unsigned>(m_graphIndices.size());
-  if (graphVertexCount == 0 || graphIndexCount == 0) {
-    m_graphIndexCount = 0;
-  } else if (!m_graphVertexBuffer || !m_graphIndexBuffer ||
-             graphVertexCount > m_graphVertexCapacity ||
-             graphIndexCount > m_graphIndexCapacity) {
-    if (m_graphVertexBuffer) {
-      m_graphVertexBuffer->release();
-      m_graphVertexBuffer = nullptr;
-    }
-    if (m_graphIndexBuffer) {
-      m_graphIndexBuffer->release();
-      m_graphIndexBuffer = nullptr;
-    }
-    m_graphVertexCapacity = 0;
-    m_graphIndexCapacity = 0;
+  navMesh.GetDebugOffMeshLinks(NavTraversalType::Drop, m_dropLinkPoints, m_dropLinkIndices, m_graphVerticalOffset + 0.010f);
+  if (!UploadLineBuffers("navmesh drop link",
+                         m_dropLinkPoints,
+                         m_dropLinkIndices,
+                         m_dropLinkVertices,
+                         m_dropLinkVertexBuffer,
+                         m_dropLinkIndexBuffer,
+                         m_dropLinkVertexCapacity,
+                         m_dropLinkIndexCapacity,
+                         m_dropLinkIndexCount)) {
+    return false;
+  }
 
-    m_graphVertexBuffer = LineRenderer::CreatePositionVB(m_graphVertices.data(), graphVertexCount, BufferUsage::DINAMIC);
+  navMesh.GetDebugOffMeshLinks(NavTraversalType::Jump, m_jumpLinkPoints, m_jumpLinkIndices, m_graphVerticalOffset + 0.020f);
+  if (!UploadLineBuffers("navmesh jump link",
+                         m_jumpLinkPoints,
+                         m_jumpLinkIndices,
+                         m_jumpLinkVertices,
+                         m_jumpLinkVertexBuffer,
+                         m_jumpLinkIndexBuffer,
+                         m_jumpLinkVertexCapacity,
+                         m_jumpLinkIndexCapacity,
+                         m_jumpLinkIndexCount)) {
+    return false;
+  }
 
-    BufferDesc graphIndexDesc;
-    graphIndexDesc.byteWidth = static_cast<int>(sizeof(unsigned int) * graphIndexCount);
-    graphIndexDesc.usage = BufferUsage::DINAMIC;
-    m_graphIndexBuffer = T8Device ? static_cast<IndexBuffer*>(
-        T8Device->CreateBuffer(BufferType::INDEX, graphIndexDesc, m_graphIndices.data())) : nullptr;
-
-    if (!m_graphVertexBuffer || !m_graphIndexBuffer) {
-      T8_LOG_ERROR("[NavigationDebugRenderer] Failed to create navmesh graph edge buffers");
-      if (m_graphVertexBuffer) {
-        m_graphVertexBuffer->release();
-        m_graphVertexBuffer = nullptr;
-      }
-      if (m_graphIndexBuffer) {
-        m_graphIndexBuffer->release();
-        m_graphIndexBuffer = nullptr;
-      }
-      m_graphIndexCount = 0;
-    } else {
-      m_graphVertexCapacity = graphVertexCount;
-      m_graphIndexCapacity = graphIndexCount;
-      m_graphIndexCount = graphIndexCount;
-    }
-  } else {
-    if (!T8DeviceContext) {
-      return false;
-    }
-    m_graphVertices.resize(static_cast<std::size_t>(m_graphVertexCapacity) * 4u, 0.0f);
-    m_graphIndices.resize(m_graphIndexCapacity, 0u);
-    m_graphVertexBuffer->UpdateFromBuffer(*T8DeviceContext, m_graphVertices.data());
-    m_graphIndexBuffer->UpdateFromBuffer(*T8DeviceContext, m_graphIndices.data());
-    m_graphIndexCount = graphIndexCount;
+  navMesh.GetDebugOffMeshLinks(NavTraversalType::JumpPad, m_jumpPadLinkPoints, m_jumpPadLinkIndices, m_graphVerticalOffset + 0.030f);
+  if (!UploadLineBuffers("navmesh jump pad link",
+                         m_jumpPadLinkPoints,
+                         m_jumpPadLinkIndices,
+                         m_jumpPadLinkVertices,
+                         m_jumpPadLinkVertexBuffer,
+                         m_jumpPadLinkIndexBuffer,
+                         m_jumpPadLinkVertexCapacity,
+                         m_jumpPadLinkIndexCapacity,
+                         m_jumpPadLinkIndexCount)) {
+    return false;
   }
 
   m_uploadedNavMesh = &navMesh;
   m_uploadedPolygonCount = stats.polygonCount;
   m_uploadedDetailTriangleCount = stats.detailTriangleCount;
+  m_uploadedOffMeshLinkCount = stats.offMeshLinkCount;
   m_uploadedVerticalOffset = m_verticalOffset;
   m_uploadedGraphVerticalOffset = m_graphVerticalOffset;
   m_uploadedShapeMode = m_shapeMode;
   m_indexCount = indexCount;
-  T8_LOG_INFO("[NavigationDebugRenderer] Uploaded navmesh debug mode=%d magentaLines=%u graphEdges=%u verts=%u bounds=(%.2f,%.2f,%.2f)-(%.2f,%.2f,%.2f) offsets=(%.2f,%.2f)",
+  T8_LOG_INFO("[NavigationDebugRenderer] Uploaded navmesh debug mode=%d magentaLines=%u graphEdges=%u dropLinks=%u jumpLinks=%u jumpPadLinks=%u verts=%u bounds=(%.2f,%.2f,%.2f)-(%.2f,%.2f,%.2f) offsets=(%.2f,%.2f)",
               static_cast<int>(m_shapeMode),
-              indexCount / 2u, m_graphIndexCount / 2u, vertexCount,
+              indexCount / 2u, m_graphIndexCount / 2u,
+              m_dropLinkIndexCount / 2u, m_jumpLinkIndexCount / 2u, m_jumpPadLinkIndexCount / 2u, vertexCount,
               minPoint.x, minPoint.y, minPoint.z,
               maxPoint.x, maxPoint.y, maxPoint.z,
               m_verticalOffset, m_graphVerticalOffset);
@@ -249,6 +358,36 @@ void NavMeshDebugRenderer::Draw(const NavMesh& navMesh, const XMATRIX44& viewPro
                              m_graphVertexBuffer,
                              m_graphIndexBuffer,
                              m_graphIndexCount,
+                             sizeof(float) * 4,
+                             IndexBufferFormat::R32);
+  }
+  if (m_dropLinkVertexBuffer && m_dropLinkIndexBuffer && m_dropLinkIndexCount > 0) {
+    m_lineRenderer.DrawLines(identity,
+                             viewProjection,
+                             XVECTOR3(1.0f, 0.55f, 0.0f, 1.0f),
+                             m_dropLinkVertexBuffer,
+                             m_dropLinkIndexBuffer,
+                             m_dropLinkIndexCount,
+                             sizeof(float) * 4,
+                             IndexBufferFormat::R32);
+  }
+  if (m_jumpLinkVertexBuffer && m_jumpLinkIndexBuffer && m_jumpLinkIndexCount > 0) {
+    m_lineRenderer.DrawLines(identity,
+                             viewProjection,
+                             XVECTOR3(1.0f, 1.0f, 0.0f, 1.0f),
+                             m_jumpLinkVertexBuffer,
+                             m_jumpLinkIndexBuffer,
+                             m_jumpLinkIndexCount,
+                             sizeof(float) * 4,
+                             IndexBufferFormat::R32);
+  }
+  if (m_jumpPadLinkVertexBuffer && m_jumpPadLinkIndexBuffer && m_jumpPadLinkIndexCount > 0) {
+    m_lineRenderer.DrawLines(identity,
+                             viewProjection,
+                             XVECTOR3(0.0f, 0.75f, 1.0f, 1.0f),
+                             m_jumpPadLinkVertexBuffer,
+                             m_jumpPadLinkIndexBuffer,
+                             m_jumpPadLinkIndexCount,
                              sizeof(float) * 4,
                              IndexBufferFormat::R32);
   }

--- a/T850/Framework/src/navigation/NavigationSystem.cpp
+++ b/T850/Framework/src/navigation/NavigationSystem.cpp
@@ -2,7 +2,9 @@
 
 #include <navigation/NavigationSystem.h>
 
+#include <debug/RuntimeTelemetry.h>
 #include <utils/Log.h>
+#include <utils/ResourceLocator.h>
 #include <utils/XDataBase.h>
 #include <utils/xDefs.h>
 #include <utils/ThreadPool.h>
@@ -11,8 +13,14 @@
 #include <scene/RenderSkinnedMesh.h>
 
 #include <algorithm>
+#include <array>
+#include <cstdint>
 #include <cmath>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
 
 #if defined(T850_ENABLE_RECAST)
 #include <recastnavigation/DetourCrowd.h>
@@ -70,14 +78,760 @@ struct NavMeshQueryDeleter {
 };
 
 constexpr unsigned short kNavPolyFlagWalk = 0x01;
+constexpr unsigned short kNavPolyFlagDrop = 0x02;
+constexpr unsigned short kNavPolyFlagJump = 0x04;
+constexpr unsigned short kNavPolyFlagJumpPad = 0x08;
+constexpr unsigned short kNavPolyFlagJumpIntent = 0x10;
+constexpr unsigned short kNavPolyFlagAllTraversal =
+    kNavPolyFlagWalk | kNavPolyFlagDrop | kNavPolyFlagJump | kNavPolyFlagJumpPad | kNavPolyFlagJumpIntent;
+constexpr unsigned char kNavAreaWalk = 0;
+constexpr unsigned char kNavAreaDrop = 1;
+constexpr unsigned char kNavAreaJump = 2;
+constexpr unsigned char kNavAreaJumpPad = 3;
+constexpr unsigned char kNavAreaJumpIntent = 4;
 constexpr int kMaxPathPolys = 256;
 constexpr int kMaxStraightPath = 256;
+constexpr std::array<char, 8> kNavMeshCacheMagic = { 'T', '8', 'N', 'A', 'V', 'C', 'H', 'E' };
+constexpr uint32_t kNavMeshCacheVersion = 5;
+constexpr uint32_t kOffMeshUserIdBase = 0x85000000u;
+
+template <typename T>
+void HashBytes(uint64_t& hash, const T& value) {
+  const unsigned char* bytes = reinterpret_cast<const unsigned char*>(&value);
+  for (std::size_t i = 0; i < sizeof(T); ++i) {
+    hash ^= bytes[i];
+    hash *= 0x100000001b3ull;
+  }
+}
+
+void HashData(uint64_t& hash, const void* data, std::size_t byteCount) {
+  const unsigned char* bytes = static_cast<const unsigned char*>(data);
+  for (std::size_t i = 0; i < byteCount; ++i) {
+    hash ^= bytes[i];
+    hash *= 0x100000001b3ull;
+  }
+}
+
+uint64_t ComputeNavMeshCacheKey(const NavMeshGeometry& geometry,
+                                const NavMeshBuildSettings& settings) {
+  uint64_t hash = 0xcbf29ce484222325ull;
+  HashBytes(hash, kNavMeshCacheVersion);
+  HashBytes(hash, settings.cellSize);
+  HashBytes(hash, settings.cellHeight);
+  HashBytes(hash, settings.agentHeight);
+  HashBytes(hash, settings.agentRadius);
+  HashBytes(hash, settings.agentMaxClimb);
+  HashBytes(hash, settings.agentMaxSlope);
+  HashBytes(hash, settings.regionMinSize);
+  HashBytes(hash, settings.regionMergeSize);
+  HashBytes(hash, settings.edgeMaxLen);
+  HashBytes(hash, settings.edgeMaxError);
+  HashBytes(hash, settings.vertsPerPoly);
+  HashBytes(hash, settings.detailSampleDist);
+  HashBytes(hash, settings.detailSampleMaxError);
+  HashBytes(hash, settings.queryExtents.x);
+  HashBytes(hash, settings.queryExtents.y);
+  HashBytes(hash, settings.queryExtents.z);
+  HashBytes(hash, settings.queryExtents.w);
+  HashBytes(hash, settings.enableAutoDropLinks);
+  HashBytes(hash, settings.dropLinkMinHeight);
+  HashBytes(hash, settings.dropLinkMaxHeight);
+  HashBytes(hash, settings.dropLinkMaxHorizontalDistance);
+  HashBytes(hash, settings.dropLinkSampleSpacing);
+  HashBytes(hash, settings.dropLinkRadius);
+  HashBytes(hash, settings.enableAutoJumpLinks);
+  HashBytes(hash, settings.jumpLinkMaxHorizontalDistance);
+  HashBytes(hash, settings.jumpLinkSampleSpacing);
+  HashBytes(hash, settings.jumpLinkRadius);
+  HashBytes(hash, settings.enableHybridJumpLinks);
+  HashBytes(hash, settings.hybridJumpMaxLinks);
+  HashBytes(hash, settings.offMeshLinkValidationKey);
+  const uint64_t vertexCount = static_cast<uint64_t>(geometry.vertices.size());
+  const uint64_t indexCount = static_cast<uint64_t>(geometry.indices.size());
+  const uint64_t offMeshLinkCount = static_cast<uint64_t>(geometry.offMeshLinks.size());
+  HashBytes(hash, vertexCount);
+  HashBytes(hash, indexCount);
+  HashBytes(hash, offMeshLinkCount);
+  for (const XVECTOR3& vertex : geometry.vertices) {
+    HashBytes(hash, vertex.x);
+    HashBytes(hash, vertex.y);
+    HashBytes(hash, vertex.z);
+  }
+  if (!geometry.indices.empty()) {
+    HashData(hash, geometry.indices.data(), geometry.indices.size() * sizeof(int));
+  }
+  for (const NavOffMeshLink& link : geometry.offMeshLinks) {
+    HashBytes(hash, link.start.x);
+    HashBytes(hash, link.start.y);
+    HashBytes(hash, link.start.z);
+    HashBytes(hash, link.end.x);
+    HashBytes(hash, link.end.y);
+    HashBytes(hash, link.end.z);
+    HashBytes(hash, link.radius);
+    HashBytes(hash, link.bidirectional);
+    const uint8_t type = static_cast<uint8_t>(link.type);
+    HashBytes(hash, type);
+    HashBytes(hash, link.userId);
+  }
+  return hash;
+}
+
+std::filesystem::path NavMeshCachePath(uint64_t key) {
+  std::ostringstream name;
+  name << "Navigation/.t8cache/navmesh_"
+       << std::hex << std::uppercase << std::setw(16) << std::setfill('0') << key
+       << ".t8nav";
+  return ResourceLocator::Instance().ResolveCachePath(name.str());
+}
+
+uint32_t EncodeOffMeshUserId(NavTraversalType type, uint32_t index) {
+  return kOffMeshUserIdBase |
+      ((static_cast<uint32_t>(type) & 0xffu) << 16u) |
+      (index & 0xffffu);
+}
+
+NavTraversalType DecodeOffMeshUserId(uint32_t userId) {
+  if ((userId & 0xff000000u) != kOffMeshUserIdBase) {
+    return NavTraversalType::Walk;
+  }
+
+  const uint32_t type = (userId >> 16u) & 0xffu;
+  if (type == static_cast<uint32_t>(NavTraversalType::Drop)) {
+    return NavTraversalType::Drop;
+  }
+  if (type == static_cast<uint32_t>(NavTraversalType::Jump)) {
+    return NavTraversalType::Jump;
+  }
+  if (type == static_cast<uint32_t>(NavTraversalType::JumpIntent)) {
+    return NavTraversalType::Jump;
+  }
+  if (type == static_cast<uint32_t>(NavTraversalType::JumpPad)) {
+    return NavTraversalType::JumpPad;
+  }
+  return NavTraversalType::Walk;
+}
+
+unsigned short PolyFlagsForTraversal(NavTraversalType type) {
+  switch (type) {
+    case NavTraversalType::Drop:
+      return kNavPolyFlagDrop;
+    case NavTraversalType::Jump:
+      return kNavPolyFlagJump;
+    case NavTraversalType::JumpIntent:
+      return kNavPolyFlagJumpIntent;
+    case NavTraversalType::JumpPad:
+      return kNavPolyFlagJumpPad;
+    case NavTraversalType::Walk:
+    default:
+      return kNavPolyFlagWalk;
+  }
+}
+
+unsigned char PolyAreaForTraversal(NavTraversalType type) {
+  switch (type) {
+    case NavTraversalType::Drop:
+      return kNavAreaDrop;
+    case NavTraversalType::Jump:
+      return kNavAreaJump;
+    case NavTraversalType::JumpIntent:
+      return kNavAreaJumpIntent;
+    case NavTraversalType::JumpPad:
+      return kNavAreaJumpPad;
+    case NavTraversalType::Walk:
+    default:
+      return kNavAreaWalk;
+  }
+}
+
+void ConfigureTraversalFilter(dtQueryFilter& filter) {
+  filter.setIncludeFlags(kNavPolyFlagAllTraversal);
+  filter.setExcludeFlags(0);
+  filter.setAreaCost(kNavAreaWalk, 1.0f);
+  filter.setAreaCost(kNavAreaDrop, 0.35f);
+  filter.setAreaCost(kNavAreaJump, 0.20f);
+  filter.setAreaCost(kNavAreaJumpPad, 0.15f);
+  filter.setAreaCost(kNavAreaJumpIntent, 1.75f);
+}
+
+void ConfigureWalkFilter(dtQueryFilter& filter) {
+  filter.setIncludeFlags(kNavPolyFlagWalk);
+  filter.setExcludeFlags(0);
+  filter.setAreaCost(kNavAreaWalk, 1.0f);
+}
+
+float DistanceSq3(const XVECTOR3& a, const XVECTOR3& b) {
+  const float dx = a.x - b.x;
+  const float dy = a.y - b.y;
+  const float dz = a.z - b.z;
+  return dx * dx + dy * dy + dz * dz;
+}
+
+float HorizontalDistanceSq3(const XVECTOR3& a, const XVECTOR3& b) {
+  const float dx = a.x - b.x;
+  const float dz = a.z - b.z;
+  return dx * dx + dz * dz;
+}
+
+XVECTOR3 NormalizeHorizontalOr(XVECTOR3 value, const XVECTOR3& fallback) {
+  value.y = 0.0f;
+  value.w = 0.0f;
+  const float lengthSq = value.x * value.x + value.z * value.z;
+  if (lengthSq <= 0.000001f) {
+    return fallback;
+  }
+  const float invLength = 1.0f / std::sqrt(lengthSq);
+  value.x *= invLength;
+  value.z *= invLength;
+  return value;
+}
+
+XVECTOR3 PolyMeshVertexWorld(const rcPolyMesh& polyMesh, unsigned short vertexIndex) {
+  if (vertexIndex >= static_cast<unsigned short>(polyMesh.nverts)) {
+    return XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+  }
+
+  const unsigned short* v = &polyMesh.verts[static_cast<std::size_t>(vertexIndex) * 3u];
+  return XVECTOR3(
+      polyMesh.bmin[0] + static_cast<float>(v[0]) * polyMesh.cs,
+      polyMesh.bmin[1] + static_cast<float>(v[1]) * polyMesh.ch,
+      polyMesh.bmin[2] + static_cast<float>(v[2]) * polyMesh.cs,
+      1.0f);
+}
+
+XVECTOR3 PolyMeshPolyCenter(const rcPolyMesh& polyMesh, int polyIndex) {
+  const unsigned short* poly = &polyMesh.polys[static_cast<std::size_t>(polyIndex) * polyMesh.nvp * 2u];
+  XVECTOR3 center(0.0f, 0.0f, 0.0f, 1.0f);
+  int validCount = 0;
+  for (int vertexIndex = 0; vertexIndex < polyMesh.nvp; ++vertexIndex) {
+    if (poly[vertexIndex] == RC_MESH_NULL_IDX) {
+      break;
+    }
+    center += PolyMeshVertexWorld(polyMesh, poly[vertexIndex]);
+    ++validCount;
+  }
+  if (validCount > 0) {
+    const float invCount = 1.0f / static_cast<float>(validCount);
+    center.x *= invCount;
+    center.y *= invCount;
+    center.z *= invCount;
+    center.w = 1.0f;
+  }
+  return center;
+}
+
+bool ProjectLinkEndpoint(dtNavMeshQuery& query,
+                         const XVECTOR3& point,
+                         const XVECTOR3& extents,
+                         XVECTOR3& outPoint,
+                         dtPolyRef& outRef) {
+  dtQueryFilter filter;
+  ConfigureWalkFilter(filter);
+  const float position[3] = { point.x, point.y, point.z };
+  const float queryExtents[3] = {
+    (std::max)(0.05f, extents.x),
+    (std::max)(0.05f, extents.y),
+    (std::max)(0.05f, extents.z)
+  };
+  float nearestPoint[3] = {};
+  outRef = 0;
+  const dtStatus status = query.findNearestPoly(position, queryExtents, &filter, &outRef, nearestPoint);
+  if (dtStatusFailed(status) || !outRef) {
+    return false;
+  }
+  outPoint = XVECTOR3(nearestPoint[0], nearestPoint[1], nearestPoint[2], 1.0f);
+  return true;
+}
+
+bool IsDuplicateOffMeshLink(const std::vector<NavOffMeshLink>& links,
+                            const XVECTOR3& start,
+                            const XVECTOR3& end,
+                            NavTraversalType type,
+                            float thresholdSq) {
+  for (const NavOffMeshLink& link : links) {
+    if (link.type != type) {
+      continue;
+    }
+    if (DistanceSq3(link.start, start) <= thresholdSq &&
+        DistanceSq3(link.end, end) <= thresholdSq) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool PassesOffMeshLinkValidator(const NavOffMeshLink& link,
+                                const std::function<bool(const NavOffMeshLink&)>& validator,
+                                int& rejectedCount) {
+  if (!validator) {
+    return true;
+  }
+  if (validator(link)) {
+    return true;
+  }
+  ++rejectedCount;
+  return false;
+}
+
+bool PassesOffMeshHybridLinkValidator(const NavOffMeshLink& link,
+                                      const std::function<bool(const NavOffMeshLink&)>& validator,
+                                      int& rejectedCount) {
+  if (!validator) {
+    return true;
+  }
+  if (validator(link)) {
+    return true;
+  }
+  ++rejectedCount;
+  return false;
+}
+
+std::vector<NavOffMeshLink> NormalizeExplicitOffMeshLinks(const std::vector<NavOffMeshLink>& sourceLinks,
+                                                          dtNavMeshQuery& query,
+                                                          const NavMeshBuildSettings& settings,
+                                                          const std::function<bool(const NavOffMeshLink&)>& validator,
+                                                          int& outSkippedCount,
+                                                          int& outRejectedCount) {
+  std::vector<NavOffMeshLink> links;
+  links.reserve(sourceLinks.size());
+  outSkippedCount = 0;
+
+  const XVECTOR3 extents(
+      (std::max)(settings.queryExtents.x, settings.agentRadius + settings.dropLinkRadius),
+      (std::max)(settings.queryExtents.y, settings.dropLinkMaxHeight),
+      (std::max)(settings.queryExtents.z, settings.agentRadius + settings.dropLinkRadius),
+      0.0f);
+  const float duplicateThresholdSq = (std::max)(0.10f, settings.agentRadius * 0.5f);
+  const float duplicateThresholdSqFinal = duplicateThresholdSq * duplicateThresholdSq;
+
+  for (const NavOffMeshLink& sourceLink : sourceLinks) {
+    if (!IsFiniteVec3(sourceLink.start) ||
+        !IsFiniteVec3(sourceLink.end) ||
+        sourceLink.radius <= 0.0f ||
+        sourceLink.type == NavTraversalType::Walk) {
+      ++outSkippedCount;
+      continue;
+    }
+
+    XVECTOR3 projectedStart;
+    XVECTOR3 projectedEnd;
+    dtPolyRef startRef = 0;
+    dtPolyRef endRef = 0;
+    if (!ProjectLinkEndpoint(query, sourceLink.start, extents, projectedStart, startRef) ||
+        !ProjectLinkEndpoint(query, sourceLink.end, extents, projectedEnd, endRef) ||
+        startRef == endRef) {
+      ++outSkippedCount;
+      continue;
+    }
+
+    if (IsDuplicateOffMeshLink(links, projectedStart, projectedEnd, sourceLink.type, duplicateThresholdSqFinal)) {
+      continue;
+    }
+
+    NavOffMeshLink link = sourceLink;
+    link.start = projectedStart;
+    link.end = projectedEnd;
+    link.radius = (std::max)(0.05f, sourceLink.radius);
+    link.userId = EncodeOffMeshUserId(link.type, static_cast<uint32_t>(links.size()));
+    if (!PassesOffMeshLinkValidator(link, validator, outRejectedCount)) {
+      continue;
+    }
+    links.push_back(link);
+  }
+  return links;
+}
+
+int GenerateAutoDropLinks(const rcPolyMesh& polyMesh,
+                          dtNavMeshQuery& query,
+                          const NavMeshBuildSettings& settings,
+                          const std::function<bool(const NavOffMeshLink&)>& validator,
+                          const std::function<bool(const NavOffMeshLink&)>& hybridValidator,
+                          int& rejectedByValidatorCount,
+                          int& generatedJumpLinks,
+                          std::vector<NavOffMeshLink>& links) {
+  generatedJumpLinks = 0;
+  const bool canGenerateDrops =
+      settings.enableAutoDropLinks &&
+      settings.dropLinkMaxHeight > settings.dropLinkMinHeight &&
+      settings.dropLinkMaxHorizontalDistance > 0.0f &&
+      settings.dropLinkRadius > 0.0f;
+  const bool canGenerateJumps =
+      settings.enableAutoJumpLinks &&
+      settings.jumpLinkMaxHorizontalDistance > 0.0f &&
+      settings.jumpLinkRadius > 0.0f;
+  if (!canGenerateDrops && !canGenerateJumps) {
+    return 0;
+  }
+
+  const int existingCount = static_cast<int>(links.size());
+  const float sampleSpacing = (std::max)(0.25f, settings.dropLinkSampleSpacing);
+  const float maxHorizontal = (std::max)(0.25f, settings.dropLinkMaxHorizontalDistance);
+  const float jumpSampleSpacing = (std::max)(0.25f, settings.jumpLinkSampleSpacing);
+  const float maxJumpHorizontal = (std::max)(0.25f, settings.jumpLinkMaxHorizontalDistance);
+  const float maxCandidateHorizontal = canGenerateJumps
+      ? (std::max)(maxHorizontal, maxJumpHorizontal)
+      : maxHorizontal;
+  const float minDropHeight = (std::max)(settings.agentMaxClimb + 0.05f, settings.dropLinkMinHeight);
+  const float maxDropHeight = (std::max)(minDropHeight + 0.05f, settings.dropLinkMaxHeight);
+  const float duplicateThreshold = (std::max)(0.25f, settings.dropLinkRadius * 0.75f);
+  const float duplicateThresholdSq = duplicateThreshold * duplicateThreshold;
+  const int maxHybridJumpLinks = (std::max)(0, settings.hybridJumpMaxLinks);
+  int generatedHybridJumpLinks = 0;
+  const XVECTOR3 startExtents(
+      (std::max)(0.25f, settings.agentRadius + settings.dropLinkRadius),
+      (std::max)(settings.agentHeight, settings.queryExtents.y),
+      (std::max)(0.25f, settings.agentRadius + settings.dropLinkRadius),
+      0.0f);
+  const XVECTOR3 endExtents(
+      (std::max)(0.35f, settings.agentRadius + settings.dropLinkRadius),
+      (std::max)(maxDropHeight + settings.agentHeight, settings.queryExtents.y),
+      (std::max)(0.35f, settings.agentRadius + settings.dropLinkRadius),
+      0.0f);
+  const XVECTOR3 jumpEndExtents(
+      (std::max)(0.35f, settings.agentRadius + settings.jumpLinkRadius),
+      (std::max)(maxDropHeight + settings.agentHeight, settings.queryExtents.y),
+      (std::max)(0.35f, settings.agentRadius + settings.jumpLinkRadius),
+      0.0f);
+
+  const std::array<float, 5> horizontalFractions = { 0.30f, 0.45f, 0.60f, 0.80f, 1.0f };
+  constexpr int kMaxAutoDropLinks = 4096;
+  constexpr int kMaxAutoJumpLinks = 4096;
+
+  for (int polyIndex = 0; polyIndex < polyMesh.npolys; ++polyIndex) {
+    const unsigned short* poly = &polyMesh.polys[static_cast<std::size_t>(polyIndex) * polyMesh.nvp * 2u];
+    const unsigned short* neis = poly + polyMesh.nvp;
+    const XVECTOR3 polyCenter = PolyMeshPolyCenter(polyMesh, polyIndex);
+    int vertexCount = 0;
+    while (vertexCount < polyMesh.nvp && poly[vertexCount] != RC_MESH_NULL_IDX) {
+      ++vertexCount;
+    }
+    if (vertexCount < 3) {
+      continue;
+    }
+
+    for (int edgeIndex = 0; edgeIndex < vertexCount; ++edgeIndex) {
+      const unsigned short v0Index = poly[edgeIndex];
+      const unsigned short v1Index = poly[(edgeIndex + 1) % vertexCount];
+      if (v0Index == RC_MESH_NULL_IDX ||
+          v1Index == RC_MESH_NULL_IDX ||
+          neis[edgeIndex] != RC_MESH_NULL_IDX) {
+        continue;
+      }
+
+      const XVECTOR3 v0 = PolyMeshVertexWorld(polyMesh, v0Index);
+      const XVECTOR3 v1 = PolyMeshVertexWorld(polyMesh, v1Index);
+      XVECTOR3 edge = v1 - v0;
+      edge.y = 0.0f;
+      edge.w = 0.0f;
+      const float edgeLength = edge.Length();
+      if (edgeLength <= 0.05f) {
+        continue;
+      }
+
+      XVECTOR3 outward(edge.z, 0.0f, -edge.x, 0.0f);
+      outward = NormalizeHorizontalOr(outward, XVECTOR3(1.0f, 0.0f, 0.0f, 0.0f));
+      const XVECTOR3 edgeMid = (v0 + v1) * 0.5f;
+      XVECTOR3 centerToEdge = edgeMid - polyCenter;
+      centerToEdge.y = 0.0f;
+      centerToEdge.w = 0.0f;
+      if (outward.x * centerToEdge.x + outward.z * centerToEdge.z < 0.0f) {
+        outward *= -1.0f;
+      }
+
+      const int sampleCount = (std::max)(1, static_cast<int>(std::ceil(edgeLength / (std::min)(sampleSpacing, jumpSampleSpacing))));
+      for (int sampleIndex = 0; sampleIndex < sampleCount; ++sampleIndex) {
+        const float t = (static_cast<float>(sampleIndex) + 0.5f) / static_cast<float>(sampleCount);
+        XVECTOR3 edgePoint = v0 + (v1 - v0) * t;
+        edgePoint.w = 1.0f;
+
+        XVECTOR3 startProbe = edgePoint - outward * (std::max)(0.05f, settings.agentRadius * 0.25f);
+        startProbe.w = 1.0f;
+        XVECTOR3 projectedStart;
+        dtPolyRef startRef = 0;
+        if (!ProjectLinkEndpoint(query, startProbe, startExtents, projectedStart, startRef)) {
+          continue;
+        }
+
+        for (float fraction : horizontalFractions) {
+          const float horizontal = maxCandidateHorizontal * fraction;
+          XVECTOR3 endProbe = edgePoint + outward * horizontal;
+          endProbe.y = edgePoint.y - (minDropHeight + maxDropHeight) * 0.5f;
+          endProbe.w = 1.0f;
+
+          XVECTOR3 projectedEnd;
+          dtPolyRef endRef = 0;
+          if (!ProjectLinkEndpoint(query, endProbe, canGenerateJumps ? jumpEndExtents : endExtents, projectedEnd, endRef) ||
+              !endRef ||
+              endRef == startRef) {
+            continue;
+          }
+
+          bool acceptedAnyLink = false;
+          const float dropHeight = projectedStart.y - projectedEnd.y;
+          if (canGenerateDrops &&
+              dropHeight >= minDropHeight &&
+              dropHeight <= maxDropHeight &&
+              HorizontalDistanceSq3(projectedStart, projectedEnd) <= maxHorizontal * maxHorizontal * 1.25f &&
+              !IsDuplicateOffMeshLink(links, projectedStart, projectedEnd, NavTraversalType::Drop, duplicateThresholdSq)) {
+            NavOffMeshLink link;
+            link.start = projectedStart;
+            link.end = projectedEnd;
+            link.radius = (std::max)(0.05f, settings.dropLinkRadius);
+            link.bidirectional = false;
+            link.type = NavTraversalType::Drop;
+            link.userId = EncodeOffMeshUserId(link.type, static_cast<uint32_t>(links.size()));
+            if (PassesOffMeshLinkValidator(link, validator, rejectedByValidatorCount)) {
+              links.push_back(link);
+              acceptedAnyLink = true;
+            }
+          }
+
+          const float jumpHorizontalSq = HorizontalDistanceSq3(projectedStart, projectedEnd);
+          if (canGenerateJumps &&
+              jumpHorizontalSq > settings.agentRadius * settings.agentRadius &&
+              jumpHorizontalSq <= maxJumpHorizontal * maxJumpHorizontal * 1.25f &&
+              !IsDuplicateOffMeshLink(links, projectedStart, projectedEnd, NavTraversalType::Jump, duplicateThresholdSq)) {
+            NavOffMeshLink link;
+            link.start = projectedStart;
+            link.end = projectedEnd;
+            link.radius = (std::max)(0.05f, settings.jumpLinkRadius);
+            link.bidirectional = false;
+            link.type = NavTraversalType::Jump;
+            link.userId = EncodeOffMeshUserId(link.type, static_cast<uint32_t>(links.size()));
+            if (PassesOffMeshLinkValidator(link, validator, rejectedByValidatorCount)) {
+              links.push_back(link);
+              ++generatedJumpLinks;
+              acceptedAnyLink = true;
+            } else if (settings.enableHybridJumpLinks &&
+                       generatedHybridJumpLinks < maxHybridJumpLinks &&
+                       !IsDuplicateOffMeshLink(links, projectedStart, projectedEnd, NavTraversalType::JumpIntent, duplicateThresholdSq)) {
+              link.type = NavTraversalType::JumpIntent;
+              link.userId = EncodeOffMeshUserId(link.type, static_cast<uint32_t>(links.size()));
+              if (PassesOffMeshHybridLinkValidator(link, hybridValidator, rejectedByValidatorCount)) {
+                links.push_back(link);
+                ++generatedJumpLinks;
+                ++generatedHybridJumpLinks;
+                acceptedAnyLink = true;
+              }
+            }
+          }
+
+          if (acceptedAnyLink) {
+            break;
+          }
+        }
+
+        const int generatedLinks = static_cast<int>(links.size()) - existingCount;
+        if (generatedLinks >= kMaxAutoDropLinks + kMaxAutoJumpLinks) {
+          return static_cast<int>(links.size()) - existingCount;
+        }
+      }
+    }
+  }
+
+  return static_cast<int>(links.size()) - existingCount;
+}
+
+template <typename T>
+bool ReadPod(std::ifstream& file, T& value) {
+  file.read(reinterpret_cast<char*>(&value), sizeof(T));
+  return file.good();
+}
+
+template <typename T>
+void WritePod(std::ofstream& file, const T& value) {
+  file.write(reinterpret_cast<const char*>(&value), sizeof(T));
+}
+
+bool InitializeDetourMeshFromData(unsigned char* navData,
+                                  int navDataSize,
+                                  const NavMeshBuildSettings& settings,
+                                  const NavMeshBuildStats& stats,
+                                  std::unique_ptr<dtNavMesh, NavMeshDeleter>& outNavMesh,
+                                  std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter>& outQuery,
+                                  std::string* error) {
+  outNavMesh.reset();
+  outQuery.reset();
+  if (!navData || navDataSize <= 0) {
+    SetError(error, "Cached Detour navmesh data is empty");
+    return false;
+  }
+
+  std::unique_ptr<dtNavMesh, NavMeshDeleter> navMesh(dtAllocNavMesh());
+  if (!navMesh) {
+    dtFree(navData);
+    SetError(error, "Failed to allocate Detour navmesh");
+    return false;
+  }
+
+  dtStatus status = navMesh->init(navData, navDataSize, DT_TILE_FREE_DATA);
+  if (dtStatusFailed(status)) {
+    dtFree(navData);
+    SetError(error, "Failed to initialize Detour navmesh");
+    return false;
+  }
+
+  std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> query(dtAllocNavMeshQuery());
+  if (!query) {
+    SetError(error, "Failed to allocate Detour navmesh query");
+    return false;
+  }
+
+  status = query->init(navMesh.get(), 2048);
+  if (dtStatusFailed(status)) {
+    SetError(error, "Failed to initialize Detour navmesh query");
+    return false;
+  }
+
+  (void)settings;
+  (void)stats;
+  outNavMesh = std::move(navMesh);
+  outQuery = std::move(query);
+  return true;
+}
+
+bool LoadNavMeshCache(const std::filesystem::path& path,
+                      uint64_t expectedKey,
+                      const NavMeshBuildSettings& settings,
+                      NavMeshBuildStats& outStats,
+                      std::unique_ptr<dtNavMesh, NavMeshDeleter>& outNavMesh,
+                      std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter>& outQuery) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file.is_open()) {
+    return false;
+  }
+
+  std::array<char, 8> magic = {};
+  file.read(magic.data(), static_cast<std::streamsize>(magic.size()));
+  uint32_t version = 0;
+  uint64_t key = 0;
+  uint32_t dataSize = 0;
+  NavMeshBuildStats stats;
+  if (!file.good() ||
+      magic != kNavMeshCacheMagic ||
+      !ReadPod(file, version) ||
+      !ReadPod(file, key) ||
+      !ReadPod(file, stats.vertexCount) ||
+      !ReadPod(file, stats.triangleCount) ||
+      !ReadPod(file, stats.width) ||
+      !ReadPod(file, stats.height) ||
+      !ReadPod(file, stats.polygonCount) ||
+      !ReadPod(file, stats.detailTriangleCount) ||
+      !ReadPod(file, stats.offMeshLinkCount) ||
+      !ReadPod(file, stats.dropLinkCount) ||
+      !ReadPod(file, stats.jumpLinkCount) ||
+      !ReadPod(file, stats.jumpPadLinkCount) ||
+      !ReadPod(file, dataSize)) {
+    return false;
+  }
+  if (version != kNavMeshCacheVersion || key != expectedKey || dataSize == 0) {
+    return false;
+  }
+
+  unsigned char* navData = static_cast<unsigned char*>(dtAlloc(dataSize, DT_ALLOC_PERM));
+  if (!navData) {
+    return false;
+  }
+  file.read(reinterpret_cast<char*>(navData), dataSize);
+  if (!file.good()) {
+    dtFree(navData);
+    return false;
+  }
+
+  std::string error;
+  if (!InitializeDetourMeshFromData(navData, static_cast<int>(dataSize), settings, stats,
+                                    outNavMesh, outQuery, &error)) {
+    T8_LOG_INFO("[Navigation] Ignoring invalid navmesh cache '%s': %s",
+                path.string().c_str(), error.c_str());
+    return false;
+  }
+
+  outStats = stats;
+  T8_LOG_INFO("[Navigation] Loaded navmesh cache '%s': verts=%d tris=%d grid=%dx%d polys=%d detailTris=%d offMesh=%d drop=%d jump=%d jumpPad=%d",
+              path.string().c_str(),
+              outStats.vertexCount,
+              outStats.triangleCount,
+              outStats.width,
+              outStats.height,
+              outStats.polygonCount,
+              outStats.detailTriangleCount,
+              outStats.offMeshLinkCount,
+              outStats.dropLinkCount,
+              outStats.jumpLinkCount,
+              outStats.jumpPadLinkCount);
+  return true;
+}
+
+void SaveNavMeshCache(const std::filesystem::path& path,
+                      uint64_t key,
+                      const NavMeshBuildStats& stats,
+                      const unsigned char* navData,
+                      int navDataSize) {
+  if (!navData || navDataSize <= 0) {
+    return;
+  }
+
+  std::error_code ec;
+  std::filesystem::create_directories(path.parent_path(), ec);
+  if (ec) {
+    T8_LOG_INFO("[Navigation] Cannot create navmesh cache dir '%s': %s",
+                path.parent_path().string().c_str(), ec.message().c_str());
+    return;
+  }
+
+  std::filesystem::path tmpPath = path;
+  tmpPath += ".tmp";
+  std::ofstream file(tmpPath, std::ios::binary | std::ios::trunc);
+  if (!file.is_open()) {
+    T8_LOG_INFO("[Navigation] Cannot write navmesh cache '%s'", tmpPath.string().c_str());
+    return;
+  }
+
+  file.write(kNavMeshCacheMagic.data(), static_cast<std::streamsize>(kNavMeshCacheMagic.size()));
+  WritePod(file, kNavMeshCacheVersion);
+  WritePod(file, key);
+  WritePod(file, stats.vertexCount);
+  WritePod(file, stats.triangleCount);
+  WritePod(file, stats.width);
+  WritePod(file, stats.height);
+  WritePod(file, stats.polygonCount);
+  WritePod(file, stats.detailTriangleCount);
+  WritePod(file, stats.offMeshLinkCount);
+  WritePod(file, stats.dropLinkCount);
+  WritePod(file, stats.jumpLinkCount);
+  WritePod(file, stats.jumpPadLinkCount);
+  const uint32_t dataSize = static_cast<uint32_t>(navDataSize);
+  WritePod(file, dataSize);
+  file.write(reinterpret_cast<const char*>(navData), navDataSize);
+  file.close();
+  if (!file.good()) {
+    std::filesystem::remove(tmpPath, ec);
+    T8_LOG_INFO("[Navigation] Failed while writing navmesh cache '%s'", tmpPath.string().c_str());
+    return;
+  }
+
+  std::filesystem::remove(path, ec);
+  ec.clear();
+  std::filesystem::rename(tmpPath, path, ec);
+  if (ec) {
+    std::filesystem::remove(tmpPath, ec);
+    T8_LOG_INFO("[Navigation] Cannot finalize navmesh cache '%s': %s",
+                path.string().c_str(), ec.message().c_str());
+    return;
+  }
+
+  T8_LOG_INFO("[Navigation] Wrote navmesh cache '%s' (%d bytes)", path.string().c_str(), navDataSize);
+}
 
 NavPathResult FindPathWithQuery(dtNavMeshQuery* query,
                                 const NavMeshBuildSettings& settings,
                                 const NavPathRequest& request) {
+  T8_TELEMETRY_SCOPE("navigation.detour.find_path");
+  if (RuntimeTelemetry::IsFrameActive()) {
+    RuntimeTelemetry::AddCounter("navigation.detour.find_path.count", 1.0);
+  }
   NavPathResult result;
   if (!query) {
+    RuntimeTelemetry::AddCounter("navigation.detour.find_path.fail", 1.0);
     result.error = "Navigation query is not available";
     return result;
   }
@@ -91,8 +845,7 @@ NavPathResult FindPathWithQuery(dtNavMeshQuery* query,
   };
 
   dtQueryFilter filter;
-  filter.setIncludeFlags(kNavPolyFlagWalk);
-  filter.setExcludeFlags(0);
+  ConfigureTraversalFilter(filter);
 
   dtPolyRef startRef = 0;
   dtPolyRef endRef = 0;
@@ -100,11 +853,13 @@ NavPathResult FindPathWithQuery(dtNavMeshQuery* query,
   float nearestEnd[3] = {};
   dtStatus status = query->findNearestPoly(startPos, extents, &filter, &startRef, nearestStart);
   if (dtStatusFailed(status) || !startRef) {
+    RuntimeTelemetry::AddCounter("navigation.detour.find_path.fail", 1.0);
     result.error = "Failed to find nearest start nav polygon";
     return result;
   }
   status = query->findNearestPoly(endPos, extents, &filter, &endRef, nearestEnd);
   if (dtStatusFailed(status) || !endRef) {
+    RuntimeTelemetry::AddCounter("navigation.detour.find_path.fail", 1.0);
     result.error = "Failed to find nearest end nav polygon";
     return result;
   }
@@ -114,6 +869,7 @@ NavPathResult FindPathWithQuery(dtNavMeshQuery* query,
   status = query->findPath(startRef, endRef, nearestStart, nearestEnd,
                            &filter, pathPolys, &pathPolyCount, kMaxPathPolys);
   if (dtStatusFailed(status) || pathPolyCount <= 0) {
+    RuntimeTelemetry::AddCounter("navigation.detour.find_path.fail", 1.0);
     result.error = "Detour failed to find a path";
     return result;
   }
@@ -127,6 +883,7 @@ NavPathResult FindPathWithQuery(dtNavMeshQuery* query,
                                    straightPath, straightFlags, straightPolys,
                                    &straightPathCount, kMaxStraightPath);
   if (dtStatusFailed(status) || straightPathCount <= 0) {
+    RuntimeTelemetry::AddCounter("navigation.detour.find_path.fail", 1.0);
     result.error = "Detour failed to straighten path";
     return result;
   }
@@ -135,6 +892,36 @@ NavPathResult FindPathWithQuery(dtNavMeshQuery* query,
   for (int i = 0; i < straightPathCount; ++i) {
     const float* p = &straightPath[i * 3];
     result.points.emplace_back(p[0], p[1], p[2], 1.0f);
+  }
+  int specialSegmentCount = 0;
+  if (straightPathCount > 1) {
+    result.segments.reserve(static_cast<std::size_t>(straightPathCount - 1));
+    const dtNavMesh* navMesh = query->getAttachedNavMesh();
+    for (int i = 0; i + 1 < straightPathCount; ++i) {
+      NavPathResult::Segment segment;
+      segment.startPointIndex = i;
+      segment.endPointIndex = i + 1;
+      segment.type = NavTraversalType::Walk;
+      if ((straightFlags[i] & DT_STRAIGHTPATH_OFFMESH_CONNECTION) != 0 && navMesh) {
+        const dtOffMeshConnection* connection = navMesh->getOffMeshConnectionByRef(straightPolys[i]);
+        if (!connection && i + 1 < straightPathCount) {
+          connection = navMesh->getOffMeshConnectionByRef(straightPolys[i + 1]);
+        }
+        if (connection) {
+          segment.type = DecodeOffMeshUserId(connection->userId);
+        }
+      }
+      if (segment.type != NavTraversalType::Walk) {
+        ++specialSegmentCount;
+      }
+      result.segments.push_back(segment);
+    }
+  }
+  if (RuntimeTelemetry::IsFrameActive()) {
+    RuntimeTelemetry::AddCounter("navigation.detour.find_path.success", 1.0);
+    RuntimeTelemetry::AddCounter("navigation.detour.find_path.path_polys", static_cast<double>(pathPolyCount));
+    RuntimeTelemetry::AddCounter("navigation.detour.find_path.points", static_cast<double>(straightPathCount));
+    RuntimeTelemetry::AddCounter("navigation.detour.find_path.special_segments", static_cast<double>(specialSegmentCount));
   }
   result.success = true;
   return result;
@@ -357,6 +1144,42 @@ bool NavMesh::BuildFromXDataBase(const xF::XDataBase& database,
 bool NavMesh::Build(const NavMeshGeometry& geometry,
                     const NavMeshBuildSettings& settings,
                     std::string* error) {
+  return BuildCached(geometry, settings, 0, error);
+}
+
+bool NavMesh::LoadCached(uint64_t cacheKey,
+                         const NavMeshBuildSettings& settings,
+                         std::string* error) {
+#if !defined(T850_ENABLE_RECAST)
+  SetError(error, "RecastNavigation is not enabled in this build");
+  return false;
+#else
+  Clear();
+  m_impl->settings = settings;
+  if (cacheKey == 0) {
+    if (error) *error = "Navigation cache key is zero";
+    return false;
+  }
+
+  NavMeshBuildStats cachedStats;
+  std::unique_ptr<dtNavMesh, NavMeshDeleter> cachedNavMesh;
+  std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> cachedQuery;
+  if (!LoadNavMeshCache(NavMeshCachePath(cacheKey), cacheKey, settings, cachedStats, cachedNavMesh, cachedQuery)) {
+    if (error) *error = "Navigation cache is not available";
+    return false;
+  }
+
+  m_stats = cachedStats;
+  m_impl->navMesh = std::move(cachedNavMesh);
+  m_impl->query = std::move(cachedQuery);
+  return true;
+#endif
+}
+
+bool NavMesh::BuildCached(const NavMeshGeometry& geometry,
+                          const NavMeshBuildSettings& settings,
+                          uint64_t cacheKey,
+                          std::string* error) {
 #if !defined(T850_ENABLE_RECAST)
   SetError(error, "RecastNavigation is not enabled in this build");
   return false;
@@ -374,7 +1197,10 @@ bool NavMesh::Build(const NavMeshGeometry& geometry,
   }
   if (settings.cellSize <= 0.0f || settings.cellHeight <= 0.0f ||
       settings.agentHeight <= 0.0f || settings.agentRadius < 0.0f ||
-      settings.vertsPerPoly < 3) {
+      settings.vertsPerPoly < 3 ||
+      settings.dropLinkRadius <= 0.0f ||
+      settings.dropLinkSampleSpacing <= 0.0f ||
+      settings.dropLinkMaxHorizontalDistance < 0.0f) {
     SetError(error, "Invalid navigation build settings");
     return false;
   }
@@ -397,6 +1223,18 @@ bool NavMesh::Build(const NavMeshGeometry& geometry,
       SetError(error, "Navigation geometry contains out-of-range index");
       return false;
     }
+  }
+
+  const uint64_t effectiveCacheKey = cacheKey != 0 ? cacheKey : ComputeNavMeshCacheKey(geometry, settings);
+  const std::filesystem::path cachePath = NavMeshCachePath(effectiveCacheKey);
+  NavMeshBuildStats cachedStats;
+  std::unique_ptr<dtNavMesh, NavMeshDeleter> cachedNavMesh;
+  std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> cachedQuery;
+  if (LoadNavMeshCache(cachePath, effectiveCacheKey, settings, cachedStats, cachedNavMesh, cachedQuery)) {
+    m_stats = cachedStats;
+    m_impl->navMesh = std::move(cachedNavMesh);
+    m_impl->query = std::move(cachedQuery);
+    return true;
   }
 
   rcContext context;
@@ -518,6 +1356,108 @@ bool NavMesh::Build(const NavMeshGeometry& geometry,
   params.ch = config.ch;
   params.buildBvTree = true;
 
+  std::vector<NavOffMeshLink> offMeshLinks;
+  int skippedExplicitLinks = 0;
+  int generatedDropLinks = 0;
+  int generatedJumpLinks = 0;
+  int rejectedByValidatorLinks = 0;
+  if (!geometry.offMeshLinks.empty() || settings.enableAutoDropLinks) {
+    dtNavMeshCreateParams tempParams = params;
+    tempParams.offMeshConVerts = nullptr;
+    tempParams.offMeshConRad = nullptr;
+    tempParams.offMeshConFlags = nullptr;
+    tempParams.offMeshConAreas = nullptr;
+    tempParams.offMeshConDir = nullptr;
+    tempParams.offMeshConUserID = nullptr;
+    tempParams.offMeshConCount = 0;
+
+    unsigned char* tempNavData = nullptr;
+    int tempNavDataSize = 0;
+    if (dtCreateNavMeshData(&tempParams, &tempNavData, &tempNavDataSize) && tempNavData && tempNavDataSize > 0) {
+      std::unique_ptr<dtNavMesh, NavMeshDeleter> tempNavMesh(dtAllocNavMesh());
+      if (tempNavMesh) {
+        dtStatus tempStatus = tempNavMesh->init(tempNavData, tempNavDataSize, DT_TILE_FREE_DATA);
+        if (dtStatusSucceed(tempStatus)) {
+          tempNavData = nullptr;
+          std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> tempQuery(dtAllocNavMeshQuery());
+          if (tempQuery && dtStatusSucceed(tempQuery->init(tempNavMesh.get(), 2048))) {
+            offMeshLinks = NormalizeExplicitOffMeshLinks(
+                geometry.offMeshLinks,
+                *tempQuery,
+                settings,
+                geometry.offMeshLinkValidator,
+                skippedExplicitLinks,
+                rejectedByValidatorLinks);
+            const int generatedTraversalLinks = GenerateAutoDropLinks(
+                *polyMesh,
+                *tempQuery,
+                settings,
+                geometry.offMeshLinkValidator,
+                geometry.offMeshHybridLinkValidator,
+                rejectedByValidatorLinks,
+                generatedJumpLinks,
+                offMeshLinks);
+            generatedDropLinks = (std::max)(0, generatedTraversalLinks - generatedJumpLinks);
+          }
+        }
+      }
+      if (tempNavData) {
+        dtFree(tempNavData);
+      }
+    }
+  }
+
+  std::vector<float> offMeshConVerts;
+  std::vector<float> offMeshConRad;
+  std::vector<unsigned short> offMeshConFlags;
+  std::vector<unsigned char> offMeshConAreas;
+  std::vector<unsigned char> offMeshConDir;
+  std::vector<unsigned int> offMeshConUserIds;
+  int jumpPadLinkCount = 0;
+  int dropLinkCount = 0;
+  int jumpLinkCount = 0;
+  if (!offMeshLinks.empty()) {
+    offMeshConVerts.reserve(offMeshLinks.size() * 6u);
+    offMeshConRad.reserve(offMeshLinks.size());
+    offMeshConFlags.reserve(offMeshLinks.size());
+    offMeshConAreas.reserve(offMeshLinks.size());
+    offMeshConDir.reserve(offMeshLinks.size());
+    offMeshConUserIds.reserve(offMeshLinks.size());
+    for (std::size_t linkIndex = 0; linkIndex < offMeshLinks.size(); ++linkIndex) {
+      NavOffMeshLink& link = offMeshLinks[linkIndex];
+      link.userId = EncodeOffMeshUserId(link.type, static_cast<uint32_t>(linkIndex));
+      if (link.type == NavTraversalType::Drop) {
+        ++dropLinkCount;
+      } else if (link.type == NavTraversalType::Jump) {
+        ++jumpLinkCount;
+      } else if (link.type == NavTraversalType::JumpIntent) {
+        ++jumpLinkCount;
+      } else if (link.type == NavTraversalType::JumpPad) {
+        ++jumpPadLinkCount;
+      }
+
+      offMeshConVerts.push_back(link.start.x);
+      offMeshConVerts.push_back(link.start.y);
+      offMeshConVerts.push_back(link.start.z);
+      offMeshConVerts.push_back(link.end.x);
+      offMeshConVerts.push_back(link.end.y);
+      offMeshConVerts.push_back(link.end.z);
+      offMeshConRad.push_back((std::max)(0.05f, link.radius));
+      offMeshConFlags.push_back(PolyFlagsForTraversal(link.type));
+      offMeshConAreas.push_back(PolyAreaForTraversal(link.type));
+      offMeshConDir.push_back(link.bidirectional ? DT_OFFMESH_CON_BIDIR : 0);
+      offMeshConUserIds.push_back(link.userId);
+    }
+
+    params.offMeshConVerts = offMeshConVerts.data();
+    params.offMeshConRad = offMeshConRad.data();
+    params.offMeshConFlags = offMeshConFlags.data();
+    params.offMeshConAreas = offMeshConAreas.data();
+    params.offMeshConDir = offMeshConDir.data();
+    params.offMeshConUserID = offMeshConUserIds.data();
+    params.offMeshConCount = static_cast<int>(offMeshLinks.size());
+  }
+
   unsigned char* navData = nullptr;
   int navDataSize = 0;
   if (!dtCreateNavMeshData(&params, &navData, &navDataSize) || !navData || navDataSize <= 0) {
@@ -555,12 +1495,19 @@ bool NavMesh::Build(const NavMeshGeometry& geometry,
   m_stats.height = config.height;
   m_stats.polygonCount = polyMesh->npolys;
   m_stats.detailTriangleCount = detailMesh->ntris;
+  m_stats.offMeshLinkCount = static_cast<int>(offMeshLinks.size());
+  m_stats.dropLinkCount = dropLinkCount;
+  m_stats.jumpLinkCount = jumpLinkCount;
+  m_stats.jumpPadLinkCount = jumpPadLinkCount;
+  SaveNavMeshCache(cachePath, effectiveCacheKey, m_stats, navData, navDataSize);
   m_impl->navMesh = std::move(navMesh);
   m_impl->query = std::move(query);
 
-  T8_LOG_INFO("[Navigation] Built navmesh: verts=%d tris=%d grid=%dx%d polys=%d detailTris=%d",
+  T8_LOG_INFO("[Navigation] Built navmesh: verts=%d tris=%d grid=%dx%d polys=%d detailTris=%d offMesh=%d drop=%d jump=%d jumpPad=%d skippedExplicit=%d rejectedByValidator=%d generatedDrop=%d generatedJump=%d",
               m_stats.vertexCount, m_stats.triangleCount, m_stats.width, m_stats.height,
-              m_stats.polygonCount, m_stats.detailTriangleCount);
+              m_stats.polygonCount, m_stats.detailTriangleCount,
+              m_stats.offMeshLinkCount, m_stats.dropLinkCount, m_stats.jumpLinkCount, m_stats.jumpPadLinkCount,
+              skippedExplicitLinks, rejectedByValidatorLinks, generatedDropLinks, generatedJumpLinks);
   return true;
 #endif
 }
@@ -584,8 +1531,7 @@ bool NavMesh::FindPath(const XVECTOR3& start,
   const float extents[3] = { m_impl->settings.queryExtents.x, m_impl->settings.queryExtents.y, m_impl->settings.queryExtents.z };
 
   dtQueryFilter filter;
-  filter.setIncludeFlags(kNavPolyFlagWalk);
-  filter.setExcludeFlags(0);
+  ConfigureTraversalFilter(filter);
 
   dtPolyRef startRef = 0;
   dtPolyRef endRef = 0;
@@ -637,6 +1583,10 @@ bool NavMesh::ProjectPoint(const XVECTOR3& point,
                            XVECTOR3& outPoint,
                            const XVECTOR3& queryExtents,
                            std::string* error) const {
+  T8_TELEMETRY_SCOPE("navigation.project_point");
+  if (RuntimeTelemetry::IsFrameActive()) {
+    RuntimeTelemetry::AddCounter("navigation.project_point.count", 1.0);
+  }
 #if !defined(T850_ENABLE_RECAST)
   if (error) *error = "RecastNavigation is not enabled in this build";
   outPoint = point;
@@ -660,18 +1610,23 @@ bool NavMesh::ProjectPoint(const XVECTOR3& point,
   };
 
   dtQueryFilter filter;
-  filter.setIncludeFlags(kNavPolyFlagWalk);
-  filter.setExcludeFlags(0);
+  ConfigureWalkFilter(filter);
 
   dtPolyRef nearestRef = 0;
   float nearestPoint[3] = {};
   const dtStatus status = m_impl->query->findNearestPoly(position, extents, &filter, &nearestRef, nearestPoint);
   if (dtStatusFailed(status) || !nearestRef) {
+    if (RuntimeTelemetry::IsFrameActive()) {
+      RuntimeTelemetry::AddCounter("navigation.project_point.fail", 1.0);
+    }
     if (error) *error = "Failed to project point onto nearest nav polygon";
     return false;
   }
 
   outPoint = XVECTOR3(nearestPoint[0], nearestPoint[1], nearestPoint[2], 1.0f);
+  if (RuntimeTelemetry::IsFrameActive()) {
+    RuntimeTelemetry::AddCounter("navigation.project_point.success", 1.0);
+  }
   return true;
 #endif
 }
@@ -700,6 +1655,11 @@ NavPathResult NavMesh::FindPath(const NavPathRequest& request) const {
 
 void NavMesh::FindPaths(const std::vector<NavPathRequest>& requests,
                         std::vector<NavPathResult>& outResults) const {
+  T8_TELEMETRY_SCOPE("navigation.find_paths_batch");
+  if (RuntimeTelemetry::IsFrameActive()) {
+    RuntimeTelemetry::AddCounter("navigation.find_paths_batch.calls", 1.0);
+    RuntimeTelemetry::AddCounter("navigation.find_paths_batch.requests", static_cast<double>(requests.size()));
+  }
   outResults.clear();
   outResults.resize(requests.size());
   if (requests.empty()) {
@@ -742,11 +1702,34 @@ void NavMesh::FindPaths(const std::vector<NavPathRequest>& requests,
       requests.size() > 1 &&
       g_threadPool->NumWorkers() > 0 &&
       !g_threadPool->IsWorkerThread()) {
+    if (RuntimeTelemetry::IsFrameActive()) {
+      RuntimeTelemetry::AddCounter("navigation.find_paths_batch.threaded", 1.0);
+    }
     g_threadPool->ParallelForHeavy(0, static_cast<int>(requests.size()), runRequest);
   } else {
     for (int i = 0; i < static_cast<int>(requests.size()); ++i) {
       runRequest(i);
     }
+  }
+  if (RuntimeTelemetry::IsFrameActive()) {
+    int successCount = 0;
+    int pointCount = 0;
+    int specialSegmentCount = 0;
+    for (const NavPathResult& result : outResults) {
+      if (result.success) {
+        ++successCount;
+      }
+      pointCount += static_cast<int>(result.points.size());
+      for (const NavPathResult::Segment& segment : result.segments) {
+        if (segment.type != NavTraversalType::Walk) {
+          ++specialSegmentCount;
+        }
+      }
+    }
+    RuntimeTelemetry::AddCounter("navigation.find_paths_batch.success", static_cast<double>(successCount));
+    RuntimeTelemetry::AddCounter("navigation.find_paths_batch.fail", static_cast<double>(outResults.size() - static_cast<std::size_t>(successCount)));
+    RuntimeTelemetry::AddCounter("navigation.find_paths_batch.points", static_cast<double>(pointCount));
+    RuntimeTelemetry::AddCounter("navigation.find_paths_batch.special_segments", static_cast<double>(specialSegmentCount));
   }
 #endif
 }
@@ -985,6 +1968,65 @@ bool NavMesh::GetDebugGraphEdges(std::vector<XVECTOR3>& outVertices,
         appendGraphEdge(centers[static_cast<std::size_t>(polyIndex)],
                         centers[static_cast<std::size_t>(neighborPolyIndex)]);
       }
+    }
+  }
+
+  return !outVertices.empty() && !outIndices.empty();
+#endif
+}
+
+bool NavMesh::GetDebugOffMeshLinks(NavTraversalType type,
+                                   std::vector<XVECTOR3>& outVertices,
+                                   std::vector<unsigned int>& outIndices,
+                                   float verticalOffset) const {
+  outVertices.clear();
+  outIndices.clear();
+#if !defined(T850_ENABLE_RECAST)
+  (void)type;
+  (void)verticalOffset;
+  return false;
+#else
+  if (!IsReady() || type == NavTraversalType::Walk) {
+    return false;
+  }
+
+  const dtNavMesh* detourMesh = m_impl->navMesh.get();
+  const int maxTiles = detourMesh ? detourMesh->getMaxTiles() : 0;
+  const float arrowLength = (std::max)(0.20f, m_impl->settings.agentRadius * 0.75f);
+  const float arrowHalfWidth = arrowLength * 0.45f;
+
+  auto appendLine = [&](const XVECTOR3& a, const XVECTOR3& b) {
+    const unsigned int base = static_cast<unsigned int>(outVertices.size());
+    outVertices.push_back(a);
+    outVertices.push_back(b);
+    outIndices.push_back(base);
+    outIndices.push_back(base + 1);
+  };
+
+  for (int tileIndex = 0; tileIndex < maxTiles; ++tileIndex) {
+    const dtMeshTile* tile = detourMesh->getTile(tileIndex);
+    if (!tile || !tile->header || !tile->offMeshCons) {
+      continue;
+    }
+
+    for (int linkIndex = 0; linkIndex < tile->header->offMeshConCount; ++linkIndex) {
+      const dtOffMeshConnection& connection = tile->offMeshCons[linkIndex];
+      if (DecodeOffMeshUserId(connection.userId) != type) {
+        continue;
+      }
+
+      XVECTOR3 start(connection.pos[0], connection.pos[1] + verticalOffset, connection.pos[2], 1.0f);
+      XVECTOR3 end(connection.pos[3], connection.pos[4] + verticalOffset, connection.pos[5], 1.0f);
+      appendLine(start, end);
+
+      XVECTOR3 direction = end - start;
+      direction.y = 0.0f;
+      direction.w = 0.0f;
+      direction = NormalizeHorizontalOr(direction, XVECTOR3(0.0f, 0.0f, 1.0f, 0.0f));
+      const XVECTOR3 right(-direction.z, 0.0f, direction.x, 0.0f);
+      const XVECTOR3 arrowBase = end - direction * arrowLength;
+      appendLine(end, arrowBase + right * arrowHalfWidth);
+      appendLine(end, arrowBase - right * arrowHalfWidth);
     }
   }
 

--- a/T850/Framework/src/physics/Q3BspCollision.cpp
+++ b/T850/Framework/src/physics/Q3BspCollision.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <optional>
 
 namespace t850 {
 
@@ -46,16 +47,32 @@ struct Q3ClipJumpPadDesc {
   int entity_id = 0;
   Q3ClipVec3 mins;
   Q3ClipVec3 maxs;
+  std::optional<Q3ClipVec3> target_position;
   Q3ClipVec3 velocity;
+};
+
+struct Q3ClipReachabilityDesc {
+  int source_area = 0;
+  int target_area = 0;
+  int face = 0;
+  int edge = 0;
+  Q3ClipVec3 start;
+  Q3ClipVec3 end;
+  std::string travel_type;
+  int travel_type_id = 0;
+  int travel_flags = 0;
+  int travel_time = 0;
 };
 
 struct Q3ClipFileDesc {
   int version = 1;
   std::string source;
+  std::string aas_source;
   float unit_scale = 1.0f;
   std::vector<Q3ClipBrushDesc> brushes;
   std::vector<Q3ClipPatchFacetDesc> patch_facets;
   std::vector<Q3ClipJumpPadDesc> jump_pads;
+  std::vector<Q3ClipReachabilityDesc> reachabilities;
 };
 
 namespace {
@@ -341,14 +358,57 @@ bool Q3BspCollisionWorld::Load(const std::string& resourcePath, std::string* err
     jumpPad.entityId = static_cast<uint32_t>((std::max)(0, jumpPadDesc.entity_id));
     jumpPad.mins = XVECTOR3(jumpPadDesc.mins.x, jumpPadDesc.mins.y, jumpPadDesc.mins.z, 1.0f);
     jumpPad.maxs = XVECTOR3(jumpPadDesc.maxs.x, jumpPadDesc.maxs.y, jumpPadDesc.maxs.z, 1.0f);
+    if (jumpPadDesc.target_position) {
+      jumpPad.targetPosition = XVECTOR3(
+          jumpPadDesc.target_position->x,
+          jumpPadDesc.target_position->y,
+          jumpPadDesc.target_position->z,
+          1.0f);
+      jumpPad.hasTargetPosition =
+          std::isfinite(jumpPad.targetPosition.x) &&
+          std::isfinite(jumpPad.targetPosition.y) &&
+          std::isfinite(jumpPad.targetPosition.z);
+    }
     jumpPad.velocity = XVECTOR3(jumpPadDesc.velocity.x, jumpPadDesc.velocity.y, jumpPadDesc.velocity.z, 0.0f);
     if (jumpPad.mins.x > jumpPad.maxs.x) std::swap(jumpPad.mins.x, jumpPad.maxs.x);
     if (jumpPad.mins.y > jumpPad.maxs.y) std::swap(jumpPad.mins.y, jumpPad.maxs.y);
     if (jumpPad.mins.z > jumpPad.maxs.z) std::swap(jumpPad.mins.z, jumpPad.maxs.z);
     if (std::isfinite(jumpPad.velocity.x) &&
-        std::isfinite(jumpPad.velocity.y) &&
-        std::isfinite(jumpPad.velocity.z)) {
+    std::isfinite(jumpPad.velocity.y) &&
+    std::isfinite(jumpPad.velocity.z)) {
       m_jumpPads.push_back(jumpPad);
+    }
+  }
+
+  m_reachabilities.reserve(desc.reachabilities.size());
+  for (const Q3ClipReachabilityDesc& reachabilityDesc : desc.reachabilities) {
+    Reachability reachability;
+    reachability.sourceArea = static_cast<uint32_t>((std::max)(0, reachabilityDesc.source_area));
+    reachability.targetArea = static_cast<uint32_t>((std::max)(0, reachabilityDesc.target_area));
+    reachability.face = reachabilityDesc.face;
+    reachability.edge = reachabilityDesc.edge;
+    reachability.start = XVECTOR3(
+        reachabilityDesc.start.x,
+        reachabilityDesc.start.y,
+        reachabilityDesc.start.z,
+        1.0f);
+    reachability.end = XVECTOR3(
+        reachabilityDesc.end.x,
+        reachabilityDesc.end.y,
+        reachabilityDesc.end.z,
+        1.0f);
+    reachability.travelType = reachabilityDesc.travel_type;
+    reachability.travelTypeId = static_cast<uint32_t>((std::max)(0, reachabilityDesc.travel_type_id));
+    reachability.travelFlags = static_cast<uint32_t>((std::max)(0, reachabilityDesc.travel_flags));
+    reachability.travelTime = static_cast<uint32_t>((std::max)(0, reachabilityDesc.travel_time));
+    if (std::isfinite(reachability.start.x) &&
+        std::isfinite(reachability.start.y) &&
+        std::isfinite(reachability.start.z) &&
+        std::isfinite(reachability.end.x) &&
+        std::isfinite(reachability.end.y) &&
+        std::isfinite(reachability.end.z) &&
+        !reachability.travelType.empty()) {
+      m_reachabilities.push_back(std::move(reachability));
     }
   }
 
@@ -365,11 +425,12 @@ bool Q3BspCollisionWorld::Load(const std::string& resourcePath, std::string* err
   m_surfaceClipEpsilon = (std::max)(kQ3SurfaceClipEpsilon * unitScale, kMinTraceEpsilon);
   m_triggerTouchSlop = (std::max)(kQ3EntityLinkEpsilon * unitScale, m_surfaceClipEpsilon);
   T8_LOG_INFO(
-      "[Q3BspCollision] Loaded %s brushes=%zu patchFacets=%zu jumpPads=%zu",
+      "[Q3BspCollision] Loaded %s brushes=%zu patchFacets=%zu jumpPads=%zu reachabilities=%zu",
       resourcePath.c_str(),
       m_brushes.size(),
       m_patchFacets.size(),
-      m_jumpPads.size());
+      m_jumpPads.size(),
+      m_reachabilities.size());
   return true;
 }
 
@@ -378,6 +439,7 @@ void Q3BspCollisionWorld::Clear() {
   m_brushes.clear();
   m_patchFacets.clear();
   m_jumpPads.clear();
+  m_reachabilities.clear();
   m_surfaceClipEpsilon = kQ3SurfaceClipEpsilon * kDefaultQ3UnitScale;
   m_triggerTouchSlop = kQ3EntityLinkEpsilon * kDefaultQ3UnitScale;
 }

--- a/T850/Framework/src/scene/PrimitiveManager.cpp
+++ b/T850/Framework/src/scene/PrimitiveManager.cpp
@@ -19,6 +19,7 @@
 #include <scene/SplineWireframe.h>
 #include <core/EngineContext.h>
 #include <utils/Log.h>
+#include <exception>
 
 namespace t850 {
   PrimitiveBase*	PrimitiveManager::GetPrimitive(unsigned int index) const {
@@ -41,7 +42,13 @@ namespace t850 {
     RenderMesh* probe = new RenderMesh();
     probe->SetEngineContext(m_engineContext);
     T8_LOG_INFO("Loading mesh begin: '%s'", fname);
-    probe->Load(fname);
+    try {
+      probe->Load(fname);
+    } catch (const std::exception& ex) {
+      T8_LOG_ERROR("Mesh '%s' threw while loading: %s", fname ? fname : "<null>", ex.what());
+      delete probe;
+      return -1;
+    }
     T8_LOG_INFO("Loading mesh: '%s'", fname);
     if (!probe->xFile) {
       T8_LOG_ERROR("Mesh '%s' failed to load; primitive creation aborted", fname);

--- a/T850/Framework/src/utils/CameraProfiles.cpp
+++ b/T850/Framework/src/utils/CameraProfiles.cpp
@@ -1,6 +1,7 @@
 #include <pch.h>
 
 #include <utils/CameraProfiles.h>
+#include <utils/Log.h>
 
 #include <algorithm>
 #include <cmath>
@@ -62,8 +63,23 @@ void ApplyMouseLook(Camera& camera, const CameraInputState& input, float sensiti
   if (!input.mouseLook) {
     return;
   }
-  camera.MoveYaw(input.mouseDeltaX * sensitivity);
-  camera.MovePitch(input.mouseDeltaY * sensitivity);
+  const float yawStep = input.mouseDeltaX * sensitivity;
+  const float pitchStep = input.mouseDeltaY * sensitivity;
+  T8_LOG_VERBOSE("[CameraMouse] delta=(%.3f,%.3f) sensitivity=%.6f yawStep=%.6f pitchStep=%.6f before=(yaw=%.6f,pitch=%.6f,roll=%.6f)",
+                 input.mouseDeltaX,
+                 input.mouseDeltaY,
+                 sensitivity,
+                 yawStep,
+                 pitchStep,
+                 camera.Yaw,
+                 camera.Pitch,
+                 camera.Roll);
+  camera.MoveYaw(yawStep);
+  camera.MovePitch(pitchStep);
+  T8_LOG_VERBOSE("[CameraMouse] after=(yaw=%.6f,pitch=%.6f,roll=%.6f)",
+                 camera.Yaw,
+                 camera.Pitch,
+                 camera.Roll);
 }
 
 KinematicCharacterInput BuildCharacterInput(const Camera& camera, const CameraInputState& input) {
@@ -422,6 +438,10 @@ void CameraController::HandleInput(const CameraInputState& input) {
   if (m_camera && GetActiveProfile()) {
     GetActiveProfile()->HandleInput(*m_camera, input);
   }
+}
+
+void CameraController::ClearInput() {
+  HandleInput(CameraInputState{});
 }
 
 void CameraController::Update(float deltaSeconds, const CameraUpdateContext& context) {

--- a/T850/Framework/src/utils/ConfigRuntime.cpp
+++ b/T850/Framework/src/utils/ConfigRuntime.cpp
@@ -387,7 +387,6 @@ bool ValidateConfig(Config& cfg) {
   }
 
   if (cfg.flags.dumpEnabled && cfg.flags.dumpByFrame && cfg.dumpFrame < 0) {
-    WarnConfigAdjusted("dumpFrame", "frame dump requested with a negative frame, disabling dump");
     cfg.flags.dumpEnabled = false;
     valid = false;
   }
@@ -455,7 +454,7 @@ void ApplyCommandLine(int argc, char** argv, Config& cfg) {
     else if (arg == "--api" && i + 1 < argc) {
       cfg.api = argv[++i];
     }
-    else if (arg == "--dump-frame" || arg == "--dumpSnapshot-frame") {
+    else if (arg == "--dump-frame" || arg == "--dumpFrame" || arg == "--dumpSnapshot-frame") {
       int value = 0;
       if (ReadIntArgument(arg, argc, argv, i, value)) {
         cfg.flags.dumpEnabled = true;
@@ -614,6 +613,7 @@ void PrintHelp() {
     << "  --orbitYaw <radians>               Override Sandbox orbit yaw after model fit\n\n"
     << "Capture/debug:\n"
     << "  --dump-frame <frame>               Dump render targets at frame\n"
+    << "  --dumpFrame <frame>                Alias for --dump-frame\n"
     << "  --dumpSnapshot-frame <frame>       Legacy alias for --dump-frame\n"
     << "  --dumpSnapshot-seconds <seconds>   Dump render targets after elapsed seconds\n"
     << "  --debugFrames                      Enable spacebar dump/exit debug flow\n"

--- a/T850/Framework/src/video/vulkan/VulkanDriver.cpp
+++ b/T850/Framework/src/video/vulkan/VulkanDriver.cpp
@@ -1777,7 +1777,8 @@ namespace t850 {
     // Submit
     VkSemaphore waitSemaphores[] = { m_imageAvailableSemaphores[m_currentFrame] };
     VkPipelineStageFlags waitStages[] = {
-      latePresentCopied ? VK_PIPELINE_STAGE_TRANSFER_BIT : VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
+      static_cast<VkPipelineStageFlags>(
+          latePresentCopied ? VK_PIPELINE_STAGE_TRANSFER_BIT : VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
     };
     VkSemaphore presentSemaphore =
       (m_imageIndex < m_imageRenderFinishedSemaphores.size())

--- a/T850/Framework/src/video/vulkan/VulkanDriver.cpp
+++ b/T850/Framework/src/video/vulkan/VulkanDriver.cpp
@@ -1503,7 +1503,7 @@ namespace t850 {
       EndRenderPassIfActive(cmd);
 
       VkClearValue clearValues[2] = {};
-      clearValues[0].color = { {0.9f, 0.9f, 0.9f, 1.0f} };
+      clearValues[0].color = { {0.227f, 0.227f, 0.227f, 1.0f} };
       clearValues[1].depthStencil = { 0.0f, 0 };
 
       VkRenderPassBeginInfo rpBegin = { VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO };
@@ -1520,7 +1520,72 @@ namespace t850 {
 
       vkCmdSetViewport(cmd, 0, 1, &m_viewport);
       vkCmdSetScissor(cmd, 0, 1, &m_scissorRect);
-      T8_TRACE(EvClearRT(-1, 1u | 2u, 0.9f, 0.9f, 0.9f, 1.0f, 0.0f, 0));
+      T8_TRACE(EvClearRT(-1, 1u | 2u, 0.227f, 0.227f, 0.227f, 1.0f, 0.0f, 0));
+    }
+  }
+
+  void VulkanDriver::ClearWithColor(float r, float g, float b, float a) {
+    if (!m_frameStarted) {
+      BeginFrame();
+      m_frameStarted = true;
+    }
+
+    if (!m_renderPassActive) {
+      Clear();
+    }
+    if (!m_renderPassActive) {
+      return;
+    }
+
+    VkCommandBuffer cmd = m_commandBuffers[m_currentFrame];
+    std::vector<VkClearAttachment> attachments;
+    VkClearRect clearRect = {};
+    clearRect.rect.offset = { 0, 0 };
+    clearRect.baseArrayLayer = 0;
+    clearRect.layerCount = 1;
+
+    if (CurrentRT >= 0 && CurrentRT < static_cast<int>(RTs.size()) && RTs[CurrentRT]) {
+      VulkanRT* rt = static_cast<VulkanRT*>(RTs[CurrentRT]);
+      for (int colorIndex = 0; colorIndex < rt->number_RT; ++colorIndex) {
+        VkClearAttachment attachment = {};
+        attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        attachment.colorAttachment = static_cast<uint32_t>(colorIndex);
+        attachment.clearValue.color = {{ r, g, b, a }};
+        attachments.push_back(attachment);
+      }
+      if (rt->m_depthImage) {
+        VkClearAttachment attachment = {};
+        attachment.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+        attachment.clearValue.depthStencil = { 0.0f, 0 };
+        attachments.push_back(attachment);
+      }
+      clearRect.rect.extent = { static_cast<uint32_t>(rt->w), static_cast<uint32_t>(rt->h) };
+    } else {
+      VkClearAttachment colorAttachment = {};
+      colorAttachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+      colorAttachment.colorAttachment = 0;
+      colorAttachment.clearValue.color = {{ r, g, b, a }};
+      attachments.push_back(colorAttachment);
+
+      VkClearAttachment depthAttachment = {};
+      depthAttachment.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+      depthAttachment.clearValue.depthStencil = { 0.0f, 0 };
+      attachments.push_back(depthAttachment);
+      clearRect.rect.extent = m_swapChainExtent;
+    }
+
+    if (!attachments.empty() && clearRect.rect.extent.width > 0 && clearRect.rect.extent.height > 0) {
+      vkCmdClearAttachments(cmd,
+                            static_cast<uint32_t>(attachments.size()),
+                            attachments.data(),
+                            1,
+                            &clearRect);
+      T8_TRACE(EvClearRT(CurrentRT,
+                         (CurrentRT >= 0 && CurrentRT < static_cast<int>(RTs.size()) && RTs[CurrentRT])
+                             ? ((static_cast<VulkanRT*>(RTs[CurrentRT])->number_RT > 0 ? 1u : 0u) |
+                                (static_cast<VulkanRT*>(RTs[CurrentRT])->m_depthImage ? 2u : 0u))
+                             : (1u | 2u),
+                         r, g, b, a, 0.0f, 0));
     }
   }
 
@@ -2029,7 +2094,7 @@ namespace t850 {
     rpBegin.framebuffer = m_backbufferFramebuffers[m_imageIndex];
     rpBegin.renderArea.extent = { (uint32_t)width, (uint32_t)height };
     VkClearValue clears[2] = {};
-    clears[0].color = {{0.9f, 0.9f, 0.9f, 1.0f}};
+    clears[0].color = {{0.227f, 0.227f, 0.227f, 1.0f}};
     clears[1].depthStencil = {0.0f, 0};
     rpBegin.clearValueCount = 2;
     rpBegin.pClearValues = clears;

--- a/T850/FrameworkImGui/src/ImGuiSystem.cpp
+++ b/T850/FrameworkImGui/src/ImGuiSystem.cpp
@@ -158,8 +158,6 @@ bool ImGuiSystem::Init(RootFramework* framework, const char* iniFileName, bool e
     ID3D12Device* device = static_cast<D3D12Device*>(T8Device)->GetNativeDevice();
     auto& srvHeap = d3d12Driver->GetHeap(D3D12Heap::CBV_SRV_UAV_VISIBLE);
     m_d3d12SrvHeap = srvHeap.GetHeap();
-    D3D12_CPU_DESCRIPTOR_HANDLE fontCpu = srvHeap.AllocateCPU();
-    D3D12_GPU_DESCRIPTOR_HANDLE fontGpu = srvHeap.AllocateGPU();
 
     ImGui_ImplDX12_InitInfo initInfo = {};
     initInfo.Device = device;
@@ -168,8 +166,25 @@ bool ImGuiSystem::Init(RootFramework* framework, const char* iniFileName, bool e
     initInfo.RTVFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
     initInfo.DSVFormat = DXGI_FORMAT_D32_FLOAT;
     initInfo.SrvDescriptorHeap = m_d3d12SrvHeap;
-    initInfo.LegacySingleSrvCpuDescriptor = fontCpu;
-    initInfo.LegacySingleSrvGpuDescriptor = fontGpu;
+    initInfo.UserData = &srvHeap;
+    initInfo.SrvDescriptorAllocFn =
+        [](ImGui_ImplDX12_InitInfo* info,
+           D3D12_CPU_DESCRIPTOR_HANDLE* outCpu,
+           D3D12_GPU_DESCRIPTOR_HANDLE* outGpu) {
+          auto* heap = static_cast<D3D12Heap*>(info ? info->UserData : nullptr);
+          if (!heap || !outCpu || !outGpu) {
+            if (outCpu) *outCpu = D3D12_CPU_DESCRIPTOR_HANDLE{0};
+            if (outGpu) *outGpu = D3D12_GPU_DESCRIPTOR_HANDLE{0};
+            return;
+          }
+          *outCpu = heap->AllocateCPU();
+          *outGpu = heap->AllocateGPU();
+        };
+    initInfo.SrvDescriptorFreeFn =
+        [](ImGui_ImplDX12_InitInfo*,
+           D3D12_CPU_DESCRIPTOR_HANDLE,
+           D3D12_GPU_DESCRIPTOR_HANDLE) {
+        };
     rendererOK = ImGui_ImplDX12_Init(&initInfo);
   }
 #endif

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -817,8 +817,11 @@ void EditorApp::CloneSelected() {
     const std::string name = makeUniqueObjectName(sourceName);
     const std::string ragdollResourcePath = src.ragdollResourcePath;
     const bool visible = src.visible;
+    const std::optional<bool> mobileVisible = src.mobileVisible;
     const bool frozen = src.frozen;
     const bool showWire = src.showWire;
+    const std::optional<float> navAgentFrontYawOffsetDeg = src.navAgentFrontYawOffsetDeg;
+    const std::optional<float> navAgentFaceYawSign = src.navAgentFaceYawSign;
     const XVECTOR3 position = src.wireframe.Position();
     const XVECTOR3 rotation = src.wireframe.EulerRadians();
     const XVECTOR3 scale = src.wireframe.Scale();
@@ -852,8 +855,11 @@ void EditorApp::CloneSelected() {
     clone.name = name;
     clone.meshPath = meshPath;
     clone.visible = visible;
+    clone.mobileVisible = mobileVisible;
     clone.frozen = frozen;
     clone.showWire = showWire;
+    clone.navAgentFrontYawOffsetDeg = navAgentFrontYawOffsetDeg;
+    clone.navAgentFaceYawSign = navAgentFaceYawSign;
     clone.ragdollResourcePath = ragdollResourcePath;
     clone.ragdollDebugDraw = sourceDebugDraw;
     clone.litInst.CreateInstance(m_primMgr.GetPrimitive(id), &m_vp);
@@ -1097,6 +1103,8 @@ void EditorApp::OnUpdate() {
           obj.mobileVisible = od.mobile_visible;
           obj.frozen   = od.frozen;
           obj.showWire = od.show_wire;
+          obj.navAgentFrontYawOffsetDeg = od.nav_agent_front_yaw_offset_deg;
+          obj.navAgentFaceYawSign = od.nav_agent_face_yaw_sign;
         } else {
           g_unloadedSceneObjects.push_back(od);
           T8_LOG_ERROR("[T8ditor] Preserving unloaded scene object '%s' mesh='%s' for save",
@@ -2186,6 +2194,8 @@ void EditorApp::OnDraw() {
           od.mobile_visible = obj.mobileVisible;
           od.frozen    = obj.frozen;
           od.show_wire = obj.showWire;
+          od.nav_agent_front_yaw_offset_deg = obj.navAgentFrontYawOffsetDeg;
+          od.nav_agent_face_yaw_sign = obj.navAgentFaceYawSign;
           sf.objects.push_back(od);
         }
         for (const SceneObjectDesc& od : g_unloadedSceneObjects) {

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -22,6 +22,7 @@
 #include <utils/xMaths.h>
 #include <utils/Picking.h>
 #include <debug/FrameDumper.h>
+#include <debug/LoadingProgress.h>
 
 #include <Descriptors.h>
 
@@ -49,6 +50,7 @@ namespace t8ditor {
 
 namespace {
   std::string g_startupMeshPath;
+  int g_startupDumpFrame = -1;
   const float kRadToDeg = 180.0f / xPI;
   const float kDegToRad = xPI / 180.0f;
   constexpr float kMinEditableScale = 0.000001f;
@@ -124,10 +126,35 @@ namespace {
   // Frame dumper for RT snapshot debugging (space key)
   t850::FrameDumper g_dumper;
   bool              g_dumperInited = false;
+
+  std::string FormatLoadingProgressForConsole(const t850::LoadingProgress::Snapshot& snapshot) {
+    if (!snapshot.active) {
+      return {};
+    }
+    std::string text = "[Loading] " + snapshot.phase;
+    if (!snapshot.item.empty()) {
+      text += ": " + snapshot.item;
+    }
+    if (!snapshot.detail.empty()) {
+      text += " - " + snapshot.detail;
+    }
+    char percentText[32] = {};
+    std::snprintf(percentText, sizeof(percentText), " (%.0f%%)", snapshot.percent);
+    text += percentText;
+    return text;
+  }
+
+  void LogEditorLoadingLabel(const char* phase, const char* item) {
+    T8_LOG_INFO("[Loading] %s: %s", phase ? phase : "", item ? item : "");
+  }
 }
 
 void SetStartupMeshPath(const std::string& p) {
   g_startupMeshPath = p;
+}
+
+void SetStartupDumpFrame(int frame) {
+  g_startupDumpFrame = frame;
 }
 
 // Helpers to access current selection
@@ -600,102 +627,146 @@ void EditorApp::CreateAssets() {
     return;
   }
 
+  ImGuiLogCaptureStart();
+  t850::LoadingProgress::Reset(100.0f, "Starting editor", "Preparing renderer");
+  {
+    auto lastLoadingLine = std::make_shared<std::string>();
+    t850::LoadingProgress::SetFrameCallback([lastLoadingLine]() {
+      const t850::LoadingProgress::Snapshot snapshot = t850::LoadingProgress::GetSnapshot();
+      if (snapshot.detail.empty() && snapshot.percent < 99.5f) {
+        return;
+      }
+      const std::string line = FormatLoadingProgressForConsole(snapshot);
+      if (!line.empty() && line != *lastLoadingLine) {
+        *lastLoadingLine = line;
+        T8_LOG_INFO("%s", line.c_str());
+      }
+    });
+  }
+
   const auto& desc = pFramework->aplicationDescriptor;
   const int w = (int)desc.width;
   const int h = (int)desc.height;
 
-  m_camera.Init(w, h, 50.0f);
-  m_camera.SetTarget(XVECTOR3(0.0f, 0.0f, 0.0f));
-  m_camera.Frame();
-  m_lastW = w;
-  m_lastH = h;
-
-  if (!m_lines.Create())
-    T8_LOG_ERROR("[T8ditor] EditorLineRenderer::Create failed");
-  m_grid.Create(10, 1.0f);
-  m_gizmo.Create();
-
-  m_sceneProps.AddCamera(&m_camera.GetCameraMutable());
-  m_sceneProps.AddDirectionalLight(
-    XVECTOR3(0.0f, -1.0f, 0.0f), XVECTOR3(1.0f, 1.0f, 1.0f), 1.5f, true);
-  m_sceneProps.ActiveLights = 1;
-  m_sceneProps.AmbientColor = XVECTOR3(0.15f, 0.15f, 0.15f);
-  m_sceneProps.EnvFactor = 0.3f;  // reduced env reflections (no HDR tone mapping)
-
-  XMatIdentity(m_vp);
-  t850::GetEngineContext().physics = &m_physics;
-  if (!m_physics.Initialize() && m_physics.IsAvailable()) {
-    T8_LOG_ERROR("[T8ditor] Physics runtime failed to initialize");
-  }
-  m_primMgr.SetEngineContext(&t850::GetEngineContext());
-  m_primMgr.Init();
-  m_primMgr.SetVP(&m_vp);
-  m_primMgr.SetSceneProps(&m_sceneProps);
-  if (!m_physicsDebug.Create()) {
-    T8_LOG_ERROR("[T8ditor] Physics debug renderer failed to initialize");
-  } else {
-    m_physicsDebug.SetDepthTestEnabled(false);
+  {
+    LogEditorLoadingLabel("Initializing editor", "Camera and viewport");
+    t850::LoadingProgress::ScopedStep cameraStep("Initializing editor", "Camera and viewport", 8.0f);
+    m_camera.Init(w, h, 50.0f);
+    m_camera.SetTarget(XVECTOR3(0.0f, 0.0f, 0.0f));
+    m_camera.Frame();
+    m_lastW = w;
+    m_lastH = h;
   }
 
-  // Load skybox as persistent editor backdrop
-  if (std::filesystem::exists("Models/SkyBox.glb")) {
-    g_skyboxMgr.SetEngineContext(&t850::GetEngineContext());
-    g_skyboxMgr.Init();
-    g_skyboxMgr.SetVP(&m_vp);
-    g_skyboxMgr.SetSceneProps(&m_sceneProps);
-    int sid = g_skyboxMgr.CreateMesh("Models/SkyBox.glb");
-    if (sid >= 0) {
-      g_skyboxPrimId = sid;
-      g_skyboxInst.CreateInstance(g_skyboxMgr.GetPrimitive(sid), &m_vp);
-      g_skyboxInst.Update();
+  {
+    LogEditorLoadingLabel("Initializing editor", "Viewport helpers");
+    t850::LoadingProgress::ScopedStep helpersStep("Initializing editor", "Viewport helpers", 12.0f);
+    if (!m_lines.Create())
+      T8_LOG_ERROR("[T8ditor] EditorLineRenderer::Create failed");
+    m_grid.Create(10, 1.0f);
+    m_gizmo.Create();
+  }
+
+  {
+    LogEditorLoadingLabel("Initializing editor", "Scene properties");
+    t850::LoadingProgress::ScopedStep scenePropsStep("Initializing editor", "Scene properties", 8.0f);
+    m_sceneProps.AddCamera(&m_camera.GetCameraMutable());
+    m_sceneProps.AddDirectionalLight(
+      XVECTOR3(0.0f, -1.0f, 0.0f), XVECTOR3(1.0f, 1.0f, 1.0f), 1.5f, true);
+    m_sceneProps.ActiveLights = 1;
+    m_sceneProps.AmbientColor = XVECTOR3(0.15f, 0.15f, 0.15f);
+    m_sceneProps.EnvFactor = 0.3f;  // reduced env reflections (no HDR tone mapping)
+  }
+
+  {
+    LogEditorLoadingLabel("Initializing editor", "Physics and primitive managers");
+    t850::LoadingProgress::ScopedStep physicsStep("Initializing editor", "Physics and primitive managers", 12.0f);
+    XMatIdentity(m_vp);
+    t850::GetEngineContext().physics = &m_physics;
+    if (!m_physics.Initialize() && m_physics.IsAvailable()) {
+      T8_LOG_ERROR("[T8ditor] Physics runtime failed to initialize");
+    }
+    m_primMgr.SetEngineContext(&t850::GetEngineContext());
+    m_primMgr.Init();
+    m_primMgr.SetVP(&m_vp);
+    m_primMgr.SetSceneProps(&m_sceneProps);
+    if (!m_physicsDebug.Create()) {
+      T8_LOG_ERROR("[T8ditor] Physics debug renderer failed to initialize");
+    } else {
+      m_physicsDebug.SetDepthTestEnabled(false);
+    }
+  }
+
+  {
+    LogEditorLoadingLabel("Loading editor assets", "Skybox");
+    t850::LoadingProgress::ScopedStep skyboxStep("Loading editor assets", "Skybox", 18.0f);
+    if (std::filesystem::exists("Models/SkyBox.glb")) {
+      g_skyboxMgr.SetEngineContext(&t850::GetEngineContext());
+      g_skyboxMgr.Init();
+      g_skyboxMgr.SetVP(&m_vp);
       g_skyboxMgr.SetSceneProps(&m_sceneProps);
-      g_skyboxReady = true;
+      int sid = g_skyboxMgr.CreateMesh("Models/SkyBox.glb");
+      if (sid >= 0) {
+        g_skyboxPrimId = sid;
+        g_skyboxInst.CreateInstance(g_skyboxMgr.GetPrimitive(sid), &m_vp);
+        g_skyboxInst.Update();
+        g_skyboxMgr.SetSceneProps(&m_sceneProps);
+        g_skyboxReady = true;
+      }
     }
   }
 
-  // Set up deferred render graph
-  if (g_renderGraph.Load("Scenes/T8ditor_RenderGraph.json")) {
-    g_renderGraph.CreateRenderTargets(pFramework->pVideoDriver, m_sceneProps);
-    XMatIdentity(g_quadVP);
-    for (int i = 0; i < 8; ++i) {
-      g_quads[i].CreateInstance(m_primMgr.GetPrimitive(t850::PrimitiveManager::QUAD), &g_quadVP);
-      g_quads[i].Update();
-    }
-    // Bind the G-buffer textures to quads[0] — the deferred lighting quad reads from these
-    if (!pFramework->pVideoDriver->RTs.empty()) {
-      auto* gbufferRT = pFramework->pVideoDriver->RTs[0];
-      for (int j = 0; j < (int)gbufferRT->vColorTextures.size() && j < 4; ++j)
-        g_quads[0].SetTexture(gbufferRT->vColorTextures[j], j);
-      if (gbufferRT->vColorTextures.size() > 4)
-        g_quads[0].SetTexture(gbufferRT->vColorTextures[4], 9);
-      if (gbufferRT->pDepthTexture)
-        g_quads[0].SetTexture(gbufferRT->pDepthTexture, 4);
-    }
-    g_deferredReady = true;
-    m_primMgr.SetSceneProps(&m_sceneProps); // re-set so QUAD gets pScProp
+  {
+    LogEditorLoadingLabel("Loading editor assets", "Render graph");
+    t850::LoadingProgress::ScopedStep graphStep("Loading editor assets", "Render graph", 24.0f);
+    if (g_renderGraph.Load("Scenes/T8ditor_RenderGraph.json")) {
+      g_renderGraph.CreateRenderTargets(pFramework->pVideoDriver, m_sceneProps);
+      XMatIdentity(g_quadVP);
+      for (int i = 0; i < 8; ++i) {
+        g_quads[i].CreateInstance(m_primMgr.GetPrimitive(t850::PrimitiveManager::QUAD), &g_quadVP);
+        g_quads[i].Update();
+      }
+      // Bind the G-buffer textures to quads[0] — the deferred lighting quad reads from these
+      if (!pFramework->pVideoDriver->RTs.empty()) {
+        auto* gbufferRT = pFramework->pVideoDriver->RTs[0];
+        for (int j = 0; j < (int)gbufferRT->vColorTextures.size() && j < 4; ++j)
+          g_quads[0].SetTexture(gbufferRT->vColorTextures[j], j);
+        if (gbufferRT->vColorTextures.size() > 4)
+          g_quads[0].SetTexture(gbufferRT->vColorTextures[4], 9);
+        if (gbufferRT->pDepthTexture)
+          g_quads[0].SetTexture(gbufferRT->pDepthTexture, 4);
+      }
+      g_deferredReady = true;
+      m_primMgr.SetSceneProps(&m_sceneProps); // re-set so QUAD gets pScProp
 
-    // Create a 1x1 white texture for shadow slot (deferred shader reads
-    // shadow from tex5; without it, Shadow=0 and everything multiplies to black)
-    unsigned char white[4] = { 255, 255, 255, 255 };
-    g_dummyWhiteTex = t850::T8Device->CreateTextureFromMemory(white, 1, 1, 4, "dummyWhite");
+      // Create a 1x1 white texture for shadow slot (deferred shader reads
+      // shadow from tex5; without it, Shadow=0 and everything multiplies to black)
+      unsigned char white[4] = { 255, 255, 255, 255 };
+      g_dummyWhiteTex = t850::T8Device->CreateTextureFromMemory(white, 1, 1, 4, "dummyWhite");
 
-    // Load environment cubemap for skybox (matID=0 in deferred shader samples texEnv)
-    g_dummyEnvMapIdx = t850::g_pBaseDriver->CreateTexture("sky/CubeMap_SkyWater.dds");
-    if (g_dummyEnvMapIdx >= 0) {
-      g_quads[0].SetEnvironmentMap(t850::g_pBaseDriver->GetTexture(g_dummyEnvMapIdx));
-      T8_LOG_INFO("[T8ditor] Environment cubemap loaded");
+      // Load environment cubemap for skybox (matID=0 in deferred shader samples texEnv)
+      g_dummyEnvMapIdx = t850::g_pBaseDriver->CreateTexture("sky/CubeMap_SkyWater.dds");
+      if (g_dummyEnvMapIdx >= 0) {
+        g_quads[0].SetEnvironmentMap(t850::g_pBaseDriver->GetTexture(g_dummyEnvMapIdx));
+        T8_LOG_INFO("[T8ditor] Environment cubemap loaded");
+      }
+
+      T8_LOG_INFO("[T8ditor] Deferred render graph ready");
+    } else {
+      T8_LOG_ERROR("[T8ditor] Render graph load failed — using forward fallback");
     }
-
-    T8_LOG_INFO("[T8ditor] Deferred render graph ready");
-  } else {
-    T8_LOG_ERROR("[T8ditor] Render graph load failed — using forward fallback");
   }
 
   // Initialize frame dumper (space key to dump)
   {
     t850::FrameDumperConfig cfg;
-    cfg.debugFrames = true;
-    cfg.keepRunning = true;
+    cfg.debugFrames = g_startupDumpFrame < 0;
+    cfg.keepRunning = g_startupDumpFrame < 0;
+    if (g_startupDumpFrame >= 0) {
+      cfg.dumpEnabled = true;
+      cfg.dumpByFrame = true;
+      cfg.dumpFrame = g_startupDumpFrame;
+    }
     g_dumper.Init(cfg);
     g_dumperInited = true;
   }
@@ -713,12 +784,17 @@ void EditorApp::CreateAssets() {
   }
 #endif
 
-  m_imguiReady = ImGuiInit(pFramework);
+  {
+    LogEditorLoadingLabel("Loading editor UI", "ImGui panels");
+    t850::LoadingProgress::ScopedStep imguiStep("Loading editor UI", "ImGui panels", 12.0f);
+    m_imguiReady = ImGuiInit(pFramework);
+  }
   if (!m_imguiReady)
     T8_LOG_ERROR("[T8ditor] ImGui init failed");
-  else
-    ImGuiLogCaptureStart();
 
+  t850::LoadingProgress::Complete("Editor ready", "T8ditor");
+  t850::LoadingProgress::ClearFrameCallback();
+  t850::LoadingProgress::Clear();
   T8_LOG_INFO("[T8ditor] CreateAssets done (%dx%d)", w, h);
 }
 
@@ -1182,17 +1258,7 @@ void EditorApp::OnInput() {
       else if (ctrlDown)
         g_undoStack.Undo();
       else {
-        SceneObject* sel = SelectedObject();
-        if (sel && sel->wireframe.IsLoaded()) {
-          // Center camera on the selected model's position with default viewing angle
-          XVECTOR3 modelPos = sel->wireframe.Position();
-          m_camera.SetTarget(modelPos);
-          m_camera.ResetViewAngle();  // reset yaw/pitch/distance to default, keep target
-          T8_LOG_INFO("[T8ditor] View centered on model at (%.1f, %.1f, %.1f)",
-                      modelPos.x, modelPos.y, modelPos.z);
-        } else {
-          m_camera.ResetToDefault();
-        }
+        FrameSelectedEntity();
       }
     }
     // Ctrl+Y also redoes
@@ -1271,6 +1337,83 @@ void EditorApp::ProcessSelectionInput() {
   if (IManager.PressedKey(T800K_SEMICOLON)) {
     scl.x /= sclStep; scl.y /= sclStep; scl.z /= sclStep;
   }
+}
+
+void EditorApp::FrameSelectedEntity() {
+  auto frameSphere = [&](const XVECTOR3& center, float radius, const char* label) {
+    m_camera.FrameBounds(center, radius);
+    T8_LOG_INFO("[T8ditor] Framed %s at (%.2f, %.2f, %.2f), radius=%.2f",
+                label ? label : "selection", center.x, center.y, center.z, radius);
+  };
+
+  if (g_selectionType == 0) {
+    bool haveBounds = false;
+    t850::AABB bounds;
+    auto addMeshBounds = [&](int index) {
+      if (index < 0 || index >= static_cast<int>(g_objects.size())) {
+        return;
+      }
+      const SceneObject& object = g_objects[static_cast<std::size_t>(index)];
+      if (!object.wireframe.IsLoaded()) {
+        return;
+      }
+      const t850::AABB objectBounds = object.wireframe.WorldAABB();
+      if (!haveBounds) {
+        bounds = objectBounds;
+        haveBounds = true;
+      } else {
+        if (objectBounds.vMin.x < bounds.vMin.x) bounds.vMin.x = objectBounds.vMin.x;
+        if (objectBounds.vMin.y < bounds.vMin.y) bounds.vMin.y = objectBounds.vMin.y;
+        if (objectBounds.vMin.z < bounds.vMin.z) bounds.vMin.z = objectBounds.vMin.z;
+        if (objectBounds.vMax.x > bounds.vMax.x) bounds.vMax.x = objectBounds.vMax.x;
+        if (objectBounds.vMax.y > bounds.vMax.y) bounds.vMax.y = objectBounds.vMax.y;
+        if (objectBounds.vMax.z > bounds.vMax.z) bounds.vMax.z = objectBounds.vMax.z;
+      }
+    };
+
+    if (!g_multiSelect.empty()) {
+      for (int index : g_multiSelect) {
+        addMeshBounds(index);
+      }
+    } else {
+      addMeshBounds(g_selectedIdx);
+    }
+
+    if (haveBounds) {
+      const XVECTOR3 center(
+          (bounds.vMin.x + bounds.vMax.x) * 0.5f,
+          (bounds.vMin.y + bounds.vMax.y) * 0.5f,
+          (bounds.vMin.z + bounds.vMax.z) * 0.5f,
+          1.0f);
+      const float dx = bounds.vMax.x - center.x;
+      const float dy = bounds.vMax.y - center.y;
+      const float dz = bounds.vMax.z - center.z;
+      frameSphere(center, std::sqrt(dx * dx + dy * dy + dz * dz), "mesh selection");
+      return;
+    }
+  } else if (g_selectionType == 1 && g_selectedIdx >= 0 && g_selectedIdx < static_cast<int>(g_cameras.size())) {
+    const SceneCamera& camera = g_cameras[static_cast<std::size_t>(g_selectedIdx)];
+    const XVECTOR3 center(
+        (camera.position.x + camera.target.x) * 0.5f,
+        (camera.position.y + camera.target.y) * 0.5f,
+        (camera.position.z + camera.target.z) * 0.5f,
+        1.0f);
+    const float dx = camera.position.x - camera.target.x;
+    const float dy = camera.position.y - camera.target.y;
+    const float dz = camera.position.z - camera.target.z;
+    frameSphere(center, (std::max)(1.0f, 0.5f * std::sqrt(dx * dx + dy * dy + dz * dz)), "camera");
+    return;
+  } else if (g_selectionType == 2 && g_selectedIdx >= 0 && g_selectedIdx < static_cast<int>(g_lights.size())) {
+    const SceneLight& light = g_lights[static_cast<std::size_t>(g_selectedIdx)];
+    const float radius = light.type == EditorLightType::Omni
+        ? (std::clamp)(light.radius, 1.0f, 100.0f)
+        : 3.0f;
+    frameSphere(light.position, radius, "light");
+    return;
+  }
+
+  m_camera.ResetToDefault();
+  T8_LOG_INFO("[T8ditor] Reset editor view");
 }
 
 // Project a world-space point to screen coordinates.
@@ -2265,6 +2408,32 @@ void EditorApp::OnDraw() {
         if (ImGui::TreeNodeEx("Scene Root", ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_DefaultOpen)) {
           // Meshes & Groups
           if (ImGui::TreeNodeEx("Meshes", ImGuiTreeNodeFlags_DefaultOpen)) {
+            ImGui::PushID("MeshesBulkControls");
+            if (ImGui::SmallButton("Show all")) {
+              for (SceneObject& object : g_objects) object.visible = true;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton("Hide all")) {
+              for (SceneObject& object : g_objects) object.visible = false;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton("Freeze all")) {
+              for (SceneObject& object : g_objects) object.frozen = true;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton("Unfreeze all")) {
+              for (SceneObject& object : g_objects) object.frozen = false;
+            }
+            if (ImGui::SmallButton("Wire all")) {
+              for (SceneObject& object : g_objects) object.showWire = true;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton("Wire none")) {
+              for (SceneObject& object : g_objects) object.showWire = false;
+            }
+            ImGui::Separator();
+            ImGui::PopID();
+
             // Track which meshes are in persistent groups
             std::set<int> groupedIndices;
             for (auto& grp : g_groups)
@@ -2336,6 +2505,25 @@ void EditorApp::OnDraw() {
           }
           // Cameras
           if (ImGui::TreeNodeEx("Cameras", ImGuiTreeNodeFlags_DefaultOpen)) {
+            ImGui::PushID("CamerasBulkControls");
+            if (ImGui::SmallButton("Show all")) {
+              for (SceneCamera& camera : g_cameras) camera.visible = true;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton("Hide all")) {
+              for (SceneCamera& camera : g_cameras) camera.visible = false;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton("Freeze all")) {
+              for (SceneCamera& camera : g_cameras) camera.frozen = true;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton("Unfreeze all")) {
+              for (SceneCamera& camera : g_cameras) camera.frozen = false;
+            }
+            ImGui::Separator();
+            ImGui::PopID();
+
             {
               bool isDefault = (g_activeCameraIdx < 0);
               ImGui::PushID(20000);
@@ -2373,6 +2561,25 @@ void EditorApp::OnDraw() {
           }
           // Lights
           if (ImGui::TreeNodeEx("Lights", ImGuiTreeNodeFlags_DefaultOpen)) {
+            ImGui::PushID("LightsBulkControls");
+            if (ImGui::SmallButton("Show all")) {
+              for (SceneLight& light : g_lights) light.visible = true;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton("Hide all")) {
+              for (SceneLight& light : g_lights) light.visible = false;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton("Freeze all")) {
+              for (SceneLight& light : g_lights) light.frozen = true;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton("Unfreeze all")) {
+              for (SceneLight& light : g_lights) light.frozen = false;
+            }
+            ImGui::Separator();
+            ImGui::PopID();
+
             for (int i = 0; i < (int)g_lights.size(); ++i) {
               auto& l = g_lights[i];
               ImGui::PushID(i + 30000);
@@ -2512,6 +2719,7 @@ void EditorApp::OnDraw() {
     ::Camera dummyLightCam;
     g_dumper.DumpFrame(drv, m_camera.GetCameraMutable(), dummyLightCam, m_sceneProps, rts, m_dtSecs);
     T8_LOG_INFO("[T8ditor] Frame dumped to disk");
+    if (g_dumper.ShouldExit()) exit(0);
   }
 
   T8_LOG_TRACE("[T8ditor] OnDraw: SwapBuffers...");

--- a/T850/T8ditor/EditorApp.h
+++ b/T850/T8ditor/EditorApp.h
@@ -49,6 +49,7 @@ namespace t8ditor {
 
   // Set by main.cpp before constructing the app.
   void SetStartupMeshPath(const std::string& p);
+  void SetStartupDumpFrame(int frame);
 
   class EditorApp : public t850::AppBase {
   public:
@@ -86,6 +87,7 @@ namespace t8ditor {
     void UpdateSkinnedAnimationAndRagdolls();
     void UploadSkinnedBoneTextures();
     void DrawRagdollInspector(struct SceneObject& obj);
+    void FrameSelectedEntity();
 
     Timer m_dtTimer;
     float m_dtSecs   = 0.0f;

--- a/T850/T8ditor/EditorCamera.cpp
+++ b/T850/T8ditor/EditorCamera.cpp
@@ -6,6 +6,7 @@
 
 #include <utils/InputManager.h>
 #include <utils/xMaths.h>   // xPI
+#include <algorithm>
 #include <cmath>
 
 namespace t8ditor {
@@ -40,6 +41,18 @@ void EditorCamera::SetTarget(const XVECTOR3& target) {
 
 void EditorCamera::Frame() {
   m_distance = FrameDistance;
+}
+
+void EditorCamera::FrameBounds(const XVECTOR3& center, float radius) {
+  m_target = center;
+  const float safeRadius = (std::max)(0.1f, radius);
+  const float aspect = m_viewportH > 0 ? static_cast<float>(m_viewportW) / static_cast<float>(m_viewportH) : 1.0f;
+  const float verticalFov = (std::max)(0.01f, m_cam.Fov);
+  const float horizontalFov = 2.0f * std::atan(std::tan(verticalFov * 0.5f) * (std::max)(0.01f, aspect));
+  const float fitFov = (std::max)(0.01f, (std::min)(verticalFov, horizontalFov));
+  m_distance = std::clamp((safeRadius / std::tan(fitFov * 0.5f)) * 1.25f, MinDistance, MaxDistance);
+  RecomputeEye();
+  m_cam.Update(0.0f);
 }
 
 void EditorCamera::ResetToDefault() {

--- a/T850/T8ditor/EditorCamera.h
+++ b/T850/T8ditor/EditorCamera.h
@@ -53,6 +53,7 @@ public:
 
   // Frame the target — re-center distance to FrameDistance.
   void Frame();
+  void FrameBounds(const XVECTOR3& center, float radius);
 
   // Reset camera to the default position and orientation.
   void ResetToDefault();

--- a/T850/T8ditor/SceneObject.h
+++ b/T850/T8ditor/SceneObject.h
@@ -37,6 +37,8 @@ struct SceneObject {
   std::optional<bool>   mobileVisible;
   bool                  frozen  = false;  // visible but not selectable
   bool                  showWire = false; // per-object wireframe override
+  std::optional<float>  navAgentFrontYawOffsetDeg;
+  std::optional<float>  navAgentFaceYawSign;
 
   std::string                         ragdollModelKey;
   std::string                         ragdollResourcePath;

--- a/T850/T8ditor/main.cpp
+++ b/T850/T8ditor/main.cpp
@@ -37,6 +37,7 @@ t850::AppBase* pApp = nullptr;
 namespace t8ditor {
   // Defined in EditorApp.cpp.
   void SetStartupMeshPath(const std::string& p);
+  void SetStartupDumpFrame(int frame);
 }
 
 static t850::AppBase*       g_pApp       = nullptr;
@@ -51,11 +52,13 @@ int main(int argc, char** argv) {
   desc.title     = "T8ditor";
 
   // Minimal CLI: --api {d3d12|d3d11|vulkan|gl}, --width N, --height N,
-  // --logFile PATH, --logLevel {error|info|debug|verbose|trace|0..4}, --mesh PATH.
+  // --logFile PATH, --logLevel {error|info|debug|verbose|trace|0..4}, --mesh PATH,
+  // --dump-frame N.
   // Default API is D3D12.
   int   logLevel = 3;
   std::string logFile;
   std::string meshPath;
+  int dumpFrame = -1;
 
   for (int i = 1; i < argc; ++i) {
     std::string a = argv[i];
@@ -69,6 +72,7 @@ int main(int argc, char** argv) {
     else if (a == "--width"  && i + 1 < argc) desc.width  = std::stoi(argv[++i]);
     else if (a == "--height" && i + 1 < argc) desc.height = std::stoi(argv[++i]);
     else if (a == "--mesh"   && i + 1 < argc) meshPath = argv[++i];
+    else if ((a == "--dump-frame" || a == "--dumpFrame") && i + 1 < argc) dumpFrame = std::stoi(argv[++i]);
     else if (a == "--logFile" && i + 1 < argc) logFile = argv[++i];
     else if (a == "--d3d12debug") t850::g_config.flags.d3d12Debug = true;
     else if (a == "--logLevel" && i + 1 < argc) {
@@ -110,6 +114,7 @@ int main(int argc, char** argv) {
     }
   }
   t8ditor::SetStartupMeshPath(meshPath);
+  t8ditor::SetStartupDumpFrame(dumpFrame);
 
   g_pApp = new t8ditor::EditorApp();
   pApp   = g_pApp;  // RenderMesh::Load() uses this global

--- a/T850/android/app/build.gradle
+++ b/T850/android/app/build.gradle
@@ -70,7 +70,7 @@ def t850ModelAssetIncludes = t850AndroidCommonAssetIncludes + [
     'Models/RagdollEdits/**',
     'Models/Q3/*_work/*_manifest.json'
 ]
-def t850ProductionAssetIncludes = t850AndroidCoreAssetIncludes + [
+def t850ProductionAssetIncludes = t850AndroidBaseAssetIncludes + [
     'Scenes/**',
     'Models/RagdollEdits/**',
     'Models/Q3/*_work/*_manifest.json'

--- a/T850/scripts/Launcher.ps1
+++ b/T850/scripts/Launcher.ps1
@@ -357,9 +357,13 @@ $xaml = @"
             <TextBlock Name="txtStatus" Text="" FontSize="12"
                        Foreground="#A6ADC8" Margin="0,0,0,4"
                        TextWrapping="Wrap"/>
-            <TextBlock Name="txtCmdPreview" Text="" FontSize="11"
-                       Foreground="#45475A" Margin="0"
-                       TextWrapping="Wrap" FontFamily="Consolas"/>
+            <TextBox Name="txtCmdPreview" Text="" FontSize="11"
+                     Foreground="#A6ADC8" Margin="0" Padding="0"
+                     TextWrapping="Wrap" FontFamily="Consolas"
+                     IsReadOnly="True" IsReadOnlyCaretVisible="True"
+                     Background="Transparent" BorderThickness="0"
+                     Height="Auto" MinHeight="24" VerticalContentAlignment="Top"
+                     Cursor="IBeam"/>
             <!-- Build output log -->
             <Border Name="pnlBuildOutput" Background="#0D1117" CornerRadius="4"
                     Margin="0,8,0,0" Padding="2" MaxHeight="200"
@@ -517,6 +521,7 @@ $script:SceneDependencyResult = @{ Ok = $true; Missing = @() }
 $script:SuppressSceneDependencyValidation = $false
 $script:LauncherInitializing = $true
 $script:LauncherBusy = $false
+$script:AssetDownloadInProgress = $false
 $script:AndroidDeviceRefreshInProgress = $false
 $script:SelectedAndroidDeviceSerial = ""
 $script:CloudAssetStatus = $null
@@ -571,14 +576,16 @@ function Update-DownloadAssetsButton {
     if (-not $btnDownloadAssets) { return }
     $status = $script:CloudAssetStatus
     $missing = if ($status) { [int]$status.Missing } else { 0 }
-    $btnDownloadAssets.Content = "Download Assets"
-    $btnDownloadAssets.IsEnabled = ((-not $script:LauncherBusy) -and ($missing -gt 0))
-    $btnDownloadAssets.ToolTip = if ($missing -gt 0) {
+    $btnDownloadAssets.Content = if ($script:AssetDownloadInProgress) { "Downloading..." } else { "Download Assets" }
+    $btnDownloadAssets.IsEnabled = -not $script:AssetDownloadInProgress
+    $btnDownloadAssets.ToolTip = if ($script:AssetDownloadInProgress) {
+        "Asset download is already running."
+    } elseif ($missing -gt 0) {
         "$missing cloud asset(s) missing. Click to download only missing files."
     } elseif ($status -and $status.Total -gt 0) {
-        "All cloud assets are present."
+        "All cloud assets are present. Click to scan again."
     } else {
-        "No cloud asset manifest is configured."
+        "Click to scan cloud asset manifests."
     }
 }
 
@@ -602,7 +609,15 @@ function Invoke-LauncherModelDownload {
         }
     }
     $status = Update-LauncherCloudAssetStatus
-    if ($status -and $status.Missing -eq 0 -and $status.Ok) { return $true }
+    if ($status -and $status.Missing -eq 0 -and $status.Ok) {
+        if (-not $Quiet) {
+            $message = if ($status.Total -gt 0) { "OK, all asset files are there." } else { $status.Message }
+            $txtStatus.Text = $message
+            $txtStatus.Foreground = $window.FindResource("GreenBrush")
+            [System.Windows.MessageBox]::Show($message, "T850 Launcher", "OK", "Information") | Out-Null
+        }
+        return $true
+    }
     if (Get-Command Ensure-T850CloudModels -ErrorAction SilentlyContinue) {
         $result = Ensure-T850CloudModels -RootDir $rootDir -AssetRoot $targetRoot -StatusCallback $statusCallback
         if (-not $result.Ok) {
@@ -1091,6 +1106,19 @@ function Invoke-LoggedProcess {
             try { $proc.Kill() } catch {}
         }
     }
+}
+
+function Format-LauncherCommandLine {
+    param(
+        [Parameter(Mandatory = $true)] [string]$FilePath,
+        [string[]]$Arguments = @()
+    )
+    $quotedArgs = @()
+    foreach ($arg in $Arguments) {
+        if ($arg -match '[\s",]') { $quotedArgs += ('"' + ($arg -replace '"', '\"') + '"') }
+        else { $quotedArgs += $arg }
+    }
+    return (('"' + $FilePath + '" ' + ($quotedArgs -join ' ')).Trim())
 }
 
 # ── Config load/save ──
@@ -2087,14 +2115,18 @@ function Update-Preview {
     if ($script:LauncherBusy) { return }
     $sceneDeps = Get-CachedSceneDependencyResult
     $assetStatus = $script:CloudAssetStatus
-    $assetsMissing = ($assetStatus -and $assetStatus.Missing -gt 0)
+    $assetsMissing = ($assetStatus -and $assetStatus.Configured -and ($assetStatus.Missing -gt 0 -or -not $assetStatus.Ok))
     if (Test-AndroidTarget) {
         $apkPath = Get-AndroidApkPath
         $abiFilters = Get-AndroidAbiFilters
         $deviceReady = (((Get-SelectedAndroidDeviceSerial) -ne "") -and ((Get-SelectedAndroidDeviceState) -eq "device"))
-        $txtCmdPreview.Text = 'Android APK: "' + $apkPath + '"  ABI: ' + $abiFilters
-        $btnRun.IsEnabled = ((Test-Path $apkPath) -and $deviceReady -and $sceneDeps.Ok)
-        $btnEditor.IsEnabled = ($deviceReady -and $sceneDeps.Ok)
+        $adbPath = Get-AndroidAdbPath
+        $installArgs = Get-AndroidAdbArguments @("install", "-r", $apkPath)
+        $deployArgs = Get-AndroidAdbArguments (Get-AndroidLaunchArguments)
+        $txtCmdPreview.Text = "Install: " + (Format-LauncherCommandLine -FilePath $adbPath -Arguments $installArgs) + [System.Environment]::NewLine +
+            "Deploy: " + (Format-LauncherCommandLine -FilePath $adbPath -Arguments $deployArgs)
+        $btnRun.IsEnabled = ((Test-Path $apkPath) -and $deviceReady -and $sceneDeps.Ok -and -not $assetsMissing)
+        $btnEditor.IsEnabled = ($deviceReady -and $sceneDeps.Ok -and -not $assetsMissing)
         if (-not $sceneDeps.Ok) {
             $txtStatus.Text = "Scene missing: $($sceneDeps.Missing -join ', ')"
             $txtStatus.Foreground = $window.FindResource("RedBrush")
@@ -2102,7 +2134,7 @@ function Update-Preview {
             $txtStatus.Text = "Select a connected Android device"
             $txtStatus.Foreground = $window.FindResource("RedBrush")
         } elseif ($assetsMissing) {
-            $txtStatus.Text = "Cloud assets missing: $($assetStatus.Missing)/$($assetStatus.Total). Download Assets, or Install/Deploy will download them."
+            $txtStatus.Text = "Cloud assets missing: $($assetStatus.Missing)/$($assetStatus.Total). Click Download Assets before running."
             $txtStatus.Foreground = $window.FindResource("AccentBrush")
         } elseif ($btnRun.IsEnabled) {
             $txtStatus.Text = "Android APK ready - Install; Deploy runs installed app"
@@ -2126,24 +2158,19 @@ function Update-Preview {
         $txtStatus.Foreground = $window.FindResource("RedBrush")
         $btnRun.IsEnabled = $false
         $btnEditor.IsEnabled = $editorOk
+    } elseif ($assetsMissing) {
+        $txtStatus.Text = "Cloud assets missing: $($assetStatus.Missing)/$($assetStatus.Total). Click Download Assets before running."
+        $txtStatus.Foreground = $window.FindResource("AccentBrush")
+        $btnRun.IsEnabled = $false
+        $btnEditor.IsEnabled = $editorOk
     } elseif ($sceneOk -and $editorOk) {
-        if ($assetsMissing) {
-            $txtStatus.Text = "Cloud assets missing: $($assetStatus.Missing)/$($assetStatus.Total). Download Assets, or Run/Editor will download them."
-            $txtStatus.Foreground = $window.FindResource("AccentBrush")
-        } else {
-            $txtStatus.Text = "Ready to run (Scene + Editor)"
-            $txtStatus.Foreground = $window.FindResource("GreenBrush")
-        }
+        $txtStatus.Text = "Ready to run (Scene + Editor)"
+        $txtStatus.Foreground = $window.FindResource("GreenBrush")
         $btnRun.IsEnabled = $true
         $btnEditor.IsEnabled = $true
     } elseif ($sceneOk) {
-        if ($assetsMissing) {
-            $txtStatus.Text = "Cloud assets missing: $($assetStatus.Missing)/$($assetStatus.Total). Download Assets, or Run will download them."
-            $txtStatus.Foreground = $window.FindResource("AccentBrush")
-        } else {
-            $txtStatus.Text = "Scene ready, Editor not found - build required"
-            $txtStatus.Foreground = $window.FindResource("GreenBrush")
-        }
+        $txtStatus.Text = "Scene ready, Editor not found - build required"
+        $txtStatus.Foreground = $window.FindResource("GreenBrush")
         $btnRun.IsEnabled = $true
         $btnEditor.IsEnabled = $false
     } else {
@@ -2270,7 +2297,7 @@ function Set-LauncherBusy {
     $btnBuild.IsEnabled = -not $Busy
     $btnRebuild.IsEnabled = -not $Busy
     $btnRun.IsEnabled = -not $Busy
-    if ($btnDownloadAssets) { $btnDownloadAssets.IsEnabled = ((-not $Busy) -and $script:CloudAssetStatus -and $script:CloudAssetStatus.Missing -gt 0) }
+    Update-DownloadAssetsButton
     $btnEditor.IsEnabled = -not $Busy
     $btnBuild.Content = $BuildText
 }
@@ -2576,6 +2603,7 @@ $btnRebuild.Add_Click({ Invoke-Build -buildTarget "Rebuild" })
 
 # DOWNLOAD ASSETS button — downloads only missing cloud assets
 $btnDownloadAssets.Add_Click({
+    $script:AssetDownloadInProgress = $true
     Set-LauncherBusy $true "DOWNLOADING..."
     try {
         if (-not (Invoke-LauncherModelDownload)) { return }
@@ -2583,6 +2611,7 @@ $btnDownloadAssets.Add_Click({
         Populate-SceneFileList
         Update-SceneDependencyCache
     } finally {
+        $script:AssetDownloadInProgress = $false
         Set-LauncherBusy $false
         Update-Preview
     }
@@ -2590,7 +2619,15 @@ $btnDownloadAssets.Add_Click({
 
 # RUN button — launch the app with current settings (no dump override)
 $btnRun.Add_Click({
-    if (-not (Invoke-LauncherModelDownload)) { return }
+    Update-LauncherCloudAssetStatus | Out-Null
+    Update-Preview
+    $assetStatus = $script:CloudAssetStatus
+    if ($assetStatus -and $assetStatus.Configured -and ($assetStatus.Missing -gt 0 -or -not $assetStatus.Ok)) {
+        [System.Windows.MessageBox]::Show(
+            ("Cloud assets are missing or invalid. Click Download Assets before running." + "`n`n" + $assetStatus.Message),
+            "T850 Launcher", "OK", "Warning") | Out-Null
+        return
+    }
     Populate-ModelList
     Populate-SceneFileList
     Update-SceneDependencyCache
@@ -2624,7 +2661,6 @@ $btnRun.Add_Click({
 
 # EDITOR button — launch T8ditor with current graphics/resolution/log settings
 $btnEditor.Add_Click({
-    if (-not (Invoke-LauncherModelDownload)) { return }
     Populate-ModelList
     if (Test-AndroidTarget) {
         Update-SceneDependencyCache

--- a/T850/scripts/Launcher_Release.ps1
+++ b/T850/scripts/Launcher_Release.ps1
@@ -311,9 +311,13 @@ $xaml = @"
             <TextBlock Name="txtStatus" Text="" FontSize="12"
                        Foreground="#A6ADC8" Margin="0,0,0,4"
                        TextWrapping="Wrap"/>
-            <TextBlock Name="txtCmdPreview" Text="" FontSize="11"
-                       Foreground="#45475A" Margin="0"
-                       TextWrapping="Wrap" FontFamily="Consolas"/>
+            <TextBox Name="txtCmdPreview" Text="" FontSize="11"
+                     Foreground="#A6ADC8" Margin="0" Padding="0"
+                     TextWrapping="Wrap" FontFamily="Consolas"
+                     IsReadOnly="True" IsReadOnlyCaretVisible="True"
+                     Background="Transparent" BorderThickness="0"
+                     Height="Auto" MinHeight="24" VerticalContentAlignment="Top"
+                     Cursor="IBeam"/>
         </StackPanel>
 
         <!-- Buttons -->
@@ -421,6 +425,7 @@ $script:SceneDependencyResult = @{ Ok = $true; Missing = @() }
 $script:SuppressSceneDependencyValidation = $false
 $script:LauncherInitializing = $true
 $script:LauncherBusy = $false
+$script:AssetDownloadInProgress = $false
 $script:CloudAssetStatus = $null
 $modelCloudScript = Join-Path $rootDir "scripts\ModelCloud.ps1"
 if (-not (Test-Path $modelCloudScript) -and $PSScriptRoot) { $modelCloudScript = Join-Path $PSScriptRoot "ModelCloud.ps1" }
@@ -494,14 +499,16 @@ function Update-DownloadAssetsButton {
     if (-not $btnDownloadAssets) { return }
     $status = $script:CloudAssetStatus
     $missing = if ($status) { [int]$status.Missing } else { 0 }
-    $btnDownloadAssets.Content = "Download Assets"
-    $btnDownloadAssets.IsEnabled = ((-not $script:LauncherBusy) -and ($missing -gt 0))
-    $btnDownloadAssets.ToolTip = if ($missing -gt 0) {
+    $btnDownloadAssets.Content = if ($script:AssetDownloadInProgress) { "Downloading..." } else { "Download Assets" }
+    $btnDownloadAssets.IsEnabled = -not $script:AssetDownloadInProgress
+    $btnDownloadAssets.ToolTip = if ($script:AssetDownloadInProgress) {
+        "Asset download is already running."
+    } elseif ($missing -gt 0) {
         "$missing cloud asset(s) missing. Click to download only missing files."
     } elseif ($status -and $status.Total -gt 0) {
-        "All cloud assets are present."
+        "All cloud assets are present. Click to scan again."
     } else {
-        "No cloud asset manifest is configured."
+        "Click to scan cloud asset manifests."
     }
 }
 
@@ -525,7 +532,15 @@ function Invoke-LauncherModelDownload {
         }
     }
     $status = Update-LauncherCloudAssetStatus
-    if ($status -and $status.Missing -eq 0 -and $status.Ok) { return $true }
+    if ($status -and $status.Missing -eq 0 -and $status.Ok) {
+        if (-not $Quiet) {
+            $message = if ($status.Total -gt 0) { "OK, all asset files are there." } else { $status.Message }
+            $txtStatus.Text = $message
+            $txtStatus.Foreground = $window.FindResource("GreenBrush")
+            [System.Windows.MessageBox]::Show($message, "T850 Launcher", "OK", "Information") | Out-Null
+        }
+        return $true
+    }
     if (Get-Command Ensure-T850CloudModels -ErrorAction SilentlyContinue) {
         $result = Ensure-T850CloudModels -RootDir $rootDir -AssetRoot $targetRoot -StatusCallback $statusCallback
         if (-not $result.Ok) {
@@ -832,6 +847,19 @@ function Save-Config {
 
 # ── Helpers ──
 
+function Format-LauncherCommandLine {
+    param(
+        [Parameter(Mandatory = $true)] [string]$FilePath,
+        [string[]]$Arguments = @()
+    )
+    $quotedArgs = @()
+    foreach ($arg in $Arguments) {
+        if ($arg -match '[\s",]') { $quotedArgs += ('"' + ($arg -replace '"', '\"') + '"') }
+        else { $quotedArgs += $arg }
+    }
+    return (('"' + $FilePath + '" ' + ($quotedArgs -join ' ')).Trim())
+}
+
 function Get-LaunchCommand {
     $apiTag = ($cmbApi.SelectedItem).Tag.ToString()
 
@@ -955,31 +983,26 @@ function Update-Preview {
     $editorOk = Test-Path $editorCmd.ExePath
     $sceneDeps = Get-CachedSceneDependencyResult
     $assetStatus = $script:CloudAssetStatus
-    $assetsMissing = ($assetStatus -and $assetStatus.Missing -gt 0)
+    $assetsMissing = ($assetStatus -and $assetStatus.Configured -and ($assetStatus.Missing -gt 0 -or -not $assetStatus.Ok))
 
     if (-not $sceneDeps.Ok) {
         $txtStatus.Text = "Scene missing: $($sceneDeps.Missing -join ', ')"
         $txtStatus.Foreground = $window.FindResource("RedBrush")
         $btnRun.IsEnabled = $false
         $btnEditor.IsEnabled = $editorOk
+    } elseif ($assetsMissing) {
+        $txtStatus.Text = "Cloud assets missing: $($assetStatus.Missing)/$($assetStatus.Total). Click Download Assets before running."
+        $txtStatus.Foreground = $window.FindResource("AccentBrush")
+        $btnRun.IsEnabled = $false
+        $btnEditor.IsEnabled = $editorOk
     } elseif ($sceneOk -and $editorOk) {
-        if ($assetsMissing) {
-            $txtStatus.Text = "Cloud assets missing: $($assetStatus.Missing)/$($assetStatus.Total). Download Assets, or Run/Editor will download them."
-            $txtStatus.Foreground = $window.FindResource("AccentBrush")
-        } else {
-            $txtStatus.Text = "Ready to run (Scene + Editor)"
-            $txtStatus.Foreground = $window.FindResource("GreenBrush")
-        }
+        $txtStatus.Text = "Ready to run (Scene + Editor)"
+        $txtStatus.Foreground = $window.FindResource("GreenBrush")
         $btnRun.IsEnabled = $true
         $btnEditor.IsEnabled = $true
     } elseif ($sceneOk) {
-        if ($assetsMissing) {
-            $txtStatus.Text = "Cloud assets missing: $($assetStatus.Missing)/$($assetStatus.Total). Download Assets, or Run will download them."
-            $txtStatus.Foreground = $window.FindResource("AccentBrush")
-        } else {
-            $txtStatus.Text = "Scene ready, Editor not found"
-            $txtStatus.Foreground = $window.FindResource("GreenBrush")
-        }
+        $txtStatus.Text = "Scene ready, Editor not found"
+        $txtStatus.Foreground = $window.FindResource("GreenBrush")
         $btnRun.IsEnabled = $true
         $btnEditor.IsEnabled = $false
     } else {
@@ -1086,6 +1109,7 @@ $txtHeight.Add_TextChanged({ Update-Preview })
 
 # DOWNLOAD ASSETS button
 $btnDownloadAssets.Add_Click({
+    $script:AssetDownloadInProgress = $true
     $script:LauncherBusy = $true
     Update-DownloadAssetsButton
     try {
@@ -1094,6 +1118,7 @@ $btnDownloadAssets.Add_Click({
         Populate-SceneFileList
         Update-SceneDependencyCache
     } finally {
+        $script:AssetDownloadInProgress = $false
         $script:LauncherBusy = $false
         Update-Preview
     }
@@ -1101,7 +1126,15 @@ $btnDownloadAssets.Add_Click({
 
 # RUN button
 $btnRun.Add_Click({
-    if (-not (Invoke-LauncherModelDownload)) { return }
+    Update-LauncherCloudAssetStatus | Out-Null
+    Update-Preview
+    $assetStatus = $script:CloudAssetStatus
+    if ($assetStatus -and $assetStatus.Configured -and ($assetStatus.Missing -gt 0 -or -not $assetStatus.Ok)) {
+        [System.Windows.MessageBox]::Show(
+            ("Cloud assets are missing or invalid. Click Download Assets before running." + "`n`n" + $assetStatus.Message),
+            "T850 Launcher", "OK", "Warning") | Out-Null
+        return
+    }
     Populate-ModelList
     Populate-SceneFileList
     Update-SceneDependencyCache
@@ -1131,7 +1164,6 @@ $btnRun.Add_Click({
 
 # EDITOR button
 $btnEditor.Add_Click({
-    if (-not (Invoke-LauncherModelDownload)) { return }
     Populate-ModelList
     $cmd = Get-EditorLaunchCommand
     if (-not (Test-Path $cmd.ExePath)) {

--- a/T850/scripts/build.ps1
+++ b/T850/scripts/build.ps1
@@ -37,7 +37,7 @@ $Config = $Config.Substring(0,1).ToUpper() + $Config.Substring(1).ToLower()
 
 # Map platform to MSBuild platform name (x86 -> Win32 in .sln)
 $msbuildPlatform = switch ($Platform.ToLower()) {
-    "x86"   { "x86" }
+    "x86"   { "Win32" }
     "x64"   { "x64" }
     "arm64" { "ARM64" }
 }

--- a/T850/scripts/convert_q3_bsp_to_glb.py
+++ b/T850/scripts/convert_q3_bsp_to_glb.py
@@ -81,9 +81,9 @@ def sanitize_name(value: str) -> str:
 
 
 def archive_roots(q3_root: Path, rtx_root: Path | None) -> list[Path]:
-    roots: list[Path] = [q3_root / "baseq3"]
+    roots: list[Path] = [q3_root if q3_root.name.lower() == "baseq3" else q3_root / "baseq3"]
     if rtx_root is not None:
-        roots.append(rtx_root / "baseq3")
+        roots.append(rtx_root if rtx_root.name.lower() == "baseq3" else rtx_root / "baseq3")
     return [root for root in roots if root.exists()]
 
 

--- a/T850/scripts/export_q3_bsp_collision.py
+++ b/T850/scripts/export_q3_bsp_collision.py
@@ -37,10 +37,41 @@ Q3_BSP_LUMP_MODELS = 7
 Q3_BSP_LUMP_BRUSHES = 8
 Q3_BSP_LUMP_BRUSHSIDES = 9
 
+Q3_AAS_LUMP_AREASETTINGS = 8
+Q3_AAS_LUMP_REACHABILITY = 9
+
 Q3_CONTENTS_SOLID = 0x00000001
 Q3_CONTENTS_PLAYERCLIP = 0x00010000
 Q3_PLAYER_COLLISION_CONTENTS = Q3_CONTENTS_SOLID | Q3_CONTENTS_PLAYERCLIP
 Q3_DEFAULT_GRAVITY = 800.0
+
+Q3_AAS_IDENT = (ord("S") << 24) + (ord("A") << 16) + (ord("A") << 8) + ord("E")
+Q3_AAS_VERSION = 5
+Q3_AAS_REACHABILITY_SIZE = 44
+Q3_AAS_AREA_SETTINGS_SIZE = 28
+
+TRAVELTYPE_MASK = 0xFFFFFF
+TRAVEL_TYPE_NAMES = {
+    1: "invalid",
+    2: "walk",
+    3: "crouch",
+    4: "barrier_jump",
+    5: "jump",
+    6: "ladder",
+    7: "walk_off_ledge",
+    8: "swim",
+    9: "water_jump",
+    10: "teleport",
+    11: "elevator",
+    12: "rocket_jump",
+    13: "bfg_jump",
+    14: "grapple_hook",
+    15: "double_jump",
+    16: "ramp_jump",
+    17: "strafe_jump",
+    18: "jump_pad",
+    19: "func_bob",
+}
 
 
 def q3_normal_to_scene(value: tuple[float, float, float]) -> tuple[float, float, float]:
@@ -200,6 +231,83 @@ def parse_jump_pads(bsp_data: bytes, unit_scale: float) -> list[dict[str, object
             "velocity": vec3(*q3_velocity_to_scene(q3_velocity, unit_scale)),
         })
     return jump_pads
+
+
+def parse_aas_reachabilities(aas_data: bytes, unit_scale: float) -> list[dict[str, object]]:
+    if len(aas_data) < 12 + 14 * 8:
+        raise ValueError("AAS data is too small")
+
+    header_size = 12 + 14 * 8
+    header = bytearray(aas_data[:header_size])
+    ident, version = struct.unpack_from("<II", header, 0)
+    if ident != Q3_AAS_IDENT:
+        raise ValueError(f"unexpected AAS ident 0x{ident:08x}")
+    if version != Q3_AAS_VERSION:
+        raise ValueError(f"unsupported AAS version {version}")
+
+    for index in range(8, header_size):
+        header[index] ^= ((index - 8) * 119) & 0xFF
+
+    lumps = [struct.unpack_from("<II", header, 12 + lump_index * 8) for lump_index in range(14)]
+    area_settings_offset, area_settings_length = lumps[Q3_AAS_LUMP_AREASETTINGS]
+    reachability_offset, reachability_length = lumps[Q3_AAS_LUMP_REACHABILITY]
+
+    reachability_source_areas: dict[int, int] = {}
+    area_count = area_settings_length // Q3_AAS_AREA_SETTINGS_SIZE
+    for area_index in range(area_count):
+        offset = area_settings_offset + area_index * Q3_AAS_AREA_SETTINGS_SIZE
+        if offset + Q3_AAS_AREA_SETTINGS_SIZE > len(aas_data):
+            break
+        (
+            _contents,
+            _area_flags,
+            _presence_type,
+            _cluster,
+            _cluster_area_num,
+            num_reachable_areas,
+            first_reachable_area,
+        ) = struct.unpack_from("<7i", aas_data, offset)
+        for reach_index in range(first_reachable_area, first_reachable_area + num_reachable_areas):
+            reachability_source_areas[reach_index] = area_index
+
+    reachabilities: list[dict[str, object]] = []
+    reachability_count = reachability_length // Q3_AAS_REACHABILITY_SIZE
+    for reach_index in range(reachability_count):
+        offset = reachability_offset + reach_index * Q3_AAS_REACHABILITY_SIZE
+        if offset + Q3_AAS_REACHABILITY_SIZE > len(aas_data):
+            break
+        (
+            target_area,
+            face_num,
+            edge_num,
+            start_x,
+            start_y,
+            start_z,
+            end_x,
+            end_y,
+            end_z,
+            travel_type,
+            travel_time,
+        ) = struct.unpack_from("<3i3f3fiHxx", aas_data, offset)
+
+        travel_type_id = travel_type & TRAVELTYPE_MASK
+        travel_type_name = TRAVEL_TYPE_NAMES.get(travel_type_id, f"unknown_{travel_type_id}")
+        start = q3_to_scene((start_x, start_y, start_z), unit_scale)
+        end = q3_to_scene((end_x, end_y, end_z), unit_scale)
+        reachabilities.append({
+            "source_area": reachability_source_areas.get(reach_index, 0),
+            "target_area": target_area,
+            "face": face_num,
+            "edge": edge_num,
+            "start": vec3(*start),
+            "end": vec3(*end),
+            "travel_type": travel_type_name,
+            "travel_type_id": travel_type_id,
+            "travel_flags": travel_type & ~TRAVELTYPE_MASK,
+            "travel_time": int(travel_time),
+        })
+
+    return reachabilities
 
 
 def parse_bsp_collision(
@@ -397,18 +505,27 @@ def export_collision(args: argparse.Namespace) -> None:
             continue
 
         bsp_data = read_archive_file(archive_index, bsp_path)
+        aas_path = f"maps/{map_name}.aas".lower()
+        reachabilities: list[dict[str, object]] = []
+        if not args.no_aas and aas_path in archive_index:
+            try:
+                reachabilities = parse_aas_reachabilities(read_archive_file(archive_index, aas_path), args.unit_scale)
+            except ValueError as exc:
+                print(f"warning: skipped {aas_path}: {exc}", file=sys.stderr)
         excluded_trigger_brushes = trigger_brush_indices(bsp_data)
         brushes = parse_bsp_collision(bsp_data, args.unit_scale, excluded_trigger_brushes)
         patch_facets = parse_bsp_patch_facets(bsp_data, args.unit_scale, args.patch_subdivisions)
         jump_pads = parse_jump_pads(bsp_data, args.unit_scale)
         clip = {
-            "version": 2,
+            "version": 3,
             "source": bsp_path,
+            "aas_source": aas_path if reachabilities else "",
             "unit_scale": args.unit_scale,
             "contents_mask": Q3_PLAYER_COLLISION_CONTENTS,
             "brushes": brushes,
             "patch_facets": patch_facets,
             "jump_pads": jump_pads,
+            "reachabilities": reachabilities,
         }
         output_path = output_dir / f"{map_name}.t8q3clip"
         output_path.write_text(json.dumps(clip, indent=2), encoding="utf-8")
@@ -421,10 +538,12 @@ def export_collision(args: argparse.Namespace) -> None:
             "patch_subdivisions": int(args.patch_subdivisions),
             "excluded_trigger_brushes": len(excluded_trigger_brushes),
             "jump_pads": len(jump_pads),
+            "reachabilities": len(reachabilities),
         })
         print(
             f"wrote {output_path} brushes={len(brushes)} patch_facets={len(patch_facets)} "
-            f"excluded_trigger_brushes={len(excluded_trigger_brushes)} jump_pads={len(jump_pads)}"
+            f"excluded_trigger_brushes={len(excluded_trigger_brushes)} jump_pads={len(jump_pads)} "
+            f"reachabilities={len(reachabilities)}"
         )
 
     summary_path = output_dir / "_q3_bsp_collision_summary.json"
@@ -449,6 +568,11 @@ def build_parser() -> argparse.ArgumentParser:
         type=float,
         default=DEFAULT_UNIT_SCALE,
         help="Scale Q3 map units into engine scene units; default maps 32 Q3 units to 1 engine unit",
+    )
+    parser.add_argument(
+        "--no-aas",
+        action="store_true",
+        help="Do not embed .aas reachability records even if maps/<map>.aas exists",
     )
     return parser
 


### PR DESCRIPTION
## Summary
- Integrate Q3 AAS reachabilities and typed traversal links for nav agents
- Fix Android profile/rendering parity by packaging generated IBL cache and preserving profile values
- Improve jump-pad/forced-drop traversal diagnostics and behavior
- Update T8ditor save preservation, Vulkan clears, loading console labels, hierarchy bulk controls, and selection framing

## Validation
- Built x64 Release
- Built and installed signed Android production APK on connected tablet
- Compared PC/Android Vulkan frame dumps for deferred output parity