### PR TITLE
Editor refactor and NavMesh authoring tools

### DIFF
--- a/T850/Assets/Scenes/DayScene.t8scene
+++ b/T850/Assets/Scenes/DayScene.t8scene
@@ -192,6 +192,8 @@
       "name": "DayScene God Rays Volume",
       "position": { "x": 0, "y": 50, "z": 0 },
       "half_extents": { "x": 65, "y": 65, "z": 65 },
+      "light_camera": 0,
+      "authored": true,
       "enabled": true,
       "clip_enabled": false,
       "visible": true,

--- a/T850/Assets/Scenes/Nexus.t8scene
+++ b/T850/Assets/Scenes/Nexus.t8scene
@@ -1,0 +1,495 @@
+{
+   "version": 1,
+   "collision": "",
+   "render_graph": "",
+   "editor": {
+      "camera_target": {
+         "x": 15.6976595,
+         "y": -30.373623,
+         "z": -37.704468
+      },
+      "camera_yaw": -1.150002,
+      "camera_pitch": 0.49000016,
+      "camera_distance": 201.82504,
+      "show_skybox": true,
+      "show_wireframe": false,
+      "allow_custom_layout": false,
+      "imgui_layout": ""
+   },
+   "objects": [
+      {
+         "name": "D:/Code/Game/SC2Extract/NexusWarsOneLane/map_terrain/nexus_wars_terrain.glb",
+         "mesh": "D:/Code/Game/SC2Extract/NexusWarsOneLane/map_terrain/nexus_wars_terrain.glb",
+         "ragdoll": "",
+         "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+         },
+         "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+         },
+         "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+         },
+         "visible": false,
+         "frozen": false,
+         "show_wire": false,
+         "show_orientation": false,
+         "nav_agent_target_mode": "direct",
+         "nav_agent_follow_distance": 0,
+         "nav_agent_side_offset": 0,
+         "nav_agent_formation_depth_step": 0,
+         "nav_agent_slot": -1,
+         "navigation": {
+            "include": true,
+            "walkable": true,
+            "static_object": true,
+            "area": "walkable",
+            "cost": 1
+         }
+      }
+   ],
+   "game_entities": [],
+   "physics_entities": [
+      {
+         "name": "D:/Code/Game/SC2Extract/NexusWarsOneLane/map_terrain/nexus_wars_terrain.glb Static Triangle Mesh",
+         "type": "static_triangle_mesh",
+         "source_object": "D:/Code/Game/SC2Extract/NexusWarsOneLane/map_terrain/nexus_wars_terrain.glb",
+         "position": {
+            "x": 0,
+            "y": 64,
+            "z": 0
+         },
+         "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+         },
+         "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+         },
+         "visible": false,
+         "frozen": false,
+         "show_wire": true,
+         "show_orientation": false,
+         "shape": "box",
+         "half_extents": {
+            "x": 16,
+            "y": 32,
+            "z": 16
+         },
+         "radius": 16,
+         "half_height": 24,
+         "friction": 0.6,
+         "restitution": 0,
+         "sensor": false,
+         "cook_settings": {
+            "max_triangles_per_leaf": 8,
+            "build_quality": "runtime_performance",
+            "active_edge_cos_threshold_angle": 0.996195,
+            "per_triangle_user_data": false,
+            "use_disk_cache": true
+         },
+         "character": {
+            "runtime_path": "kinematic",
+            "implementation": "virtual",
+            "bot_radius": 2,
+            "mass": 70,
+            "max_strength": 100,
+            "max_slope_angle_deg": 50,
+            "enhanced_internal_edge_removal": true,
+            "supporting_volume_offset": -1.0E10,
+            "shape_offset": {
+               "x": 0,
+               "y": 0,
+               "z": 0
+            },
+            "back_face_mode": "collide",
+            "predictive_contact_distance": 0.1,
+            "max_collision_iterations": 5,
+            "max_constraint_iterations": 15,
+            "min_time_remaining": 0.0001,
+            "collision_tolerance": 0.001,
+            "character_padding": 0.02,
+            "max_num_hits": 256,
+            "hit_reduction_cos_max_angle": 0.999,
+            "penetration_recovery_speed": 1,
+            "gravity_factor": 1,
+            "allow_translation_x": true,
+            "allow_translation_y": true,
+            "allow_translation_z": true,
+            "inner_body": false
+         }
+      }
+   ],
+   "navigation_mesh": {
+      "name": "NavMesh",
+      "enabled": true,
+      "visible": true,
+      "frozen": false,
+      "show_wire": true,
+      "debug_offset": 0.01,
+      "debug_shape_mode": 0,
+      "runtime_mode": "build_cached",
+      "baked_asset": "",
+      "build_settings": {
+         "cell_size": 0.3,
+         "cell_height": 0.2,
+         "agent_height": 2,
+         "agent_radius": 0.6,
+         "agent_max_climb": 0.9,
+         "agent_max_slope": 45,
+         "region_min_size": 8,
+         "region_merge_size": 20,
+         "edge_max_len": 12,
+         "edge_max_error": 1.3,
+         "verts_per_poly": 6,
+         "detail_sample_dist": 6,
+         "detail_sample_max_error": 1,
+         "query_extents": {
+            "x": 2,
+            "y": 4,
+            "z": 2
+         },
+         "auto_drop_links": true,
+         "drop_min_height": 1,
+         "drop_max_height": 24,
+         "drop_max_horizontal": 2.4,
+         "drop_sample_spacing": 1.2,
+         "drop_link_radius": 0.75,
+         "auto_jump_links": true,
+         "jump_max_horizontal": 7,
+         "jump_sample_spacing": 1.2,
+         "jump_link_radius": 0.75,
+         "hybrid_jump_links": true,
+         "hybrid_max_links": 192,
+         "off_mesh_link_validation_key": 0
+      },
+      "volumes": [
+         {
+            "name": "Include Bounds 1",
+            "type": "include_bounds",
+            "shape": "box",
+            "position": {
+               "x": 0,
+               "y": 0,
+               "z": 0
+            },
+            "rotation": {
+               "x": 0,
+               "y": -0,
+               "z": 0
+            },
+            "half_extents": {
+               "x": 132.82854,
+               "y": 16,
+               "z": 32
+            },
+            "area": "walkable",
+            "cost": 1,
+            "enabled": true,
+            "visible": true,
+            "frozen": false,
+            "show_wire": true
+         },
+         {
+            "name": "Exclude Volume 2",
+            "type": "exclude",
+            "shape": "box",
+            "position": {
+               "x": 0,
+               "y": 0,
+               "z": -0.17920113
+            },
+            "rotation": {
+               "x": 0,
+               "y": -0,
+               "z": 0
+            },
+            "half_extents": {
+               "x": 51.331047,
+               "y": 4,
+               "z": 35.783607
+            },
+            "area": "walkable",
+            "cost": 1,
+            "enabled": true,
+            "visible": true,
+            "frozen": false,
+            "show_wire": true
+         }
+      ],
+      "authored_links": []
+   },
+   "splines": [],
+   "cameras": [],
+   "light_cameras": [],
+   "camera_animations": [],
+   "lights": [],
+   "profiles": [
+      {
+         "name": "pc/x64",
+         "platform": "windows",
+         "architecture": "x64",
+         "gpu_family": "",
+         "gpu_name_contains": "",
+         "model": "",
+         "sliders": [
+            {
+               "name": "exposure",
+               "value": 1
+            },
+            {
+               "name": "bloom_factor",
+               "value": 0.35
+            },
+            {
+               "name": "bloom_threshold",
+               "value": 0.7
+            },
+            {
+               "name": "light_radius_scale",
+               "value": 1
+            },
+            {
+               "name": "light_intensity_scale",
+               "value": 1
+            },
+            {
+               "name": "lightmap_intensity",
+               "value": 1
+            },
+            {
+               "name": "tm_white_level",
+               "value": 4
+            },
+            {
+               "name": "tm_adapt_tau",
+               "value": 1.1
+            },
+            {
+               "name": "shadow_map_resolution",
+               "value": 1024
+            },
+            {
+               "name": "god_rays_resolution",
+               "value": 0
+            },
+            {
+               "name": "pcf_radius",
+               "value": 1.7
+            },
+            {
+               "name": "pcf_samples",
+               "value": 1
+            },
+            {
+               "name": "ssao_kernel_size",
+               "value": 8
+            },
+            {
+               "name": "ssao_radius",
+               "value": 1.5
+            },
+            {
+               "name": "dof_aperture",
+               "value": 120
+            },
+            {
+               "name": "dof_focal_length",
+               "value": 50
+            },
+            {
+               "name": "dof_focus_depth",
+               "value": 0
+            },
+            {
+               "name": "dof_max_coc",
+               "value": 2.5
+            },
+            {
+               "name": "dof_far_samples",
+               "value": 2
+            },
+            {
+               "name": "dof_near_samples",
+               "value": 1
+            },
+            {
+               "name": "parallax_low_samples",
+               "value": 2
+            },
+            {
+               "name": "parallax_high_samples",
+               "value": 8
+            },
+            {
+               "name": "parallax_height",
+               "value": 0.01
+            },
+            {
+               "name": "parallax_shadow_min_layers",
+               "value": 8
+            },
+            {
+               "name": "parallax_shadow_max_layers",
+               "value": 32
+            },
+            {
+               "name": "parallax_shadow_softness",
+               "value": 0.5
+            },
+            {
+               "name": "parallax_shadow_strength",
+               "value": 1
+            },
+            {
+               "name": "light_volume_steps",
+               "value": 32
+            },
+            {
+               "name": "godrays_factor",
+               "value": 1
+            },
+            {
+               "name": "active_lights",
+               "value": 1
+            },
+            {
+               "name": "gauss_kernel_radius",
+               "value": 2.5
+            },
+            {
+               "name": "gauss_kernel_deviation",
+               "value": 4.5
+            },
+            {
+               "name": "fov",
+               "value": 49.999992
+            },
+            {
+               "name": "shadow_bias",
+               "value": 0.000005
+            },
+            {
+               "name": "shadow_min",
+               "value": 0.2
+            },
+            {
+               "name": "env_factor",
+               "value": 0.3
+            },
+            {
+               "name": "ibl_factor",
+               "value": 1
+            },
+            {
+               "name": "ibl_mip_count",
+               "value": 4
+            },
+            {
+               "name": "ibl_diffuse_mip_level",
+               "value": 4
+            },
+            {
+               "name": "ibl_brdf_lut_enabled",
+               "value": 0
+            },
+            {
+               "name": "material_emissive_intensity",
+               "value": 1
+            },
+            {
+               "name": "material_transmission_multiplier",
+               "value": 1
+            },
+            {
+               "name": "material_refraction_strength",
+               "value": 0.03
+            }
+         ],
+         "checkboxes": [
+            {
+               "name": "shadow_toggle",
+               "value": false
+            },
+            {
+               "name": "ssao_toggle",
+               "value": false
+            },
+            {
+               "name": "dof_toggle",
+               "value": true
+            },
+            {
+               "name": "dof_auto_focus",
+               "value": true
+            },
+            {
+               "name": "parallax_toggle",
+               "value": true
+            },
+            {
+               "name": "parallax_shadow_toggle",
+               "value": true
+            },
+            {
+               "name": "godrays_toggle",
+               "value": true
+            },
+            {
+               "name": "show_wireframe",
+               "value": false
+            },
+            {
+               "name": "show_skeleton",
+               "value": false
+            },
+            {
+               "name": "show_physics",
+               "value": false
+            },
+            {
+               "name": "show_light_volumes",
+               "value": false
+            },
+            {
+               "name": "debug_luminance",
+               "value": false
+            }
+         ],
+         "selectors": [
+            {
+               "name": "debug_render_target",
+               "value": 0
+            },
+            {
+               "name": "cubemap",
+               "value": 8
+            },
+            {
+               "name": "gauss_kernel_sample_count",
+               "value": 11
+            },
+            {
+               "name": "active_gauss_kernel",
+               "value": 1
+            },
+            {
+               "name": "luminance_mode",
+               "value": 0
+            }
+         ],
+         "lights": [],
+         "animations": [],
+         "cubemap_path": "sky/CubeMap_SkyWater.dds"
+      }
+   ]
+}

--- a/T850/DayScene/SceneTemplate.cpp
+++ b/T850/DayScene/SceneTemplate.cpp
@@ -4190,8 +4190,15 @@ bool SceneTemplate::EnsureNavMeshBuilt() {
           m_loadedEditorScenePath,
           navBuildSettings);
   const auto navBuildStart = std::chrono::steady_clock::now();
-  const bool hasAuthoredNavVolumes = !m_authoredNavMesh.volumes.empty();
-  if (!hasAuthoredNavVolumes && navCacheKey != 0 && m_navMesh.LoadCached(navCacheKey, navBuildSettings, nullptr)) {
+  const std::string runtimeMode = m_authoredNavMesh.runtime_mode.empty()
+      ? "build_cached"
+      : m_authoredNavMesh.runtime_mode;
+  if (runtimeMode == "baked_asset") {
+    T8_LOG_INFO("[Navigation] Baked NavMesh asset '%s' requested but export/load is not implemented yet; falling back to cached build.",
+                m_authoredNavMesh.baked_asset.c_str());
+  }
+  const bool allowCache = runtimeMode != "build";
+  if (allowCache && navCacheKey != 0 && m_navMesh.LoadCached(navCacheKey, navBuildSettings, nullptr)) {
     m_navMeshLastBuildMs = std::chrono::duration<float, std::milli>(std::chrono::steady_clock::now() - navBuildStart).count();
     m_navMeshLastBuildFromCache = true;
     m_navMeshDebugRenderer.Invalidate();
@@ -4254,7 +4261,8 @@ bool SceneTemplate::EnsureNavMeshBuilt() {
       geometry.offMeshLinks.push_back(NavOffMeshLinkFromScene(linkDesc));
     }
   }
-  if (!m_navMesh.BuildCached(geometry, navBuildSettings, navCacheKey, &error)) {
+  const uint64_t buildCacheKey = allowCache ? navCacheKey : 0;
+  if (!m_navMesh.BuildCached(geometry, navBuildSettings, buildCacheKey, &error)) {
     T8_LOG_ERROR("[Navigation] Sandbox navmesh build failed: %s", error.c_str());
     return false;
   }

--- a/T850/DayScene/SceneTemplate.cpp
+++ b/T850/DayScene/SceneTemplate.cpp
@@ -188,6 +188,10 @@ namespace {
       return t850::navigation::NavMeshModifierMode::Include;
     if (name == "area" || name == "area_cost" || name == "cost")
       return t850::navigation::NavMeshModifierMode::Area;
+    if (name == "link_include" || name == "link_add" || name == "add_links")
+      return t850::navigation::NavMeshModifierMode::LinkInclude;
+    if (name == "link_exclude" || name == "exclude_links")
+      return t850::navigation::NavMeshModifierMode::LinkExclude;
     return t850::navigation::NavMeshModifierMode::Exclude;
   }
 

--- a/T850/DayScene/SceneTemplate.cpp
+++ b/T850/DayScene/SceneTemplate.cpp
@@ -4197,9 +4197,25 @@ bool SceneTemplate::EnsureNavMeshBuilt() {
   const std::string runtimeMode = m_authoredNavMesh.runtime_mode.empty()
       ? "build_cached"
       : m_authoredNavMesh.runtime_mode;
-  if (runtimeMode == "baked_asset") {
-    T8_LOG_INFO("[Navigation] Baked NavMesh asset '%s' requested but export/load is not implemented yet; falling back to cached build.",
-                m_authoredNavMesh.baked_asset.c_str());
+  if (runtimeMode == "baked_asset" && !m_authoredNavMesh.baked_asset.empty()) {
+    std::string bakedError;
+    if (m_navMesh.LoadBaked(m_authoredNavMesh.baked_asset, navBuildSettings, &bakedError)) {
+      m_navMeshLastBuildMs = std::chrono::duration<float, std::milli>(std::chrono::steady_clock::now() - navBuildStart).count();
+      m_navMeshLastBuildFromCache = true;
+      m_navMeshDebugRenderer.Invalidate();
+      const t850::navigation::NavMeshBuildStats& stats = m_navMesh.GetStats();
+      T8_LOG_INFO("[Navigation] Loaded baked NavMesh asset '%s': %.2fms verts=%d tris=%d polys=%d offMesh=%d",
+                  m_authoredNavMesh.baked_asset.c_str(),
+                  m_navMeshLastBuildMs,
+                  stats.vertexCount,
+                  stats.triangleCount,
+                  stats.polygonCount,
+                  stats.offMeshLinkCount);
+      return true;
+    }
+    T8_LOG_ERROR("[Navigation] Failed to load baked NavMesh asset '%s': %s; falling back to cached build.",
+                 m_authoredNavMesh.baked_asset.c_str(),
+                 bakedError.c_str());
   }
   const bool allowCache = runtimeMode != "build";
   if (allowCache && navCacheKey != 0 && m_navMesh.LoadCached(navCacheKey, navBuildSettings, nullptr)) {

--- a/T850/DayScene/SceneTemplate.cpp
+++ b/T850/DayScene/SceneTemplate.cpp
@@ -170,6 +170,66 @@ namespace {
     HashNavCacheValue(hash, settings.offMeshLinkValidationKey);
   }
 
+  int NavAreaFromSceneName(const std::string& name) {
+    if (name == "walkable") return 0;
+    if (name == "drop") return 1;
+    if (name == "jump") return 2;
+    if (name == "jump_pad") return 3;
+    if (name == "jump_intent") return 4;
+    if (name == "water") return 5;
+    if (name == "door") return 6;
+    if (name == "mud") return 7;
+    if (name == "custom") return 8;
+    return 8;
+  }
+
+  t850::navigation::NavMeshModifierMode NavModifierModeFromSceneName(const std::string& name) {
+    if (name == "include" || name == "include_bounds" || name == "bounds")
+      return t850::navigation::NavMeshModifierMode::Include;
+    if (name == "area" || name == "area_cost" || name == "cost")
+      return t850::navigation::NavMeshModifierMode::Area;
+    return t850::navigation::NavMeshModifierMode::Exclude;
+  }
+
+  t850::navigation::NavMeshVolumeModifier NavVolumeModifierFromScene(
+      const t850::scene::SceneNavMeshVolumeDesc& desc) {
+    t850::navigation::NavMeshVolumeModifier modifier;
+    modifier.name = desc.name;
+    modifier.mode = NavModifierModeFromSceneName(desc.type);
+    modifier.position = XVECTOR3(desc.position.x, desc.position.y, desc.position.z, 1.0f);
+    modifier.rotation = XVECTOR3(desc.rotation.x, desc.rotation.y, desc.rotation.z, 0.0f);
+    modifier.halfExtents = XVECTOR3(
+        (std::max)(0.001f, std::abs(desc.half_extents.x)),
+        (std::max)(0.001f, std::abs(desc.half_extents.y)),
+        (std::max)(0.001f, std::abs(desc.half_extents.z)),
+        0.0f);
+    modifier.area = NavAreaFromSceneName(desc.area);
+    modifier.cost = (std::max)(0.01f, desc.cost);
+    modifier.enabled = desc.enabled && desc.shape == "box";
+    return modifier;
+  }
+
+  void HashNavMeshVolumes(uint64_t& hash, const std::vector<t850::scene::SceneNavMeshVolumeDesc>& volumes) {
+    HashNavCacheValue(hash, static_cast<uint64_t>(volumes.size()));
+    for (const t850::scene::SceneNavMeshVolumeDesc& volume : volumes) {
+      HashNavCacheString(hash, volume.name);
+      HashNavCacheString(hash, volume.type);
+      HashNavCacheString(hash, volume.shape);
+      HashNavCacheValue(hash, volume.position.x);
+      HashNavCacheValue(hash, volume.position.y);
+      HashNavCacheValue(hash, volume.position.z);
+      HashNavCacheValue(hash, volume.rotation.x);
+      HashNavCacheValue(hash, volume.rotation.y);
+      HashNavCacheValue(hash, volume.rotation.z);
+      HashNavCacheValue(hash, volume.half_extents.x);
+      HashNavCacheValue(hash, volume.half_extents.y);
+      HashNavCacheValue(hash, volume.half_extents.z);
+      HashNavCacheString(hash, volume.area);
+      HashNavCacheValue(hash, volume.cost);
+      HashNavCacheValue(hash, volume.enabled);
+    }
+  }
+
   uint64_t ComputeSandboxNavMeshCacheKey(const PrimitiveInst* instances,
                                          int instanceCount,
                                          const std::vector<std::string>& meshPaths,
@@ -4111,6 +4171,7 @@ bool SceneTemplate::EnsureNavMeshBuilt() {
     HashNavCacheValue(authoredLinksHash, link.cost);
     HashNavCacheValue(authoredLinksHash, link.enabled);
   }
+  HashNavMeshVolumes(authoredLinksHash, m_authoredNavMesh.volumes);
   navBuildSettings.offMeshLinkValidationKey ^= authoredLinksHash;
   t850::EngineContext* engineContext = GetEngineContext();
   if (!engineContext) engineContext = &t850::GetEngineContext();
@@ -4129,7 +4190,8 @@ bool SceneTemplate::EnsureNavMeshBuilt() {
           m_loadedEditorScenePath,
           navBuildSettings);
   const auto navBuildStart = std::chrono::steady_clock::now();
-  if (navCacheKey != 0 && m_navMesh.LoadCached(navCacheKey, navBuildSettings, nullptr)) {
+  const bool hasAuthoredNavVolumes = !m_authoredNavMesh.volumes.empty();
+  if (!hasAuthoredNavVolumes && navCacheKey != 0 && m_navMesh.LoadCached(navCacheKey, navBuildSettings, nullptr)) {
     m_navMeshLastBuildMs = std::chrono::duration<float, std::milli>(std::chrono::steady_clock::now() - navBuildStart).count();
     m_navMeshLastBuildFromCache = true;
     m_navMeshDebugRenderer.Invalidate();
@@ -4176,6 +4238,16 @@ bool SceneTemplate::EnsureNavMeshBuilt() {
       return t850::ValidateNavOffMeshLinkWithPhysics(*linkValidationPhysics, navBuildSettings, link);
     };
     geometry.offMeshHybridLinkValidator = geometry.offMeshLinkValidator;
+  }
+  for (const t850::scene::SceneNavMeshVolumeDesc& volumeDesc : m_authoredNavMesh.volumes) {
+    t850::navigation::NavMeshVolumeModifier modifier = NavVolumeModifierFromScene(volumeDesc);
+    if (!modifier.enabled) {
+      continue;
+    }
+    geometry.volumeModifiers.push_back(modifier);
+    if (modifier.mode == t850::navigation::NavMeshModifierMode::Area) {
+      geometry.areaCosts.push_back({modifier.area, modifier.cost});
+    }
   }
   for (const t850::scene::SceneNavMeshLinkDesc& linkDesc : m_authoredNavMesh.authored_links) {
     if (IsUsableAuthoredNavLink(linkDesc)) {

--- a/T850/DayScene/SceneTemplate.cpp
+++ b/T850/DayScene/SceneTemplate.cpp
@@ -3314,7 +3314,18 @@ void SceneTemplate::ApplyEditorSceneCameraAndLights(const t850::scene::EditorSce
     }
     if (scene.god_rays_volume) {
       const auto& volume = *scene.god_rays_volume;
-      SceneProp.GodRaysVolumeEnabled = (volume.enabled && volume.clip_enabled) ? 1 : 0;
+      const bool volumeAuthored = volume.authored || volume.enabled || volume.visible || volume.clip_enabled;
+      const int volumeLightCamera = std::clamp(
+          volume.light_camera,
+          0,
+          SceneProp.pLightCameras.empty() ? 0 : static_cast<int>(SceneProp.pLightCameras.size()) - 1);
+      const bool validVolumeLightCamera = !SceneProp.pLightCameras.empty() &&
+          volumeLightCamera >= 0 &&
+          volumeLightCamera < static_cast<int>(SceneProp.pLightCameras.size());
+      SceneProp.GodRaysVolumeEnabled = (volumeAuthored && validVolumeLightCamera && volume.enabled && volume.clip_enabled) ? 1 : 0;
+      if (validVolumeLightCamera) {
+        SceneProp.ActiveLightCamera = volumeLightCamera;
+      }
       SceneProp.GodRaysVolumeCenter = XVECTOR3(volume.position.x, volume.position.y, volume.position.z, 1.0f);
       SceneProp.GodRaysVolumeHalfExtents = XVECTOR3((std::max)(0.001f, std::abs(volume.half_extents.x)),
                                                     (std::max)(0.001f, std::abs(volume.half_extents.y)),

--- a/T850/DayScene/SceneTemplate.cpp
+++ b/T850/DayScene/SceneTemplate.cpp
@@ -3963,7 +3963,11 @@ bool SceneTemplate::LoadEditorSceneAssets(const std::string& scenePath) {
     instance.Update();
 
     t850::scene::SceneObjectPhysicsDesc physicsMeta = object.physics.value_or(t850::scene::SceneObjectPhysicsDesc{});
+    const bool hasExplicitNavigation = object.navigation.has_value();
     t850::scene::SceneObjectNavigationDesc navigationMeta = object.navigation.value_or(t850::scene::SceneObjectNavigationDesc{});
+    if (!hasExplicitNavigation && !object.visible) {
+      navigationMeta.include = false;
+    }
     t850::scene::SceneObjectRagdollDesc ragdollMeta = object.ragdoll_authoring.value_or(t850::scene::SceneObjectRagdollDesc{});
     const std::string legacyRagdollPath = NormalizeSceneResourcePath(object.ragdoll);
     if (ragdollMeta.asset.empty()) {
@@ -4244,6 +4248,7 @@ bool SceneTemplate::EnsureNavMeshBuilt() {
     if (meshIndex < static_cast<int>(m_sceneNavigationAuthoring.size())) {
       const t850::scene::SceneObjectNavigationDesc& nav = m_sceneNavigationAuthoring[static_cast<std::size_t>(meshIndex)];
       source.includeInNavigation = nav.include;
+      source.visible = source.visible || nav.include;
       source.navigationStatic = nav.static_object;
       source.navigationWalkable = nav.walkable;
       source.area = nav.walkable ? 0 : -1;

--- a/T850/Framework/CMakeLists.txt
+++ b/T850/Framework/CMakeLists.txt
@@ -20,6 +20,7 @@ set(FRAMEWORK_SOURCES
   src/scene/RenderMesh.cpp
   src/scene/RenderSkinnedMesh.cpp
   src/scene/LineRenderer.cpp
+  src/scene/WireframeGeometry.cpp
   src/scene/AnimationController.cpp
   src/scene/PrimitiveInstance.cpp
   src/scene/PrimitiveManager.cpp

--- a/T850/Framework/Framework.vcxproj
+++ b/T850/Framework/Framework.vcxproj
@@ -45,6 +45,7 @@
     <ClInclude Include="include\scene\MaterialAsset.h" />
     <ClInclude Include="include\scene\RenderQueue.h" />
     <ClInclude Include="include\scene\LineRenderer.h" />
+    <ClInclude Include="include\scene\WireframeGeometry.h" />
     <ClInclude Include="include\scene\AnimationController.h" />
     <ClInclude Include="include\scene\PrimitiveBase.h" />
     <ClInclude Include="include\scene\PrimitiveInstance.h" />
@@ -187,6 +188,7 @@
     <ClCompile Include="src\scene\MaterialAssetCache.cpp" />
     <ClCompile Include="src\scene\RenderQueue.cpp" />
     <ClCompile Include="src\scene\LineRenderer.cpp" />
+    <ClCompile Include="src\scene\WireframeGeometry.cpp" />
     <ClCompile Include="src\scene\AnimationController.cpp" />
     <ClCompile Include="src\scene\PrimitiveInstance.cpp" />
     <ClCompile Include="src\scene\PrimitiveManager.cpp" />

--- a/T850/Framework/Framework.vcxproj.filters
+++ b/T850/Framework/Framework.vcxproj.filters
@@ -131,6 +131,9 @@
     <ClInclude Include="include\scene\PrimitiveManager.h">
       <Filter>Header Files\scene</Filter>
     </ClInclude>
+    <ClInclude Include="include\scene\WireframeGeometry.h">
+      <Filter>Header Files\scene</Filter>
+    </ClInclude>
     <ClInclude Include="include\scene\SceneProp.h">
       <Filter>Header Files\scene</Filter>
     </ClInclude>
@@ -449,6 +452,9 @@
       <Filter>Source Files\scene</Filter>
     </ClCompile>
     <ClCompile Include="src\scene\PrimitiveManager.cpp">
+      <Filter>Source Files\scene</Filter>
+    </ClCompile>
+    <ClCompile Include="src\scene\WireframeGeometry.cpp">
       <Filter>Source Files\scene</Filter>
     </ClCompile>
     <ClCompile Include="src\scene\SceneProp.cpp">

--- a/T850/Framework/include/navigation/NavigationSystem.h
+++ b/T850/Framework/include/navigation/NavigationSystem.h
@@ -78,7 +78,9 @@ struct NavOffMeshLink {
 enum class NavMeshModifierMode : uint8_t {
   Include = 0,
   Exclude = 1,
-  Area = 2
+  Area = 2,
+  LinkInclude = 3,
+  LinkExclude = 4
 };
 
 struct NavMeshVolumeModifier {

--- a/T850/Framework/include/navigation/NavigationSystem.h
+++ b/T850/Framework/include/navigation/NavigationSystem.h
@@ -229,6 +229,11 @@ public:
   bool LoadCached(uint64_t cacheKey,
                   const NavMeshBuildSettings& settings = NavMeshBuildSettings(),
                   std::string* error = nullptr);
+  bool LoadBaked(const std::string& path,
+                 const NavMeshBuildSettings& settings = NavMeshBuildSettings(),
+                 std::string* error = nullptr);
+  bool SaveBaked(const std::string& path,
+                 std::string* error = nullptr) const;
   bool BuildFromXDataBase(const xF::XDataBase& database,
                           const NavMeshBuildSettings& settings = NavMeshBuildSettings(),
                           std::string* error = nullptr);

--- a/T850/Framework/include/navigation/NavigationSystem.h
+++ b/T850/Framework/include/navigation/NavigationSystem.h
@@ -107,6 +107,33 @@ struct NavMeshGeometry {
   std::function<bool(const NavOffMeshLink&)> offMeshHybridLinkValidator;
 };
 
+enum class NavTriangleClassificationReason : uint8_t {
+  Included = 0,
+  ExcludedBySlope = 1,
+  OutsideIncludeVolume = 2,
+  ExcludedByVolume = 3,
+  InvalidGeometry = 4
+};
+
+struct NavTriangleClassification {
+  int triangleIndex = -1;
+  XVECTOR3 vertices[3];
+  XVECTOR3 centroid = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+  bool included = false;
+  int area = 0;
+  float cost = 1.0f;
+  NavTriangleClassificationReason reason = NavTriangleClassificationReason::InvalidGeometry;
+  int modifierIndex = -1;
+};
+
+struct NavMeshClassificationResult {
+  std::vector<NavTriangleClassification> triangles;
+  int includedCount = 0;
+  int excludedBySlopeCount = 0;
+  int outsideIncludeVolumeCount = 0;
+  int excludedByVolumeCount = 0;
+};
+
 struct NavMeshBuildStats {
   int vertexCount = 0;
   int triangleCount = 0;
@@ -295,6 +322,10 @@ bool BuildGeometryFromNavSources(const std::vector<NavSourceInstance>& sources,
                                  NavMeshGeometry& outGeometry,
                                  NavSourceBuildStats* stats = nullptr,
                                  std::string* error = nullptr);
+bool ClassifyNavMeshTriangles(const NavMeshGeometry& geometry,
+                              const NavMeshBuildSettings& settings,
+                              NavMeshClassificationResult& outResult,
+                              std::string* error = nullptr);
 
 } // namespace navigation
 } // namespace t850

--- a/T850/Framework/include/navigation/NavigationSystem.h
+++ b/T850/Framework/include/navigation/NavigationSystem.h
@@ -75,10 +75,34 @@ struct NavOffMeshLink {
   uint32_t userId = 0;
 };
 
+enum class NavMeshModifierMode : uint8_t {
+  Include = 0,
+  Exclude = 1,
+  Area = 2
+};
+
+struct NavMeshVolumeModifier {
+  std::string name;
+  NavMeshModifierMode mode = NavMeshModifierMode::Exclude;
+  XVECTOR3 position = XVECTOR3(0.0f, 0.0f, 0.0f, 1.0f);
+  XVECTOR3 rotation = XVECTOR3(0.0f, 0.0f, 0.0f, 0.0f);
+  XVECTOR3 halfExtents = XVECTOR3(1.0f, 1.0f, 1.0f, 0.0f);
+  int area = 0;
+  float cost = 1.0f;
+  bool enabled = true;
+};
+
+struct NavAreaCost {
+  int area = 0;
+  float cost = 1.0f;
+};
+
 struct NavMeshGeometry {
   std::vector<XVECTOR3> vertices;
   std::vector<int> indices;
   std::vector<NavOffMeshLink> offMeshLinks;
+  std::vector<NavMeshVolumeModifier> volumeModifiers;
+  std::vector<NavAreaCost> areaCosts;
   std::function<bool(const NavOffMeshLink&)> offMeshLinkValidator;
   std::function<bool(const NavOffMeshLink&)> offMeshHybridLinkValidator;
 };

--- a/T850/Framework/include/scene/EditorSceneFile.h
+++ b/T850/Framework/include/scene/EditorSceneFile.h
@@ -125,9 +125,11 @@ struct SceneGodRaysVolumeDesc {
   std::string name = "God Rays Volume";
   Vec3f position = {0.0f, 50.0f, 0.0f};
   Vec3f half_extents = {65.0f, 65.0f, 65.0f};
-  bool enabled = true;
+  int light_camera = 0;
+  bool authored = false;
+  bool enabled = false;
   bool clip_enabled = false;
-  bool visible = true;
+  bool visible = false;
   bool frozen = false;
   bool show_wire = true;
 };

--- a/T850/Framework/include/scene/EditorSceneFile.h
+++ b/T850/Framework/include/scene/EditorSceneFile.h
@@ -242,7 +242,7 @@ struct SceneNavMeshLinkDesc {
 
 struct SceneNavMeshVolumeDesc {
   std::string name = "Nav Volume";
-  std::string type = "exclude"; // include_bounds, exclude, area_cost
+  std::string type = "exclude"; // include_bounds, exclude, area_cost, link_include, link_exclude
   std::string shape = "box";
   Vec3f position = {0.0f, 0.0f, 0.0f};
   Vec3f rotation = {0.0f, 0.0f, 0.0f};

--- a/T850/Framework/include/scene/EditorSceneFile.h
+++ b/T850/Framework/include/scene/EditorSceneFile.h
@@ -263,6 +263,8 @@ struct SceneNavigationMeshDesc {
   bool show_wire = true;
   float debug_offset = 0.01f;
   int debug_shape_mode = 0;
+  std::string runtime_mode = "build_cached"; // build_cached, build, baked_asset
+  std::string baked_asset;
   SceneNavMeshBuildSettingsDesc build_settings;
   std::vector<SceneNavMeshVolumeDesc> volumes;
   std::vector<SceneNavMeshLinkDesc> authored_links;

--- a/T850/Framework/include/scene/EditorSceneFile.h
+++ b/T850/Framework/include/scene/EditorSceneFile.h
@@ -240,6 +240,21 @@ struct SceneNavMeshLinkDesc {
   bool show_wire = true;
 };
 
+struct SceneNavMeshVolumeDesc {
+  std::string name = "Nav Volume";
+  std::string type = "exclude"; // include_bounds, exclude, area_cost
+  std::string shape = "box";
+  Vec3f position = {0.0f, 0.0f, 0.0f};
+  Vec3f rotation = {0.0f, 0.0f, 0.0f};
+  Vec3f half_extents = {8.0f, 4.0f, 8.0f};
+  std::string area = "walkable";
+  float cost = 1.0f;
+  bool enabled = true;
+  bool visible = true;
+  bool frozen = false;
+  bool show_wire = true;
+};
+
 struct SceneNavigationMeshDesc {
   std::string name = "NavMesh";
   bool enabled = false;
@@ -249,6 +264,7 @@ struct SceneNavigationMeshDesc {
   float debug_offset = 0.01f;
   int debug_shape_mode = 0;
   SceneNavMeshBuildSettingsDesc build_settings;
+  std::vector<SceneNavMeshVolumeDesc> volumes;
   std::vector<SceneNavMeshLinkDesc> authored_links;
 };
 

--- a/T850/Framework/include/scene/RenderMesh.h
+++ b/T850/Framework/include/scene/RenderMesh.h
@@ -49,6 +49,7 @@
 #include <scene/MeshAssetCache.h>
 #include <scene/MaterialAsset.h>
 #include <scene/LineRenderer.h>
+#include <scene/WireframeGeometry.h>
 
 
 
@@ -524,18 +525,13 @@ namespace t850 {
     std::vector<std::size_t> m_drawOrderScratch;
 
   private:
-    struct WireGeo {
-      IndexBuffer* IB = nullptr;
-      unsigned indexCount = 0;
-      bool use32Bit = false;
-    };
     void BuildWireframeBuffers();
     void CreateWireframeShader();
     bool ApplyCullingPreprocessCache(const MeshPreprocessCacheData& cache);
     bool BuildCullingMetadata();
     const EngineContext& Context() const;
 
-    std::vector<WireGeo> m_wireGeo;
+    std::vector<WireframeGeometry> m_wireGeo;
     ShaderBase* m_wireShader = nullptr;
     LineRenderer m_lineRenderer;
     Texture* m_wireDepthTex = nullptr;
@@ -546,4 +542,3 @@ namespace t850 {
 }
 
 #endif
-

--- a/T850/Framework/include/scene/RenderQueue.h
+++ b/T850/Framework/include/scene/RenderQueue.h
@@ -134,7 +134,8 @@ namespace t850 {
   // Process-wide draw-pass state tracker. Reset by the caller at the
   // start of a multi-entity mesh pass; persists across multiple
   // RenderMesh::Draw / RenderSkinnedMesh::Draw calls inside the pass
-  // so redundant texture / IB / shader binds dedupe across entities.
+  // so redundant texture / VB / IB / topology / shader binds dedupe
+  // across entities.
   //
   // D3D12 invariants honored:
   //   - Shader::Set must run every draw (PSO is keyed by current
@@ -180,8 +181,17 @@ namespace t850 {
     // EnvMap dedup (separate slot tracking with its own lastEnv).
     bool ShouldBindEnvMap(Texture* env);
 
-    // IB-bind dedup.
+    // Geometry-bind dedup.
+    bool ShouldSetTopology(Topology::E topology);
+    bool ShouldBindVertexBuffer(VertexBuffer* vb, unsigned stride, unsigned offset);
     bool ShouldBindIB(IndexBuffer* ib, IndexBufferFormat::E fmt);
+    unsigned BindIndexedGeometry(DeviceContext& deviceContext,
+                                 VertexBuffer* vb,
+                                 unsigned stride,
+                                 unsigned offset,
+                                 IndexBuffer* ib,
+                                 IndexBufferFormat::E fmt,
+                                 Topology::E topology);
 
     // Constant-buffer update/bind dedup. This compares the pending
     // contents against the buffer's last uploaded system copy, updates
@@ -197,9 +207,15 @@ namespace t850 {
     ShaderBase*          m_lastShader   = nullptr;
     Texture*             m_lastTex[kMaxTrackedSlots] = { nullptr };
     Texture*             m_lastEnv      = nullptr;
+    VertexBuffer*        m_lastVB       = nullptr;
+    unsigned             m_lastVBStride = 0;
+    unsigned             m_lastVBOffset = 0;
+    bool                 m_lastVBSet    = false;
     IndexBuffer*         m_lastIB       = nullptr;
     IndexBufferFormat::E m_lastIBFmt    = IndexBufferFormat::R16;
     bool                 m_lastIBFmtSet = false;
+    Topology::E          m_lastTopology = Topology::TRIANLE_LIST;
+    bool                 m_lastTopologySet = false;
     ConstantBuffer*      m_lastCB[kMaxTrackedSlots] = { nullptr };
   };
 }

--- a/T850/Framework/include/scene/RenderSkinnedMesh.h
+++ b/T850/Framework/include/scene/RenderSkinnedMesh.h
@@ -165,12 +165,7 @@ private:
   std::vector<XMATRIX44> m_snapshotBoneMatrices;
 
   // ── Wireframe state (GPU-skinned) ──
-  struct WireGeo {
-    IndexBuffer* IB = nullptr;
-    unsigned indexCount = 0;
-    bool use32Bit = false;
-  };
-  std::vector<WireGeo> m_wireGeo;      // per-geometry line-list IBs
+  std::vector<WireframeGeometry> m_wireGeo;      // per-geometry line-list IBs
   ShaderBase*          m_wireShader = nullptr;
 
   // Octahedral skeleton bones (CPU-updated each frame)

--- a/T850/Framework/include/scene/WireframeGeometry.h
+++ b/T850/Framework/include/scene/WireframeGeometry.h
@@ -1,0 +1,63 @@
+/*********************************************************
+ * T850 Engine — Wireframe geometry resource
+ *********************************************************/
+
+#ifndef T850_WIREFRAME_GEOMETRY_H
+#define T850_WIREFRAME_GEOMETRY_H
+
+#include <video/BaseDriver.h>
+
+#include <vector>
+
+namespace t850 {
+
+class WireframeGeometry {
+public:
+  WireframeGeometry() = default;
+  ~WireframeGeometry();
+
+  WireframeGeometry(const WireframeGeometry&) = delete;
+  WireframeGeometry& operator=(const WireframeGeometry&) = delete;
+
+  WireframeGeometry(WireframeGeometry&& other) noexcept;
+  WireframeGeometry& operator=(WireframeGeometry&& other) noexcept;
+
+  void Destroy();
+
+  bool CreatePositionBuffer(const float* positionsXYZW,
+                            unsigned vertexCount,
+                            BufferUsage::E usage = BufferUsage::DEFAULT);
+  bool CreateLineIndexBuffer(const unsigned int* lineIndices,
+                             unsigned indexCount,
+                             unsigned vertexCount);
+  bool CreateLineIndexBuffer(const std::vector<unsigned int>& lineIndices,
+                             unsigned vertexCount);
+  bool CreateFromTriangles(const float* positionsXYZW,
+                           unsigned vertexCount,
+                           const unsigned int* triangleIndices,
+                           unsigned triangleIndexCount,
+                           BufferUsage::E usage = BufferUsage::DEFAULT);
+
+  bool HasVertexBuffer() const { return m_vb != nullptr; }
+  bool HasIndexBuffer() const { return m_ib != nullptr && m_indexCount > 0; }
+  bool IsReady() const { return HasVertexBuffer() && HasIndexBuffer(); }
+
+  VertexBuffer* GetVertexBuffer() const { return m_vb; }
+  IndexBuffer* GetIndexBuffer() const { return m_ib; }
+  unsigned GetIndexCount() const { return m_indexCount; }
+  IndexBufferFormat::E GetIndexFormat() const { return m_indexFormat; }
+
+private:
+  void ReleaseVertexBuffer();
+  void ReleaseIndexBuffer();
+  void MoveFrom(WireframeGeometry& other) noexcept;
+
+  VertexBuffer* m_vb = nullptr;
+  IndexBuffer* m_ib = nullptr;
+  unsigned m_indexCount = 0;
+  IndexBufferFormat::E m_indexFormat = IndexBufferFormat::R16;
+};
+
+} // namespace t850
+
+#endif // T850_WIREFRAME_GEOMETRY_H

--- a/T850/Framework/src/navigation/NavigationSystem.cpp
+++ b/T850/Framework/src/navigation/NavigationSystem.cpp
@@ -972,7 +972,8 @@ bool LoadNavMeshCache(const std::filesystem::path& path,
                       const NavMeshBuildSettings& settings,
                       NavMeshBuildStats& outStats,
                       std::unique_ptr<dtNavMesh, NavMeshDeleter>& outNavMesh,
-                      std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter>& outQuery) {
+                      std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter>& outQuery,
+                      std::vector<unsigned char>* outNavDataCopy = nullptr) {
   std::ifstream file(path, std::ios::binary);
   if (!file.is_open()) {
     return false;
@@ -1013,6 +1014,9 @@ bool LoadNavMeshCache(const std::filesystem::path& path,
   if (!file.good()) {
     dtFree(navData);
     return false;
+  }
+  if (outNavDataCopy) {
+    outNavDataCopy->assign(navData, navData + dataSize);
   }
 
   std::string error;
@@ -1249,6 +1253,7 @@ struct NavMesh::Impl {
   std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> query;
   NavMeshBuildSettings settings;
   std::array<float, kNavMaxAreas> areaCosts = DefaultNavAreaCosts();
+  std::vector<unsigned char> navData;
 #endif
 };
 
@@ -1613,7 +1618,8 @@ bool NavMesh::LoadCached(uint64_t cacheKey,
   NavMeshBuildStats cachedStats;
   std::unique_ptr<dtNavMesh, NavMeshDeleter> cachedNavMesh;
   std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> cachedQuery;
-  if (!LoadNavMeshCache(NavMeshCachePath(cacheKey), cacheKey, settings, cachedStats, cachedNavMesh, cachedQuery)) {
+  std::vector<unsigned char> cachedNavData;
+  if (!LoadNavMeshCache(NavMeshCachePath(cacheKey), cacheKey, settings, cachedStats, cachedNavMesh, cachedQuery, &cachedNavData)) {
     if (error) *error = "Navigation cache is not available";
     return false;
   }
@@ -1621,6 +1627,68 @@ bool NavMesh::LoadCached(uint64_t cacheKey,
   m_stats = cachedStats;
   m_impl->navMesh = std::move(cachedNavMesh);
   m_impl->query = std::move(cachedQuery);
+  m_impl->navData = std::move(cachedNavData);
+  return true;
+#endif
+}
+
+bool NavMesh::LoadBaked(const std::string& path,
+                        const NavMeshBuildSettings& settings,
+                        std::string* error) {
+#if !defined(T850_ENABLE_RECAST)
+  SetError(error, "RecastNavigation is not enabled in this build");
+  return false;
+#else
+  Clear();
+  m_impl->settings = settings;
+  m_impl->areaCosts = DefaultNavAreaCosts();
+  if (path.empty()) {
+    SetError(error, "Baked NavMesh path is empty");
+    return false;
+  }
+
+  const std::filesystem::path resolvedPath = ResourceLocator::Instance().ResolveFilePath(path);
+  NavMeshBuildStats bakedStats;
+  std::unique_ptr<dtNavMesh, NavMeshDeleter> bakedNavMesh;
+  std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> bakedQuery;
+  std::vector<unsigned char> bakedNavData;
+  if (!LoadNavMeshCache(resolvedPath, 0, settings, bakedStats, bakedNavMesh, bakedQuery, &bakedNavData)) {
+    SetError(error, "Failed to load baked NavMesh asset: " + path);
+    return false;
+  }
+
+  m_stats = bakedStats;
+  m_impl->navMesh = std::move(bakedNavMesh);
+  m_impl->query = std::move(bakedQuery);
+  m_impl->navData = std::move(bakedNavData);
+  return true;
+#endif
+}
+
+bool NavMesh::SaveBaked(const std::string& path, std::string* error) const {
+#if !defined(T850_ENABLE_RECAST)
+  SetError(error, "RecastNavigation is not enabled in this build");
+  return false;
+#else
+  if (!IsReady() || !m_impl || m_impl->navData.empty()) {
+    SetError(error, "Cannot bake NavMesh before a NavMesh is built or loaded");
+    return false;
+  }
+  if (path.empty()) {
+    SetError(error, "Baked NavMesh path is empty");
+    return false;
+  }
+
+  std::filesystem::path outputPath(path);
+  if (!outputPath.is_absolute()) {
+    outputPath = ResourceLocator::Instance().ResolveCachePath(path);
+  }
+  SaveNavMeshCache(outputPath, 0, m_stats, m_impl->navData.data(), static_cast<int>(m_impl->navData.size()));
+  std::error_code ec;
+  if (!std::filesystem::is_regular_file(outputPath, ec)) {
+    SetError(error, "Failed to write baked NavMesh asset: " + outputPath.string());
+    return false;
+  }
   return true;
 #endif
 }
@@ -1690,7 +1758,7 @@ bool NavMesh::BuildCached(const NavMeshGeometry& geometry,
   const bool hasExplicitOffMeshLinks = !geometry.offMeshLinks.empty();
   if (useCache &&
       !hasExplicitOffMeshLinks &&
-      LoadNavMeshCache(cachePath, effectiveCacheKey, settings, cachedStats, cachedNavMesh, cachedQuery)) {
+      LoadNavMeshCache(cachePath, effectiveCacheKey, settings, cachedStats, cachedNavMesh, cachedQuery, &m_impl->navData)) {
     m_stats = cachedStats;
     m_impl->navMesh = std::move(cachedNavMesh);
     m_impl->query = std::move(cachedQuery);
@@ -1935,6 +2003,9 @@ bool NavMesh::BuildCached(const NavMeshGeometry& geometry,
     return false;
   }
   dtStatus status = navMesh->init(navData, navDataSize, DT_TILE_FREE_DATA);
+  if (!dtStatusFailed(status)) {
+    m_impl->navData.assign(navData, navData + navDataSize);
+  }
   if (dtStatusFailed(status)) {
     dtFree(navData);
     SetError(error, "Failed to initialize Detour navmesh");

--- a/T850/Framework/src/navigation/NavigationSystem.cpp
+++ b/T850/Framework/src/navigation/NavigationSystem.cpp
@@ -416,10 +416,12 @@ bool NavGeometryHasIncludeVolume(const NavMeshGeometry& geometry) {
 NavModifierTriangleResult ApplyNavVolumeModifiersToTriangle(const NavMeshGeometry& geometry,
                                                             const XVECTOR3& centroid,
                                                             unsigned char initialArea,
-                                                            bool hasIncludeVolume) {
+                                                            bool hasIncludeVolume,
+                                                            bool showVolumeEffectsOnSlope = false) {
   NavModifierTriangleResult result;
   result.area = initialArea;
-  if (initialArea == RC_NULL_AREA) {
+  const bool slopeExcluded = initialArea == RC_NULL_AREA;
+  if (slopeExcluded && !showVolumeEffectsOnSlope) {
     result.reason = NavTriangleClassificationReason::ExcludedBySlope;
     return result;
   }
@@ -450,6 +452,13 @@ NavModifierTriangleResult ApplyNavVolumeModifiersToTriangle(const NavMeshGeometr
   if (!insideInclude) {
     result.area = RC_NULL_AREA;
     result.reason = NavTriangleClassificationReason::OutsideIncludeVolume;
+    return result;
+  }
+
+  if (slopeExcluded) {
+    result.area = RC_NULL_AREA;
+    result.reason = NavTriangleClassificationReason::ExcludedBySlope;
+    result.modifierIndex = areaModifierIndex;
     return result;
   }
 
@@ -1486,7 +1495,8 @@ bool ClassifyNavMeshTriangles(const NavMeshGeometry& geometry,
         geometry,
         classified.centroid,
         areas[static_cast<std::size_t>(tri)],
-        hasIncludeVolume);
+        hasIncludeVolume,
+        true);
     classified.included = modifierResult.area != RC_NULL_AREA;
     classified.reason = modifierResult.reason;
     classified.modifierIndex = modifierResult.modifierIndex;
@@ -1611,17 +1621,19 @@ bool NavMesh::BuildCached(const NavMeshGeometry& geometry,
 
   m_impl->areaCosts = BuildNavAreaCosts(geometry);
 
-  uint64_t effectiveCacheKey = cacheKey != 0 ? cacheKey : ComputeNavMeshCacheKey(geometry, settings);
-  if (cacheKey != 0 && (!geometry.volumeModifiers.empty() || !geometry.areaCosts.empty())) {
+  const bool useCache = cacheKey != 0;
+  uint64_t effectiveCacheKey = cacheKey;
+  if (useCache && (!geometry.volumeModifiers.empty() || !geometry.areaCosts.empty())) {
     const uint64_t modifierHash = ComputeNavModifierCacheKey(geometry);
     HashBytes(effectiveCacheKey, modifierHash);
   }
-  const std::filesystem::path cachePath = NavMeshCachePath(effectiveCacheKey);
+  const std::filesystem::path cachePath = useCache ? NavMeshCachePath(effectiveCacheKey) : std::filesystem::path{};
   NavMeshBuildStats cachedStats;
   std::unique_ptr<dtNavMesh, NavMeshDeleter> cachedNavMesh;
   std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> cachedQuery;
   const bool hasExplicitOffMeshLinks = !geometry.offMeshLinks.empty();
-  if (!hasExplicitOffMeshLinks &&
+  if (useCache &&
+      !hasExplicitOffMeshLinks &&
       LoadNavMeshCache(cachePath, effectiveCacheKey, settings, cachedStats, cachedNavMesh, cachedQuery)) {
     m_stats = cachedStats;
     m_impl->navMesh = std::move(cachedNavMesh);
@@ -1892,7 +1904,9 @@ bool NavMesh::BuildCached(const NavMeshGeometry& geometry,
   m_stats.dropLinkCount = dropLinkCount;
   m_stats.jumpLinkCount = jumpLinkCount;
   m_stats.jumpPadLinkCount = jumpPadLinkCount;
-  SaveNavMeshCache(cachePath, effectiveCacheKey, m_stats, navData, navDataSize);
+  if (useCache) {
+    SaveNavMeshCache(cachePath, effectiveCacheKey, m_stats, navData, navDataSize);
+  }
   m_impl->navMesh = std::move(navMesh);
   m_impl->query = std::move(query);
 

--- a/T850/Framework/src/navigation/NavigationSystem.cpp
+++ b/T850/Framework/src/navigation/NavigationSystem.cpp
@@ -413,6 +413,62 @@ bool NavGeometryHasIncludeVolume(const NavMeshGeometry& geometry) {
   return false;
 }
 
+bool NavGeometryHasLinkIncludeVolume(const NavMeshGeometry& geometry) {
+  for (const NavMeshVolumeModifier& modifier : geometry.volumeModifiers) {
+    if (modifier.enabled && modifier.mode == NavMeshModifierMode::LinkInclude) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool NavLinkTouchesModifier(const NavOffMeshLink& link, const NavMeshVolumeModifier& modifier) {
+  const XVECTOR3 midpoint((link.start.x + link.end.x) * 0.5f,
+                          (link.start.y + link.end.y) * 0.5f,
+                          (link.start.z + link.end.z) * 0.5f,
+                          1.0f);
+  return PointInsideNavModifierBox(link.start, modifier) ||
+         PointInsideNavModifierBox(link.end, modifier) ||
+         PointInsideNavModifierBox(midpoint, modifier);
+}
+
+std::vector<NavOffMeshLink> ApplyNavLinkVolumeModifiers(const NavMeshGeometry& geometry,
+                                                        const std::vector<NavOffMeshLink>& links,
+                                                        int explicitLinkCount) {
+  const bool hasLinkIncludeVolume = NavGeometryHasLinkIncludeVolume(geometry);
+  std::vector<NavOffMeshLink> filtered;
+  filtered.reserve(links.size());
+  for (int linkIndex = 0; linkIndex < static_cast<int>(links.size()); ++linkIndex) {
+    const NavOffMeshLink& link = links[static_cast<std::size_t>(linkIndex)];
+    const bool explicitLink = linkIndex < explicitLinkCount;
+    bool excluded = false;
+    bool includedByVolume = !hasLinkIncludeVolume || explicitLink;
+
+    for (const NavMeshVolumeModifier& modifier : geometry.volumeModifiers) {
+      if (!modifier.enabled ||
+          (modifier.mode != NavMeshModifierMode::LinkInclude &&
+           modifier.mode != NavMeshModifierMode::LinkExclude)) {
+        continue;
+      }
+      if (!NavLinkTouchesModifier(link, modifier)) {
+        continue;
+      }
+      if (modifier.mode == NavMeshModifierMode::LinkExclude) {
+        excluded = true;
+        break;
+      }
+      if (modifier.mode == NavMeshModifierMode::LinkInclude) {
+        includedByVolume = true;
+      }
+    }
+
+    if (!excluded && includedByVolume) {
+      filtered.push_back(link);
+    }
+  }
+  return filtered;
+}
+
 NavModifierTriangleResult ApplyNavVolumeModifiersToTriangle(const NavMeshGeometry& geometry,
                                                             const XVECTOR3& centroid,
                                                             unsigned char initialArea,
@@ -1793,6 +1849,7 @@ bool NavMesh::BuildCached(const NavMeshGeometry& geometry,
                 geometry.offMeshLinkValidator,
                 skippedExplicitLinks,
                 rejectedByValidatorLinks);
+            const int explicitLinkCount = static_cast<int>(offMeshLinks.size());
             const int generatedTraversalLinks = GenerateAutoDropLinks(
                 *polyMesh,
                 *tempQuery,
@@ -1802,6 +1859,7 @@ bool NavMesh::BuildCached(const NavMeshGeometry& geometry,
                 rejectedByValidatorLinks,
                 generatedJumpLinks,
                 offMeshLinks);
+            offMeshLinks = ApplyNavLinkVolumeModifiers(geometry, offMeshLinks, explicitLinkCount);
             generatedDropLinks = (std::max)(0, generatedTraversalLinks - generatedJumpLinks);
           }
         }

--- a/T850/Framework/src/navigation/NavigationSystem.cpp
+++ b/T850/Framework/src/navigation/NavigationSystem.cpp
@@ -1433,7 +1433,7 @@ bool BuildGeometryFromNavSources(const std::vector<NavSourceInstance>& sources,
 
   for (const NavSourceInstance& source : sources) {
     if (stats) ++stats->considered;
-    if (!source.includeInNavigation || !source.visible || !source.navigationStatic) {
+    if (!source.includeInNavigation || !source.navigationStatic) {
       if (stats) ++stats->skippedInvisible;
       continue;
     }
@@ -1441,7 +1441,7 @@ bool BuildGeometryFromNavSources(const std::vector<NavSourceInstance>& sources,
     const xF::XDataBase* database = source.database;
     XMATRIX44 worldTransform = source.worldTransform;
     if (source.instance) {
-      if (!source.instance->Visible || !source.instance->pBase) {
+      if (!source.instance->pBase) {
         if (stats) ++stats->skippedInvisible;
         continue;
       }
@@ -2685,7 +2685,7 @@ bool NavigationWorld::Rebuild(std::string* error) {
 
   for (const NavSourceInstance& source : m_sources) {
     ++m_lastSourceStats.considered;
-    if (!source.includeInNavigation || !source.visible || !source.navigationStatic) {
+    if (!source.includeInNavigation || !source.navigationStatic) {
       ++m_lastSourceStats.skippedInvisible;
       continue;
     }
@@ -2694,7 +2694,7 @@ bool NavigationWorld::Rebuild(std::string* error) {
     XMATRIX44 worldTransform = source.worldTransform;
 
     if (source.instance) {
-      if (!source.instance->Visible || !source.instance->pBase) {
+      if (!source.instance->pBase) {
         ++m_lastSourceStats.skippedInvisible;
         continue;
       }

--- a/T850/Framework/src/navigation/NavigationSystem.cpp
+++ b/T850/Framework/src/navigation/NavigationSystem.cpp
@@ -124,6 +124,41 @@ std::array<float, kNavMaxAreas> DefaultNavAreaCosts() {
   return costs;
 }
 
+std::array<float, kNavMaxAreas> BuildNavAreaCosts(const NavMeshGeometry& geometry) {
+  std::array<float, kNavMaxAreas> costs = DefaultNavAreaCosts();
+  for (const NavAreaCost& areaCost : geometry.areaCosts) {
+    if (areaCost.area >= 0 && areaCost.area < kNavMaxAreas &&
+        std::isfinite(areaCost.cost) && areaCost.cost > 0.0f) {
+      costs[static_cast<std::size_t>(areaCost.area)] = areaCost.cost;
+    }
+  }
+  for (const NavMeshVolumeModifier& modifier : geometry.volumeModifiers) {
+    if (modifier.enabled &&
+        modifier.mode == NavMeshModifierMode::Area &&
+        modifier.area >= 0 &&
+        modifier.area < kNavMaxAreas &&
+        std::isfinite(modifier.cost) &&
+        modifier.cost > 0.0f) {
+      costs[static_cast<std::size_t>(modifier.area)] = modifier.cost;
+    }
+  }
+  return costs;
+}
+
+unsigned char RecastAreaForNavArea(int area) {
+  if (area <= 0) {
+    return RC_WALKABLE_AREA;
+  }
+  if (area >= kNavMaxAreas) {
+    return RC_WALKABLE_AREA;
+  }
+  return static_cast<unsigned char>(area);
+}
+
+int NavAreaFromRecastArea(unsigned char area) {
+  return area == RC_WALKABLE_AREA ? kNavAreaWalk : static_cast<int>(area);
+}
+
 uint64_t ComputeNavModifierCacheKey(const NavMeshGeometry& geometry) {
   uint64_t hash = 0xcbf29ce484222325ull;
   HashBytes(hash, static_cast<uint64_t>(geometry.volumeModifiers.size()));
@@ -363,51 +398,80 @@ XVECTOR3 TriangleCentroid(const std::vector<float>& verts, const std::vector<int
       1.0f);
 }
 
+struct NavModifierTriangleResult {
+  unsigned char area = RC_NULL_AREA;
+  NavTriangleClassificationReason reason = NavTriangleClassificationReason::InvalidGeometry;
+  int modifierIndex = -1;
+};
+
+bool NavGeometryHasIncludeVolume(const NavMeshGeometry& geometry) {
+  for (const NavMeshVolumeModifier& modifier : geometry.volumeModifiers) {
+    if (modifier.enabled && modifier.mode == NavMeshModifierMode::Include) {
+      return true;
+    }
+  }
+  return false;
+}
+
+NavModifierTriangleResult ApplyNavVolumeModifiersToTriangle(const NavMeshGeometry& geometry,
+                                                            const XVECTOR3& centroid,
+                                                            unsigned char initialArea,
+                                                            bool hasIncludeVolume) {
+  NavModifierTriangleResult result;
+  result.area = initialArea;
+  if (initialArea == RC_NULL_AREA) {
+    result.reason = NavTriangleClassificationReason::ExcludedBySlope;
+    return result;
+  }
+
+  bool insideInclude = !hasIncludeVolume;
+  int areaOverride = -1;
+  int areaModifierIndex = -1;
+
+  for (int modifierIndex = 0; modifierIndex < static_cast<int>(geometry.volumeModifiers.size()); ++modifierIndex) {
+    const NavMeshVolumeModifier& modifier = geometry.volumeModifiers[static_cast<std::size_t>(modifierIndex)];
+    if (!modifier.enabled || !PointInsideNavModifierBox(centroid, modifier)) {
+      continue;
+    }
+    if (modifier.mode == NavMeshModifierMode::Include) {
+      insideInclude = true;
+    } else if (modifier.mode == NavMeshModifierMode::Exclude) {
+      result.area = RC_NULL_AREA;
+      result.reason = NavTriangleClassificationReason::ExcludedByVolume;
+      result.modifierIndex = modifierIndex;
+      return result;
+    } else if (modifier.mode == NavMeshModifierMode::Area &&
+               modifier.area >= 0 && modifier.area < kNavMaxAreas) {
+      areaOverride = modifier.area;
+      areaModifierIndex = modifierIndex;
+    }
+  }
+
+  if (!insideInclude) {
+    result.area = RC_NULL_AREA;
+    result.reason = NavTriangleClassificationReason::OutsideIncludeVolume;
+    return result;
+  }
+
+  if (areaOverride >= 0) {
+    result.area = RecastAreaForNavArea(areaOverride);
+    result.modifierIndex = areaModifierIndex;
+  }
+  result.reason = NavTriangleClassificationReason::Included;
+  return result;
+}
+
 void ApplyNavVolumeModifiers(const NavMeshGeometry& geometry,
                              const std::vector<float>& verts,
                              const std::vector<int>& tris,
                              std::vector<unsigned char>& areas) {
-  bool hasIncludeVolume = false;
-  for (const NavMeshVolumeModifier& modifier : geometry.volumeModifiers) {
-    if (modifier.enabled && modifier.mode == NavMeshModifierMode::Include) {
-      hasIncludeVolume = true;
-      break;
-    }
-  }
-
+  const bool hasIncludeVolume = NavGeometryHasIncludeVolume(geometry);
   const int triangleCount = static_cast<int>(areas.size());
   for (int tri = 0; tri < triangleCount; ++tri) {
-    if (areas[static_cast<std::size_t>(tri)] == RC_NULL_AREA) {
-      continue;
-    }
     const XVECTOR3 centroid = TriangleCentroid(verts, tris, tri);
-    bool insideInclude = !hasIncludeVolume;
-    int areaOverride = -1;
-
-    for (const NavMeshVolumeModifier& modifier : geometry.volumeModifiers) {
-      if (!modifier.enabled || !PointInsideNavModifierBox(centroid, modifier)) {
-        continue;
-      }
-      if (modifier.mode == NavMeshModifierMode::Include) {
-        insideInclude = true;
-      } else if (modifier.mode == NavMeshModifierMode::Exclude) {
-        areas[static_cast<std::size_t>(tri)] = RC_NULL_AREA;
-        areaOverride = -1;
-        break;
-      } else if (modifier.mode == NavMeshModifierMode::Area &&
-                 modifier.area >= 0 && modifier.area < kNavMaxAreas) {
-        areaOverride = modifier.area;
-      }
-    }
-
-    if (areas[static_cast<std::size_t>(tri)] == RC_NULL_AREA) {
-      continue;
-    }
-    if (!insideInclude) {
-      areas[static_cast<std::size_t>(tri)] = RC_NULL_AREA;
-    } else if (areaOverride >= 0) {
-      areas[static_cast<std::size_t>(tri)] = static_cast<unsigned char>(areaOverride);
-    }
+    const NavModifierTriangleResult result = ApplyNavVolumeModifiersToTriangle(
+        geometry, centroid, areas[static_cast<std::size_t>(tri)], hasIncludeVolume);
+    areas[static_cast<std::size_t>(tri)] = result.area;
   }
 }
 
@@ -1351,6 +1415,104 @@ bool BuildGeometryFromNavSources(const std::vector<NavSourceInstance>& sources,
   return true;
 }
 
+bool ClassifyNavMeshTriangles(const NavMeshGeometry& geometry,
+                              const NavMeshBuildSettings& settings,
+                              NavMeshClassificationResult& outResult,
+                              std::string* error) {
+  outResult = NavMeshClassificationResult{};
+#if !defined(T850_ENABLE_RECAST)
+  SetError(error, "RecastNavigation is not enabled in this build");
+  return false;
+#else
+  if (geometry.vertices.size() < 3 || geometry.indices.size() < 3) {
+    SetError(error, "Navigation geometry must contain vertices and triangle indices");
+    return false;
+  }
+  if ((geometry.indices.size() % 3) != 0) {
+    SetError(error, "Navigation geometry indices must be a triangle list");
+    return false;
+  }
+  if (settings.cellSize <= 0.0f || settings.cellHeight <= 0.0f || settings.agentMaxSlope < 0.0f) {
+    SetError(error, "Invalid navigation classification settings");
+    return false;
+  }
+
+  std::vector<float> verts;
+  verts.reserve(geometry.vertices.size() * 3);
+  for (const XVECTOR3& v : geometry.vertices) {
+    if (!IsFiniteVec3(v)) {
+      SetError(error, "Navigation geometry contains non-finite vertex");
+      return false;
+    }
+    verts.push_back(v.x);
+    verts.push_back(v.y);
+    verts.push_back(v.z);
+  }
+
+  std::vector<int> tris = geometry.indices;
+  for (int idx : tris) {
+    if (idx < 0 || idx >= static_cast<int>(geometry.vertices.size())) {
+      SetError(error, "Navigation geometry contains out-of-range index");
+      return false;
+    }
+  }
+
+  rcContext context;
+  const int triangleCount = static_cast<int>(tris.size() / 3);
+  std::vector<unsigned char> areas(static_cast<std::size_t>(triangleCount), RC_NULL_AREA);
+  rcMarkWalkableTriangles(&context,
+                          settings.agentMaxSlope,
+                          verts.data(),
+                          static_cast<int>(geometry.vertices.size()),
+                          tris.data(),
+                          triangleCount,
+                          areas.data());
+
+  const bool hasIncludeVolume = NavGeometryHasIncludeVolume(geometry);
+  const std::array<float, kNavMaxAreas> areaCosts = BuildNavAreaCosts(geometry);
+  outResult.triangles.reserve(static_cast<std::size_t>(triangleCount));
+  for (int tri = 0; tri < triangleCount; ++tri) {
+    const int vi0 = tris[tri * 3 + 0];
+    const int vi1 = tris[tri * 3 + 1];
+    const int vi2 = tris[tri * 3 + 2];
+    NavTriangleClassification classified;
+    classified.triangleIndex = tri;
+    classified.vertices[0] = geometry.vertices[static_cast<std::size_t>(vi0)];
+    classified.vertices[1] = geometry.vertices[static_cast<std::size_t>(vi1)];
+    classified.vertices[2] = geometry.vertices[static_cast<std::size_t>(vi2)];
+    classified.centroid = TriangleCentroid(verts, tris, tri);
+
+    const NavModifierTriangleResult modifierResult = ApplyNavVolumeModifiersToTriangle(
+        geometry,
+        classified.centroid,
+        areas[static_cast<std::size_t>(tri)],
+        hasIncludeVolume);
+    classified.included = modifierResult.area != RC_NULL_AREA;
+    classified.reason = modifierResult.reason;
+    classified.modifierIndex = modifierResult.modifierIndex;
+    if (classified.included) {
+      classified.area = NavAreaFromRecastArea(modifierResult.area);
+      if (classified.area >= 0 && classified.area < kNavMaxAreas) {
+        classified.cost = areaCosts[static_cast<std::size_t>(classified.area)];
+      }
+      ++outResult.includedCount;
+    } else {
+      classified.area = -1;
+      classified.cost = 0.0f;
+      if (classified.reason == NavTriangleClassificationReason::ExcludedBySlope) {
+        ++outResult.excludedBySlopeCount;
+      } else if (classified.reason == NavTriangleClassificationReason::OutsideIncludeVolume) {
+        ++outResult.outsideIncludeVolumeCount;
+      } else if (classified.reason == NavTriangleClassificationReason::ExcludedByVolume) {
+        ++outResult.excludedByVolumeCount;
+      }
+    }
+    outResult.triangles.push_back(classified);
+  }
+  return true;
+#endif
+}
+
 bool NavMesh::BuildFromXDataBase(const xF::XDataBase& database,
                                  const NavMeshBuildSettings& settings,
                                  std::string* error) {
@@ -1447,21 +1609,7 @@ bool NavMesh::BuildCached(const NavMeshGeometry& geometry,
     }
   }
 
-  for (const NavAreaCost& areaCost : geometry.areaCosts) {
-    if (areaCost.area >= 0 && areaCost.area < kNavMaxAreas && std::isfinite(areaCost.cost) && areaCost.cost > 0.0f) {
-      m_impl->areaCosts[static_cast<std::size_t>(areaCost.area)] = areaCost.cost;
-    }
-  }
-  for (const NavMeshVolumeModifier& modifier : geometry.volumeModifiers) {
-    if (modifier.enabled &&
-        modifier.mode == NavMeshModifierMode::Area &&
-        modifier.area >= 0 &&
-        modifier.area < kNavMaxAreas &&
-        std::isfinite(modifier.cost) &&
-        modifier.cost > 0.0f) {
-      m_impl->areaCosts[static_cast<std::size_t>(modifier.area)] = modifier.cost;
-    }
-  }
+  m_impl->areaCosts = BuildNavAreaCosts(geometry);
 
   uint64_t effectiveCacheKey = cacheKey != 0 ? cacheKey : ComputeNavMeshCacheKey(geometry, settings);
   if (cacheKey != 0 && (!geometry.volumeModifiers.empty() || !geometry.areaCosts.empty())) {

--- a/T850/Framework/src/navigation/NavigationSystem.cpp
+++ b/T850/Framework/src/navigation/NavigationSystem.cpp
@@ -89,6 +89,7 @@ constexpr unsigned char kNavAreaDrop = 1;
 constexpr unsigned char kNavAreaJump = 2;
 constexpr unsigned char kNavAreaJumpPad = 3;
 constexpr unsigned char kNavAreaJumpIntent = 4;
+constexpr int kNavMaxAreas = 64;
 constexpr int kMaxPathPolys = 256;
 constexpr int kMaxStraightPath = 256;
 constexpr std::array<char, 8> kNavMeshCacheMagic = { 'T', '8', 'N', 'A', 'V', 'C', 'H', 'E' };
@@ -110,6 +111,44 @@ void HashData(uint64_t& hash, const void* data, std::size_t byteCount) {
     hash ^= bytes[i];
     hash *= 0x100000001b3ull;
   }
+}
+
+std::array<float, kNavMaxAreas> DefaultNavAreaCosts() {
+  std::array<float, kNavMaxAreas> costs{};
+  costs.fill(1.0f);
+  costs[kNavAreaWalk] = 1.0f;
+  costs[kNavAreaDrop] = 0.35f;
+  costs[kNavAreaJump] = 0.20f;
+  costs[kNavAreaJumpPad] = 0.15f;
+  costs[kNavAreaJumpIntent] = 1.75f;
+  return costs;
+}
+
+uint64_t ComputeNavModifierCacheKey(const NavMeshGeometry& geometry) {
+  uint64_t hash = 0xcbf29ce484222325ull;
+  HashBytes(hash, static_cast<uint64_t>(geometry.volumeModifiers.size()));
+  for (const NavMeshVolumeModifier& modifier : geometry.volumeModifiers) {
+    const uint8_t mode = static_cast<uint8_t>(modifier.mode);
+    HashBytes(hash, mode);
+    HashBytes(hash, modifier.enabled);
+    HashBytes(hash, modifier.position.x);
+    HashBytes(hash, modifier.position.y);
+    HashBytes(hash, modifier.position.z);
+    HashBytes(hash, modifier.rotation.x);
+    HashBytes(hash, modifier.rotation.y);
+    HashBytes(hash, modifier.rotation.z);
+    HashBytes(hash, modifier.halfExtents.x);
+    HashBytes(hash, modifier.halfExtents.y);
+    HashBytes(hash, modifier.halfExtents.z);
+    HashBytes(hash, modifier.area);
+    HashBytes(hash, modifier.cost);
+  }
+  HashBytes(hash, static_cast<uint64_t>(geometry.areaCosts.size()));
+  for (const NavAreaCost& areaCost : geometry.areaCosts) {
+    HashBytes(hash, areaCost.area);
+    HashBytes(hash, areaCost.cost);
+  }
+  return hash;
 }
 
 uint64_t ComputeNavMeshCacheKey(const NavMeshGeometry& geometry,
@@ -173,6 +212,8 @@ uint64_t ComputeNavMeshCacheKey(const NavMeshGeometry& geometry,
     HashBytes(hash, type);
     HashBytes(hash, link.userId);
   }
+  const uint64_t modifierHash = ComputeNavModifierCacheKey(geometry);
+  HashBytes(hash, modifierHash);
   return hash;
 }
 
@@ -243,20 +284,131 @@ unsigned char PolyAreaForTraversal(NavTraversalType type) {
   }
 }
 
-void ConfigureTraversalFilter(dtQueryFilter& filter) {
+void ApplyNavAreaCosts(dtQueryFilter& filter, const std::array<float, kNavMaxAreas>* areaCosts) {
+  if (!areaCosts) {
+    filter.setAreaCost(kNavAreaWalk, 1.0f);
+    filter.setAreaCost(kNavAreaDrop, 0.35f);
+    filter.setAreaCost(kNavAreaJump, 0.20f);
+    filter.setAreaCost(kNavAreaJumpPad, 0.15f);
+    filter.setAreaCost(kNavAreaJumpIntent, 1.75f);
+    return;
+  }
+  for (int area = 0; area < kNavMaxAreas; ++area) {
+    filter.setAreaCost(area, (*areaCosts)[static_cast<std::size_t>(area)]);
+  }
+}
+
+void ConfigureTraversalFilter(dtQueryFilter& filter, const std::array<float, kNavMaxAreas>* areaCosts = nullptr) {
   filter.setIncludeFlags(kNavPolyFlagAllTraversal);
   filter.setExcludeFlags(0);
-  filter.setAreaCost(kNavAreaWalk, 1.0f);
-  filter.setAreaCost(kNavAreaDrop, 0.35f);
-  filter.setAreaCost(kNavAreaJump, 0.20f);
-  filter.setAreaCost(kNavAreaJumpPad, 0.15f);
-  filter.setAreaCost(kNavAreaJumpIntent, 1.75f);
+  ApplyNavAreaCosts(filter, areaCosts);
 }
 
 void ConfigureWalkFilter(dtQueryFilter& filter) {
   filter.setIncludeFlags(kNavPolyFlagWalk);
   filter.setExcludeFlags(0);
   filter.setAreaCost(kNavAreaWalk, 1.0f);
+}
+
+XVECTOR3 NavRotateInverseEulerXYZ(const XVECTOR3& point, const XVECTOR3& rotation) {
+  XVECTOR3 p = point;
+  auto rotateZ = [](XVECTOR3 v, float angle) {
+    const float c = std::cos(angle);
+    const float s = std::sin(angle);
+    return XVECTOR3(v.x * c - v.y * s, v.x * s + v.y * c, v.z, 0.0f);
+  };
+  auto rotateY = [](XVECTOR3 v, float angle) {
+    const float c = std::cos(angle);
+    const float s = std::sin(angle);
+    return XVECTOR3(v.x * c + v.z * s, v.y, -v.x * s + v.z * c, 0.0f);
+  };
+  auto rotateX = [](XVECTOR3 v, float angle) {
+    const float c = std::cos(angle);
+    const float s = std::sin(angle);
+    return XVECTOR3(v.x, v.y * c - v.z * s, v.y * s + v.z * c, 0.0f);
+  };
+  p = rotateZ(p, -rotation.z);
+  p = rotateY(p, -rotation.y);
+  p = rotateX(p, -rotation.x);
+  return p;
+}
+
+bool PointInsideNavModifierBox(const XVECTOR3& point, const NavMeshVolumeModifier& modifier) {
+  if (!modifier.enabled) {
+    return false;
+  }
+  const XVECTOR3 halfExtents(
+      (std::max)(0.001f, std::abs(modifier.halfExtents.x)),
+      (std::max)(0.001f, std::abs(modifier.halfExtents.y)),
+      (std::max)(0.001f, std::abs(modifier.halfExtents.z)),
+      0.0f);
+  XVECTOR3 local(point.x - modifier.position.x,
+                 point.y - modifier.position.y,
+                 point.z - modifier.position.z,
+                 0.0f);
+  local = NavRotateInverseEulerXYZ(local, modifier.rotation);
+  return std::abs(local.x) <= halfExtents.x &&
+         std::abs(local.y) <= halfExtents.y &&
+         std::abs(local.z) <= halfExtents.z;
+}
+
+XVECTOR3 TriangleCentroid(const std::vector<float>& verts, const std::vector<int>& tris, int triangleIndex) {
+  const int i0 = tris[triangleIndex * 3 + 0] * 3;
+  const int i1 = tris[triangleIndex * 3 + 1] * 3;
+  const int i2 = tris[triangleIndex * 3 + 2] * 3;
+  return XVECTOR3(
+      (verts[i0 + 0] + verts[i1 + 0] + verts[i2 + 0]) / 3.0f,
+      (verts[i0 + 1] + verts[i1 + 1] + verts[i2 + 1]) / 3.0f,
+      (verts[i0 + 2] + verts[i1 + 2] + verts[i2 + 2]) / 3.0f,
+      1.0f);
+}
+
+void ApplyNavVolumeModifiers(const NavMeshGeometry& geometry,
+                             const std::vector<float>& verts,
+                             const std::vector<int>& tris,
+                             std::vector<unsigned char>& areas) {
+  bool hasIncludeVolume = false;
+  for (const NavMeshVolumeModifier& modifier : geometry.volumeModifiers) {
+    if (modifier.enabled && modifier.mode == NavMeshModifierMode::Include) {
+      hasIncludeVolume = true;
+      break;
+    }
+  }
+
+  const int triangleCount = static_cast<int>(areas.size());
+  for (int tri = 0; tri < triangleCount; ++tri) {
+    if (areas[static_cast<std::size_t>(tri)] == RC_NULL_AREA) {
+      continue;
+    }
+    const XVECTOR3 centroid = TriangleCentroid(verts, tris, tri);
+    bool insideInclude = !hasIncludeVolume;
+    int areaOverride = -1;
+
+    for (const NavMeshVolumeModifier& modifier : geometry.volumeModifiers) {
+      if (!modifier.enabled || !PointInsideNavModifierBox(centroid, modifier)) {
+        continue;
+      }
+      if (modifier.mode == NavMeshModifierMode::Include) {
+        insideInclude = true;
+      } else if (modifier.mode == NavMeshModifierMode::Exclude) {
+        areas[static_cast<std::size_t>(tri)] = RC_NULL_AREA;
+        areaOverride = -1;
+        break;
+      } else if (modifier.mode == NavMeshModifierMode::Area &&
+                 modifier.area >= 0 && modifier.area < kNavMaxAreas) {
+        areaOverride = modifier.area;
+      }
+    }
+
+    if (areas[static_cast<std::size_t>(tri)] == RC_NULL_AREA) {
+      continue;
+    }
+    if (!insideInclude) {
+      areas[static_cast<std::size_t>(tri)] = RC_NULL_AREA;
+    } else if (areaOverride >= 0) {
+      areas[static_cast<std::size_t>(tri)] = static_cast<unsigned char>(areaOverride);
+    }
+  }
 }
 
 float DistanceSq3(const XVECTOR3& a, const XVECTOR3& b) {
@@ -821,6 +973,7 @@ void SaveNavMeshCache(const std::filesystem::path& path,
 
 NavPathResult FindPathWithQuery(dtNavMeshQuery* query,
                                 const NavMeshBuildSettings& settings,
+                                const std::array<float, kNavMaxAreas>* areaCosts,
                                 const NavPathRequest& request) {
   T8_TELEMETRY_SCOPE("navigation.detour.find_path");
   if (RuntimeTelemetry::IsFrameActive()) {
@@ -842,7 +995,7 @@ NavPathResult FindPathWithQuery(dtNavMeshQuery* query,
   };
 
   dtQueryFilter filter;
-  ConfigureTraversalFilter(filter);
+  ConfigureTraversalFilter(filter, areaCosts);
 
   dtPolyRef startRef = 0;
   dtPolyRef endRef = 0;
@@ -966,6 +1119,7 @@ struct NavMesh::Impl {
   std::unique_ptr<dtNavMesh, NavMeshDeleter> navMesh;
   std::unique_ptr<dtNavMeshQuery, NavMeshQueryDeleter> query;
   NavMeshBuildSettings settings;
+  std::array<float, kNavMaxAreas> areaCosts = DefaultNavAreaCosts();
 #endif
 };
 
@@ -1222,6 +1376,7 @@ bool NavMesh::LoadCached(uint64_t cacheKey,
 #else
   Clear();
   m_impl->settings = settings;
+  m_impl->areaCosts = DefaultNavAreaCosts();
   if (cacheKey == 0) {
     if (error) *error = "Navigation cache key is zero";
     return false;
@@ -1252,6 +1407,7 @@ bool NavMesh::BuildCached(const NavMeshGeometry& geometry,
 #else
   Clear();
   m_impl->settings = settings;
+  m_impl->areaCosts = DefaultNavAreaCosts();
 
   if (geometry.vertices.size() < 3 || geometry.indices.size() < 3) {
     SetError(error, "Navigation geometry must contain vertices and triangle indices");
@@ -1291,7 +1447,27 @@ bool NavMesh::BuildCached(const NavMeshGeometry& geometry,
     }
   }
 
-  const uint64_t effectiveCacheKey = cacheKey != 0 ? cacheKey : ComputeNavMeshCacheKey(geometry, settings);
+  for (const NavAreaCost& areaCost : geometry.areaCosts) {
+    if (areaCost.area >= 0 && areaCost.area < kNavMaxAreas && std::isfinite(areaCost.cost) && areaCost.cost > 0.0f) {
+      m_impl->areaCosts[static_cast<std::size_t>(areaCost.area)] = areaCost.cost;
+    }
+  }
+  for (const NavMeshVolumeModifier& modifier : geometry.volumeModifiers) {
+    if (modifier.enabled &&
+        modifier.mode == NavMeshModifierMode::Area &&
+        modifier.area >= 0 &&
+        modifier.area < kNavMaxAreas &&
+        std::isfinite(modifier.cost) &&
+        modifier.cost > 0.0f) {
+      m_impl->areaCosts[static_cast<std::size_t>(modifier.area)] = modifier.cost;
+    }
+  }
+
+  uint64_t effectiveCacheKey = cacheKey != 0 ? cacheKey : ComputeNavMeshCacheKey(geometry, settings);
+  if (cacheKey != 0 && (!geometry.volumeModifiers.empty() || !geometry.areaCosts.empty())) {
+    const uint64_t modifierHash = ComputeNavModifierCacheKey(geometry);
+    HashBytes(effectiveCacheKey, modifierHash);
+  }
   const std::filesystem::path cachePath = NavMeshCachePath(effectiveCacheKey);
   NavMeshBuildStats cachedStats;
   std::unique_ptr<dtNavMesh, NavMeshDeleter> cachedNavMesh;
@@ -1341,6 +1517,7 @@ bool NavMesh::BuildCached(const NavMeshGeometry& geometry,
   std::vector<unsigned char> areas(static_cast<std::size_t>(triangleCount), RC_NULL_AREA);
   rcMarkWalkableTriangles(&context, config.walkableSlopeAngle, verts.data(),
                           static_cast<int>(geometry.vertices.size()), tris.data(), triangleCount, areas.data());
+  ApplyNavVolumeModifiers(geometry, verts, tris, areas);
   if (!rcRasterizeTriangles(&context, verts.data(), static_cast<int>(geometry.vertices.size()),
                             tris.data(), areas.data(), triangleCount, *heightfield, config.walkableClimb)) {
     SetError(error, "Failed to rasterize navigation triangles");
@@ -1599,7 +1776,7 @@ bool NavMesh::FindPath(const XVECTOR3& start,
   const float extents[3] = { m_impl->settings.queryExtents.x, m_impl->settings.queryExtents.y, m_impl->settings.queryExtents.z };
 
   dtQueryFilter filter;
-  ConfigureTraversalFilter(filter);
+  ConfigureTraversalFilter(filter, &m_impl->areaCosts);
 
   dtPolyRef startRef = 0;
   dtPolyRef endRef = 0;
@@ -1713,7 +1890,7 @@ NavPathResult NavMesh::FindPath(const NavPathRequest& request) const {
     return result;
   }
 
-  NavPathResult result = FindPathWithQuery(m_impl->query.get(), m_impl->settings, request);
+  NavPathResult result = FindPathWithQuery(m_impl->query.get(), m_impl->settings, &m_impl->areaCosts, request);
   if (!result.success && !result.error.empty()) {
     SetError(nullptr, result.error);
   }
@@ -1763,7 +1940,7 @@ void NavMesh::FindPaths(const std::vector<NavPathRequest>& requests,
     }
 
     outResults[static_cast<std::size_t>(requestIndex)] =
-        FindPathWithQuery(query.get(), m_impl->settings, requests[static_cast<std::size_t>(requestIndex)]);
+        FindPathWithQuery(query.get(), m_impl->settings, &m_impl->areaCosts, requests[static_cast<std::size_t>(requestIndex)]);
   };
 
   if (g_threadPool &&

--- a/T850/Framework/src/scene/LineRenderer.cpp
+++ b/T850/Framework/src/scene/LineRenderer.cpp
@@ -6,6 +6,7 @@
 #include <scene/LineRenderer.h>
 
 #include <Config.h>
+#include <scene/RenderQueue.h>
 #include <video/BaseDriver.h>
 #include <utils/Utils.h>
 #include <utils/Log.h>
@@ -134,19 +135,22 @@ void LineRenderer::DrawLines(const XMATRIX44& world,
     m_farPlane,
     m_depthBias);
 
-  ib->Set(*T8DeviceContext, 0, ibFormat);
-  vb->Set(*T8DeviceContext, vertexStride, 0);
-
-  // Set topology BEFORE shader (Vulkan bakes topology into the pipeline at Set time)
-  T8DeviceContext->SetPrimitiveTopology(Topology::LINE_LIST);
+  MeshDrawStateTracker& tracker = MeshDrawStateTracker::Get();
+  tracker.BindIndexedGeometry(*T8DeviceContext,
+                              vb,
+                              vertexStride,
+                              0,
+                              ib,
+                              ibFormat,
+                              Topology::LINE_LIST);
 
   shader->Set(*T8DeviceContext);
-  m_cb->UpdateFromBuffer(*T8DeviceContext, &cb);
-  m_cb->Set(*T8DeviceContext);
+  tracker.OnShaderChanged(shader);
+  tracker.UpdateAndBindConstantBuffer(*T8DeviceContext, m_cb, 0, &cb, sizeof(cb));
 #if defined(USING_VULKAN) || defined(USING_VULKAN_ONLY)
   // Android offline SPIR-V can auto-map VS/FS cbuffers to different bindings
   // when the fragment shader also samples depth. Populate both logical slots.
-  m_cb->Set(*T8DeviceContext, 1);
+  tracker.UpdateAndBindConstantBuffer(*T8DeviceContext, m_cb, 1, &cb, sizeof(cb));
 #endif
 
   // Bind depth texture AFTER shader is set (D3D12 needs active root signature)
@@ -158,9 +162,6 @@ void LineRenderer::DrawLines(const XMATRIX44& world,
   }
 
   T8DeviceContext->DrawIndexed(indexCount, 0, startVertex);
-
-  // Reset topology back to triangle list for subsequent draws
-  T8DeviceContext->SetPrimitiveTopology(Topology::TRIANLE_LIST);
 }
 
 VertexBuffer* LineRenderer::CreatePositionVB(const float* positionsXYZW,

--- a/T850/Framework/src/scene/Quad.cpp
+++ b/T850/Framework/src/scene/Quad.cpp
@@ -1,5 +1,6 @@
 #include <pch.h>
 #include <scene/Quad.h>
+#include <scene/RenderQueue.h>
 #include <utils/Utils.h>
 namespace t850 {
 
@@ -40,7 +41,12 @@ namespace t850 {
   {
     unsigned int offset = 0;
     unsigned int stride = sizeof(Vertex);
-    m_VB->Set(*T8DeviceContext, stride, offset);
-    m_IB->Set(*T8DeviceContext, 0, IndexBufferFormat::R16);
+    MeshDrawStateTracker::Get().BindIndexedGeometry(*T8DeviceContext,
+                                                    m_VB,
+                                                    stride,
+                                                    offset,
+                                                    m_IB,
+                                                    IndexBufferFormat::R16,
+                                                    Topology::TRIANLE_LIST);
   }
 }

--- a/T850/Framework/src/scene/RenderMesh.cpp
+++ b/T850/Framework/src/scene/RenderMesh.cpp
@@ -1375,17 +1375,7 @@ namespace t850 {
       if (lineIdx.empty()) continue;
 
       unsigned maxVert = (unsigned)geom.Positions.size();
-      if (maxVert <= 65535) {
-        std::vector<unsigned short> idx16(lineIdx.size());
-        for (std::size_t j = 0; j < lineIdx.size(); j++)
-          idx16[j] = (unsigned short)lineIdx[j];
-        m_wireGeo[gi].IB = LineRenderer::CreateIndexBuffer16(idx16.data(), (unsigned)idx16.size());
-        m_wireGeo[gi].use32Bit = false;
-      } else {
-        m_wireGeo[gi].IB = LineRenderer::CreateIndexBuffer32(lineIdx.data(), (unsigned)lineIdx.size());
-        m_wireGeo[gi].use32Bit = true;
-      }
-      m_wireGeo[gi].indexCount = (unsigned)lineIdx.size();
+      m_wireGeo[gi].CreateLineIndexBuffer(lineIdx, maxVert);
     }
   }
 
@@ -1402,7 +1392,7 @@ namespace t850 {
     m_lineRenderer.SetFarPlane(cam->FPlane);
 
     for (std::size_t i = 0; i < Info.size() && i < m_wireGeo.size(); i++) {
-      if (!m_wireGeo[i].IB || m_wireGeo[i].indexCount == 0) continue;
+      if (!m_wireGeo[i].HasIndexBuffer()) continue;
 
       MeshInfo* mi = &Info[i];
       VertexBuffer* vbToBind = mi->VB;
@@ -1420,9 +1410,15 @@ namespace t850 {
         continue;
       }
 
-      auto ibFmt = m_wireGeo[i].use32Bit ? IndexBufferFormat::R32 : IndexBufferFormat::R16;
-      m_lineRenderer.DrawLines(transform, cam->VP, wireColor, vbToBind, m_wireGeo[i].IB,
-                               m_wireGeo[i].indexCount, mi->VertexSize, ibFmt, baseVertex);
+      m_lineRenderer.DrawLines(transform,
+                               cam->VP,
+                               wireColor,
+                               vbToBind,
+                               m_wireGeo[i].GetIndexBuffer(),
+                               m_wireGeo[i].GetIndexCount(),
+                               mi->VertexSize,
+                               m_wireGeo[i].GetIndexFormat(),
+                               baseVertex);
     }
   }
 
@@ -2179,7 +2175,6 @@ namespace t850 {
         T8_LOG_ERROR("[RenderMesh] Skipped geometry %zu: no uploaded vertex buffer", i);
         continue;
       }
-      vbToBind->Set(*deviceContext, stride, offset);
 
       // Build sorted draw order by shader key to minimize PSO switches
       std::size_t numSubsets = it_MeshInfo->SubSets.size();
@@ -2313,11 +2308,16 @@ namespace t850 {
           continue;
         }
         IndexBufferFormat::E ibFmt = sub_info->IB32Bit ? IndexBufferFormat::R32 : IndexBufferFormat::R16;
-        // Phase C step 3: IB-bind dedup via process-wide tracker.
-        if (tracker.ShouldBindIB(ibToBind, ibFmt)) {
-          if (trackCullStats) m_renderStateChanges++;
-          ibToBind->Set(*deviceContext, 0, ibFmt);
-        }
+        const unsigned geometryBindChanges =
+          tracker.BindIndexedGeometry(*deviceContext,
+                                      vbToBind,
+                                      stride,
+                                      offset,
+                                      ibToBind,
+                                      ibFmt,
+                                      Topology::TRIANLE_LIST);
+        if (trackCullStats)
+          m_renderStateChanges += geometryBindChanges;
 
         // Build final shader key: material features + global pass + toggles
         ShaderKey finalKey(sub_info->key.bits);
@@ -2466,8 +2466,6 @@ namespace t850 {
           bindTextureOnce(t, MaterialTextureSlot::Lightmap, "LightmapTex", LightmapSamplerSlot);
         }
 
-        if (trackCullStats) m_renderStateChanges++;
-        deviceContext->SetPrimitiveTopology(Topology::TRIANLE_LIST);
         // Phase A.5 step 2: when using shared pools the index/vertex
         // offsets steer the draw to this submesh's allocation. Falls
         // back to (count, 0, 0) on the legacy per-subset IB path.
@@ -2582,9 +2580,8 @@ namespace t850 {
       m_asset = nullptr;
     }
 
-    for (auto& wg : m_wireGeo) {
-      if (wg.IB) { wg.IB->release(); wg.IB = nullptr; }
-    }
+    for (auto& wg : m_wireGeo)
+      wg.Destroy();
     m_wireGeo.clear();
     m_wireShader = nullptr;
     m_lineRenderer.Destroy();

--- a/T850/Framework/src/scene/RenderQuad.cpp
+++ b/T850/Framework/src/scene/RenderQuad.cpp
@@ -14,6 +14,7 @@
 #include <scene/RenderQuad.h>
 #include <scene/RenderGraph.h>
 #include <scene/RenderMesh.h>
+#include <scene/RenderQueue.h>
 #include <utils/Utils.h>
 
 #if defined(USING_GL_COMMON)
@@ -744,8 +745,8 @@ namespace t850 {
     g_pBaseDriver->SetCullFace(BaseDriver::FRONT_AND_BACK);
 
     m_quad.Set();
-    T8DeviceContext->SetPrimitiveTopology(Topology::TRIANLE_LIST);
     s->Set(*T8DeviceContext);
+    MeshDrawStateTracker::Get().OnShaderChanged(s);
 
     auto updateQuadConstants = [&]() {
       if (g_pBaseDriver->UsesGLSL()) {

--- a/T850/Framework/src/scene/RenderQueue.cpp
+++ b/T850/Framework/src/scene/RenderQueue.cpp
@@ -37,8 +37,14 @@ namespace t850 {
     for (int i = 0; i < kMaxTrackedSlots; ++i) m_lastTex[i] = nullptr;
     for (int i = 0; i < kMaxTrackedSlots; ++i) m_lastCB[i] = nullptr;
     m_lastEnv = nullptr;
+    m_lastVB = nullptr;
+    m_lastVBStride = 0;
+    m_lastVBOffset = 0;
+    m_lastVBSet = false;
     m_lastIB = nullptr;
     m_lastIBFmtSet = false;
+    m_lastTopology = Topology::TRIANLE_LIST;
+    m_lastTopologySet = false;
   }
 
   void MeshDrawStateTracker::OnShaderChanged(ShaderBase* s) {
@@ -71,6 +77,55 @@ namespace t850 {
     m_lastIBFmt = fmt;
     m_lastIBFmtSet = true;
     return true;
+  }
+
+  bool MeshDrawStateTracker::ShouldSetTopology(Topology::E topology) {
+    if (m_lastTopologySet && m_lastTopology == topology) return false;
+    m_lastTopology = topology;
+    m_lastTopologySet = true;
+    return true;
+  }
+
+  bool MeshDrawStateTracker::ShouldBindVertexBuffer(VertexBuffer* vb,
+                                                    unsigned stride,
+                                                    unsigned offset) {
+    if (m_lastVBSet && m_lastVB == vb &&
+        m_lastVBStride == stride && m_lastVBOffset == offset)
+      return false;
+    m_lastVB = vb;
+    m_lastVBStride = stride;
+    m_lastVBOffset = offset;
+    m_lastVBSet = true;
+    return true;
+  }
+
+  unsigned MeshDrawStateTracker::BindIndexedGeometry(DeviceContext& deviceContext,
+                                                     VertexBuffer* vb,
+                                                     unsigned stride,
+                                                     unsigned offset,
+                                                     IndexBuffer* ib,
+                                                     IndexBufferFormat::E fmt,
+                                                     Topology::E topology) {
+    if (!vb || !ib)
+      return 0;
+
+    if (!m_passActive)
+      Reset();
+
+    unsigned changes = 0;
+    if (ShouldSetTopology(topology)) {
+      deviceContext.SetPrimitiveTopology(topology);
+      ++changes;
+    }
+    if (ShouldBindVertexBuffer(vb, stride, offset)) {
+      vb->Set(deviceContext, stride, offset);
+      ++changes;
+    }
+    if (ShouldBindIB(ib, fmt)) {
+      ib->Set(deviceContext, 0, fmt);
+      ++changes;
+    }
+    return changes;
   }
 
   bool MeshDrawStateTracker::UpdateAndBindConstantBuffer(const DeviceContext& deviceContext,

--- a/T850/Framework/src/scene/RenderSkinnedMesh.cpp
+++ b/T850/Framework/src/scene/RenderSkinnedMesh.cpp
@@ -703,17 +703,7 @@ namespace t850 {
       if (lineIdx.empty()) continue;
 
       unsigned maxVert = (unsigned)geom.Positions.size();
-      if (maxVert <= 65535) {
-        std::vector<unsigned short> idx16(lineIdx.size());
-        for (std::size_t j = 0; j < lineIdx.size(); j++)
-          idx16[j] = (unsigned short)lineIdx[j];
-        m_wireGeo[gi].IB = LineRenderer::CreateIndexBuffer16(idx16.data(), (unsigned)idx16.size());
-        m_wireGeo[gi].use32Bit = false;
-      } else {
-        m_wireGeo[gi].IB = LineRenderer::CreateIndexBuffer32(lineIdx.data(), (unsigned)lineIdx.size());
-        m_wireGeo[gi].use32Bit = true;
-      }
-      m_wireGeo[gi].indexCount = (unsigned)lineIdx.size();
+      m_wireGeo[gi].CreateLineIndexBuffer(lineIdx, maxVert);
     }
   }
 
@@ -995,7 +985,7 @@ namespace t850 {
     ExtractMeshInstanceCB(wireInstanceCB, wireCB);
 
     for (std::size_t i = 0; i < Info.size() && i < m_wireGeo.size(); i++) {
-      if (!m_wireGeo[i].IB || m_wireGeo[i].indexCount == 0) continue;
+      if (!m_wireGeo[i].HasIndexBuffer()) continue;
 
       MeshInfo* mi = &Info[i];
       VertexBuffer* vbToBind = mi->VB;
@@ -1012,14 +1002,17 @@ namespace t850 {
         T8_LOG_ERROR("[SkinnedMesh] Wireframe skipped geometry %zu: no vertex buffer", i);
         continue;
       }
-      vbToBind->Set(*T8DeviceContext, mi->VertexSize, 0);
-
-      auto ibFmt = m_wireGeo[i].use32Bit ? IndexBufferFormat::R32 : IndexBufferFormat::R16;
-      m_wireGeo[i].IB->Set(*T8DeviceContext, 0, ibFmt);
-
-      T8DeviceContext->SetPrimitiveTopology(Topology::LINE_LIST);
+      MeshDrawStateTracker& tracker = MeshDrawStateTracker::Get();
+      tracker.BindIndexedGeometry(*T8DeviceContext,
+                                  vbToBind,
+                                  mi->VertexSize,
+                                  0,
+                                  m_wireGeo[i].GetIndexBuffer(),
+                                  m_wireGeo[i].GetIndexFormat(),
+                                  Topology::LINE_LIST);
 
       m_wireShader->Set(*T8DeviceContext);
+      tracker.OnShaderChanged(m_wireShader);
       mi->CB->UpdateFromBuffer(*T8DeviceContext, &wireCB.WVP[0]);
       mi->CB->Set(*T8DeviceContext, 0);
       if (!g_pBaseDriver->UsesGLSL()) {
@@ -1039,9 +1032,7 @@ namespace t850 {
         secondaryDepth->Set(*T8DeviceContext, 1, "depthTex2");
       }
 
-      T8DeviceContext->DrawIndexed(m_wireGeo[i].indexCount, 0, baseVertex);
-
-      T8DeviceContext->SetPrimitiveTopology(Topology::TRIANLE_LIST);
+      T8DeviceContext->DrawIndexed(m_wireGeo[i].GetIndexCount(), 0, baseVertex);
     }
   }
 
@@ -1370,7 +1361,6 @@ namespace t850 {
         T8_LOG_ERROR("[SkinnedMesh] Skipped geometry %zu: no uploaded vertex buffer", i);
         continue;
       }
-      vbToBind->Set(*T8DeviceContext, stride, offset);
 
       std::size_t numSubsets = it_MeshInfo->SubSets.size();
       std::vector<std::size_t> drawOrder(numSubsets);
@@ -1481,9 +1471,13 @@ namespace t850 {
           T8_LOG_ERROR("[SkinnedMesh] Skipped subset %zu: no uploaded index buffer", k);
           continue;
         }
-        ibToBind->Set(*T8DeviceContext, 0,
-                      sub_info->IB32Bit ? IndexBufferFormat::R32
-                                        : IndexBufferFormat::R16);
+        tracker.BindIndexedGeometry(*T8DeviceContext,
+                                    vbToBind,
+                                    stride,
+                                    offset,
+                                    ibToBind,
+                                    sub_info->IB32Bit ? IndexBufferFormat::R32 : IndexBufferFormat::R16,
+                                    Topology::TRIANLE_LIST);
 
         ShaderKey finalKey(sub_info->key.bits);
         finalKey.setPass(gKey.getPass());
@@ -1627,7 +1621,6 @@ namespace t850 {
           sub_info->LightmapTex->SetSampler(*T8DeviceContext, LightmapSamplerSlot);
         }
 
-        T8DeviceContext->SetPrimitiveTopology(Topology::TRIANLE_LIST);
         // Phase A.5 step 3: pool offsets steer the draw to this
         // submesh's allocation.
         if (sub_info->ibPoolAlloc.IsValid() && it_MeshInfo->vbPoolAlloc.IsValid()) {
@@ -1655,9 +1648,8 @@ namespace t850 {
     m_snapshotPoseActive = false;
 
     m_lineRenderer.Destroy();
-    for (auto& wg : m_wireGeo) {
-      if (wg.IB) { wg.IB->release(); wg.IB = nullptr; }
-    }
+    for (auto& wg : m_wireGeo)
+      wg.Destroy();
     m_wireGeo.clear();
     m_wireShader = nullptr;
     if (m_skelVB) { m_skelVB->release(); m_skelVB = nullptr; }

--- a/T850/Framework/src/scene/SplineWireframe.cpp
+++ b/T850/Framework/src/scene/SplineWireframe.cpp
@@ -1,5 +1,6 @@
 #include <pch.h>
 #include <scene/SplineWireframe.h>
+#include <scene/RenderQueue.h>
 #include <utils/Log.h>
 #include <utils/Utils.h>
 namespace t850 {
@@ -95,12 +96,18 @@ void SplineWireframe::Draw(float * t, float * vp)
 
   Camera *pActualCamera = pScProp->GetPrimaryCamera();
   constantBuff.WVP = pActualCamera->VP;
-  IB->Set(*T8DeviceContext, 0, IndexBufferFormat::R16);
-  VB->Set(*T8DeviceContext,sizeof(Vert),0);
+  MeshDrawStateTracker& tracker = MeshDrawStateTracker::Get();
+  tracker.BindIndexedGeometry(*T8DeviceContext,
+                              VB,
+                              sizeof(Vert),
+                              0,
+                              IB,
+                              IndexBufferFormat::R16,
+                              Topology::LINE_STRIP);
   s->Set(*T8DeviceContext);
+  tracker.OnShaderChanged(s);
   CB->UpdateFromBuffer(*T8DeviceContext, &constantBuff.WVP[0]);
   CB->Set(*T8DeviceContext);
-  T8DeviceContext->SetPrimitiveTopology(Topology::LINE_STRIP);
   T8DeviceContext->DrawIndexed(static_cast<unsigned>(vertices.size()), 0, 0);
 }
 void SplineWireframe::Destroy()

--- a/T850/Framework/src/scene/TextRenderer.cpp
+++ b/T850/Framework/src/scene/TextRenderer.cpp
@@ -1,5 +1,6 @@
 #include <pch.h>
 #include <scene/TextRenderer.h>
+#include <scene/RenderQueue.h>
 #include <utils/Log.h>
 #include <utils/ResourceLocator.h>
 #include <utils/Utils.h>
@@ -165,9 +166,9 @@ namespace t850 {
     //y = -m_textureSize - y;
     m_quad.Set();
     m_shader->Set(*T8DeviceContext);
+    MeshDrawStateTracker::Get().OnShaderChanged(m_shader);
     m_CB->UpdateFromBuffer(*T8DeviceContext, &color.x);
     m_CB->Set(*T8DeviceContext);
-    T8DeviceContext->SetPrimitiveTopology(Topology::TRIANLE_LIST);
     ftex->Set(*T8DeviceContext, 0, "tex0");
     //ftex->SetSampler(*T8DeviceContext);
     float tempDiv = 1.0f / (float)m_textureSize;
@@ -251,9 +252,9 @@ namespace t850 {
 
     m_quad.Set();
     m_shader->Set(*T8DeviceContext);
+    MeshDrawStateTracker::Get().OnShaderChanged(m_shader);
     m_CB->UpdateFromBuffer(*T8DeviceContext, &color.x);
     m_CB->Set(*T8DeviceContext);
-    T8DeviceContext->SetPrimitiveTopology(Topology::TRIANLE_LIST);
     ftex->Set(*T8DeviceContext, 0, "tex0");
 
     float sw = (float)screenW;
@@ -308,10 +309,15 @@ namespace t850 {
 
     unsigned int stride = sizeof(Quad::Vertex);
     unsigned int offset = 0;
-    m_batchVB->Set(*T8DeviceContext, stride, offset);
-    m_batchIB->Set(*T8DeviceContext, 0, IndexBufferFormat::R16);
+    MeshDrawStateTracker::Get().BindIndexedGeometry(*T8DeviceContext,
+                                                    m_batchVB,
+                                                    stride,
+                                                    offset,
+                                                    m_batchIB,
+                                                    IndexBufferFormat::R16,
+                                                    Topology::TRIANLE_LIST);
     m_shader->Set(*T8DeviceContext);
-    T8DeviceContext->SetPrimitiveTopology(Topology::TRIANLE_LIST);
+    MeshDrawStateTracker::Get().OnShaderChanged(m_shader);
     ftex->Set(*T8DeviceContext, 0, "tex0");
   }
 

--- a/T850/Framework/src/scene/WireframeArrow.cpp
+++ b/T850/Framework/src/scene/WireframeArrow.cpp
@@ -1,5 +1,6 @@
 #include <pch.h>
 #include <scene/WireframeArrow.h>
+#include <scene/RenderQueue.h>
 #include <utils/Log.h>
 #include <utils/Utils.h>
 #include <cmath>
@@ -176,12 +177,18 @@ void WireframeArrow::Draw(const XMATRIX44& vp, const XVECTOR3& position, const X
 
   constantBuff.WVP = world * vp;
 
-  IB->Set(*T8DeviceContext, 0, IndexBufferFormat::R16);
-  VB->Set(*T8DeviceContext, sizeof(Vert), 0);
+  MeshDrawStateTracker& tracker = MeshDrawStateTracker::Get();
+  tracker.BindIndexedGeometry(*T8DeviceContext,
+                              VB,
+                              sizeof(Vert),
+                              0,
+                              IB,
+                              IndexBufferFormat::R16,
+                              Topology::LINE_LIST);
   s->Set(*T8DeviceContext);
+  tracker.OnShaderChanged(s);
   CB->UpdateFromBuffer(*T8DeviceContext, &constantBuff.WVP[0]);
   CB->Set(*T8DeviceContext);
-  T8DeviceContext->SetPrimitiveTopology(Topology::LINE_LIST);
   T8DeviceContext->DrawIndexed(static_cast<unsigned>(indexCount), 0, 0);
 }
 

--- a/T850/Framework/src/scene/WireframeGeometry.cpp
+++ b/T850/Framework/src/scene/WireframeGeometry.cpp
@@ -1,0 +1,178 @@
+#include <pch.h>
+
+#include <scene/WireframeGeometry.h>
+
+#include <utils/Log.h>
+
+#include <algorithm>
+
+namespace t850 {
+  extern Device* T8Device;
+
+  WireframeGeometry::~WireframeGeometry() {
+    Destroy();
+  }
+
+  WireframeGeometry::WireframeGeometry(WireframeGeometry&& other) noexcept {
+    MoveFrom(other);
+  }
+
+  WireframeGeometry& WireframeGeometry::operator=(WireframeGeometry&& other) noexcept {
+    if (this != &other) {
+      Destroy();
+      MoveFrom(other);
+    }
+    return *this;
+  }
+
+  void WireframeGeometry::MoveFrom(WireframeGeometry& other) noexcept {
+    m_vb = other.m_vb;
+    m_ib = other.m_ib;
+    m_indexCount = other.m_indexCount;
+    m_indexFormat = other.m_indexFormat;
+
+    other.m_vb = nullptr;
+    other.m_ib = nullptr;
+    other.m_indexCount = 0;
+    other.m_indexFormat = IndexBufferFormat::R16;
+  }
+
+  void WireframeGeometry::ReleaseVertexBuffer() {
+    if (m_vb) {
+      m_vb->release();
+      m_vb = nullptr;
+    }
+  }
+
+  void WireframeGeometry::ReleaseIndexBuffer() {
+    if (m_ib) {
+      m_ib->release();
+      m_ib = nullptr;
+    }
+    m_indexCount = 0;
+    m_indexFormat = IndexBufferFormat::R16;
+  }
+
+  void WireframeGeometry::Destroy() {
+    ReleaseIndexBuffer();
+    ReleaseVertexBuffer();
+  }
+
+  bool WireframeGeometry::CreatePositionBuffer(const float* positionsXYZW,
+                                               unsigned vertexCount,
+                                               BufferUsage::E usage) {
+    ReleaseVertexBuffer();
+    if (!T8Device || !positionsXYZW || vertexCount == 0) {
+      T8_LOG_ERROR("[WireframeGeometry] position buffer creation failed: invalid input");
+      return false;
+    }
+
+    BufferDesc bd;
+    bd.byteWidth = static_cast<int>(sizeof(float) * 4u * vertexCount);
+    bd.usage = usage;
+    m_vb = static_cast<VertexBuffer*>(
+        T8Device->CreateBuffer(BufferType::VERTEX, bd, const_cast<float*>(positionsXYZW)));
+    if (!m_vb) {
+      T8_LOG_ERROR("[WireframeGeometry] position buffer creation failed");
+      return false;
+    }
+    return true;
+  }
+
+  bool WireframeGeometry::CreateLineIndexBuffer(const std::vector<unsigned int>& lineIndices,
+                                                unsigned vertexCount) {
+    return CreateLineIndexBuffer(lineIndices.data(),
+                                 static_cast<unsigned>(lineIndices.size()),
+                                 vertexCount);
+  }
+
+  bool WireframeGeometry::CreateLineIndexBuffer(const unsigned int* lineIndices,
+                                                unsigned indexCount,
+                                                unsigned vertexCount) {
+    ReleaseIndexBuffer();
+    if (!T8Device || !lineIndices || indexCount == 0 || vertexCount == 0) {
+      T8_LOG_ERROR("[WireframeGeometry] index buffer creation failed: invalid input");
+      return false;
+    }
+
+    BufferDesc bd;
+    bd.usage = BufferUsage::DEFAULT;
+    if (vertexCount <= 65535u) {
+      std::vector<unsigned short> indices16(indexCount);
+      for (unsigned i = 0; i < indexCount; ++i) {
+        if (lineIndices[i] >= vertexCount) {
+          T8_LOG_ERROR("[WireframeGeometry] index buffer creation failed: index %u out of %u vertices",
+                       lineIndices[i], vertexCount);
+          return false;
+        }
+        indices16[i] = static_cast<unsigned short>(lineIndices[i]);
+      }
+      bd.byteWidth = static_cast<int>(sizeof(unsigned short) * indices16.size());
+      m_ib = static_cast<IndexBuffer*>(
+          T8Device->CreateBuffer(BufferType::INDEX, bd, indices16.data()));
+      m_indexFormat = IndexBufferFormat::R16;
+    } else {
+      for (unsigned i = 0; i < indexCount; ++i) {
+        if (lineIndices[i] >= vertexCount) {
+          T8_LOG_ERROR("[WireframeGeometry] index buffer creation failed: index %u out of %u vertices",
+                       lineIndices[i], vertexCount);
+          return false;
+        }
+      }
+      bd.byteWidth = static_cast<int>(sizeof(unsigned int) * indexCount);
+      m_ib = static_cast<IndexBuffer*>(
+          T8Device->CreateBuffer(BufferType::INDEX, bd, const_cast<unsigned int*>(lineIndices)));
+      m_indexFormat = IndexBufferFormat::R32;
+    }
+
+    if (!m_ib) {
+      T8_LOG_ERROR("[WireframeGeometry] index buffer creation failed");
+      m_indexCount = 0;
+      m_indexFormat = IndexBufferFormat::R16;
+      return false;
+    }
+    m_indexCount = indexCount;
+    return true;
+  }
+
+  bool WireframeGeometry::CreateFromTriangles(const float* positionsXYZW,
+                                              unsigned vertexCount,
+                                              const unsigned int* triangleIndices,
+                                              unsigned triangleIndexCount,
+                                              BufferUsage::E usage) {
+    Destroy();
+    if (!positionsXYZW || vertexCount == 0 ||
+        !triangleIndices || triangleIndexCount < 3) {
+      T8_LOG_ERROR("[WireframeGeometry] triangle wireframe creation failed: invalid input");
+      return false;
+    }
+
+    std::vector<unsigned int> lineIndices;
+    lineIndices.reserve((triangleIndexCount / 3u) * 6u);
+    for (unsigned t = 0; t + 2 < triangleIndexCount; t += 3) {
+      const unsigned int a = triangleIndices[t + 0];
+      const unsigned int b = triangleIndices[t + 1];
+      const unsigned int c = triangleIndices[t + 2];
+      if (a >= vertexCount || b >= vertexCount || c >= vertexCount)
+        continue;
+      lineIndices.push_back(a); lineIndices.push_back(b);
+      lineIndices.push_back(b); lineIndices.push_back(c);
+      lineIndices.push_back(c); lineIndices.push_back(a);
+    }
+
+    if (lineIndices.empty()) {
+      T8_LOG_ERROR("[WireframeGeometry] triangle wireframe creation failed: no valid triangles");
+      return false;
+    }
+
+    if (!CreatePositionBuffer(positionsXYZW, vertexCount, usage)) {
+      Destroy();
+      return false;
+    }
+    if (!CreateLineIndexBuffer(lineIndices, vertexCount)) {
+      Destroy();
+      return false;
+    }
+    return true;
+  }
+}

--- a/T850/Framework/src/scene/WireframeSphere.cpp
+++ b/T850/Framework/src/scene/WireframeSphere.cpp
@@ -1,5 +1,6 @@
 #include <pch.h>
 #include <scene/WireframeSphere.h>
+#include <scene/RenderQueue.h>
 #include <utils/Log.h>
 #include <utils/Utils.h>
 #include <cmath>
@@ -139,14 +140,19 @@ void WireframeSphere::Draw(const XMATRIX44& vp, const XVECTOR3& center, float ra
   constantBuff.WVP = world * vp;
   constantBuff.LineColor = color;
 
-  IB->Set(*T8DeviceContext, 0, IndexBufferFormat::R16);
-  VB->Set(*T8DeviceContext, sizeof(Vert), 0);
-  T8DeviceContext->SetPrimitiveTopology(Topology::LINE_LIST);
+  MeshDrawStateTracker& tracker = MeshDrawStateTracker::Get();
+  tracker.BindIndexedGeometry(*T8DeviceContext,
+                              VB,
+                              sizeof(Vert),
+                              0,
+                              IB,
+                              IndexBufferFormat::R16,
+                              Topology::LINE_LIST);
   s->Set(*T8DeviceContext);
+  tracker.OnShaderChanged(s);
   CB->UpdateFromBuffer(*T8DeviceContext, &constantBuff);
   CB->Set(*T8DeviceContext);
   T8DeviceContext->DrawIndexed(static_cast<unsigned>(indexCount), 0, 0);
-  T8DeviceContext->SetPrimitiveTopology(Topology::TRIANLE_LIST);
 }
 
 void WireframeSphere::Destroy() {

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -2552,9 +2552,15 @@ bool EditorApp::CreateNavVolumeFromSelectedTriangle(const char* type) {
   const XVECTOR3 center = bounds.Center();
   const XVECTOR3 extents = bounds.Extents();
   t850::scene::SceneNavMeshVolumeDesc volume;
-  volume.name = std::string(type && std::strcmp(type, "area_cost") == 0 ? "Area Cost From Triangle " : "Exclude From Triangle ") +
-      std::to_string(m_editorNavMeshVolumes.size() + 1);
   volume.type = type && *type ? type : "exclude";
+  const bool areaVolume = volume.type == "area_cost";
+  const bool linkIncludeVolume = volume.type == "link_include";
+  const bool linkExcludeVolume = volume.type == "link_exclude";
+  const char* namePrefix = areaVolume
+      ? "Area Cost From Triangle "
+      : (linkIncludeVolume ? "Link Include From Triangle "
+                           : (linkExcludeVolume ? "Link Exclude From Triangle " : "Exclude From Triangle "));
+  volume.name = std::string(namePrefix) + std::to_string(m_editorNavMeshVolumes.size() + 1);
   volume.shape = "box";
   volume.position = {center.x, center.y, center.z};
   volume.half_extents = {
@@ -2564,7 +2570,7 @@ bool EditorApp::CreateNavVolumeFromSelectedTriangle(const char* type) {
   volume.enabled = true;
   volume.visible = true;
   volume.show_wire = true;
-  if (volume.type == "area_cost") {
+  if (areaVolume) {
     volume.area = "mud";
     volume.cost = 3.0f;
   }
@@ -3272,6 +3278,13 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
     if (ImGui::Button("Area Cost Selected Triangle")) {
       CreateNavVolumeFromSelectedTriangle("area_cost");
     }
+    if (ImGui::Button("Link Include Selected Triangle")) {
+      CreateNavVolumeFromSelectedTriangle("link_include");
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Link Exclude Selected Triangle")) {
+      CreateNavVolumeFromSelectedTriangle("link_exclude");
+    }
   }
   if (m_editorNavMeshDirty) {
     ImGui::TextColored(ImVec4(1.0f, 0.75f, 0.1f, 1.0f), "Preview is stale. Click Re-generate.");
@@ -3319,6 +3332,9 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
   ImGui::SameLine();
   if (ImGui::Button("Add Exclude Volume")) makeDefaultVolume("exclude", "Exclude Volume");
   if (ImGui::Button("Add Area Cost Volume")) makeDefaultVolume("area_cost", "Area Cost Volume");
+  if (ImGui::Button("Add Link Include Volume")) makeDefaultVolume("link_include", "Link Include Volume");
+  ImGui::SameLine();
+  if (ImGui::Button("Add Link Exclude Volume")) makeDefaultVolume("link_exclude", "Link Exclude Volume");
 
   if (!m_editorNavMeshVolumes.empty()) {
     if (m_editorSelectedNavVolume >= static_cast<int>(m_editorNavMeshVolumes.size())) {
@@ -3348,12 +3364,12 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
       t850::scene::SceneNavMeshVolumeDesc& volume = m_editorNavMeshVolumes[static_cast<std::size_t>(m_editorSelectedNavVolume)];
       bool volumeChanged = false;
       volumeChanged |= InputTextString("Volume Name", volume.name);
-      const char* volumeTypes[] = { "include_bounds", "exclude", "area_cost" };
+      const char* volumeTypes[] = { "include_bounds", "exclude", "area_cost", "link_include", "link_exclude" };
       int typeIndex = 1;
-      for (int i = 0; i < 3; ++i) {
+      for (int i = 0; i < static_cast<int>(sizeof(volumeTypes) / sizeof(volumeTypes[0])); ++i) {
         if (volume.type == volumeTypes[i]) typeIndex = i;
       }
-      if (ImGui::Combo("Volume Type", &typeIndex, volumeTypes, 3)) {
+      if (ImGui::Combo("Volume Type", &typeIndex, volumeTypes, static_cast<int>(sizeof(volumeTypes) / sizeof(volumeTypes[0])))) {
         volume.type = volumeTypes[typeIndex];
         if (volume.type == "area_cost" && volume.area == "walkable") {
           volume.area = "mud";
@@ -8082,6 +8098,12 @@ static XVECTOR3 NavMeshVolumeColor(const t850::scene::SceneNavMeshVolumeDesc& vo
   }
   if (volume.type == "area_cost" || volume.type == "area" || volume.type == "cost") {
     return XVECTOR3(0.9f, 0.35f, 1.0f, 1.0f);
+  }
+  if (volume.type == "link_include" || volume.type == "link_add" || volume.type == "add_links") {
+    return XVECTOR3(0.0f, 0.95f, 0.55f, 1.0f);
+  }
+  if (volume.type == "link_exclude" || volume.type == "exclude_links") {
+    return XVECTOR3(1.0f, 0.55f, 0.0f, 1.0f);
   }
   return XVECTOR3(1.0f, 0.18f, 0.12f, 1.0f);
 }

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -2463,10 +2463,11 @@ bool EditorApp::UpdateEditorNavMeshClassification() {
     source.entityId = object.litInst.GetEntityId();
     source.instance = &object.litInst;
     source.worldTransform = object.litInst.Final;
-    source.visible = object.visible;
     source.debugName = object.name;
+    const bool hasExplicitNavigation = object.navigation.has_value();
     const t850::scene::SceneObjectNavigationDesc navigation =
         object.navigation.value_or(t850::scene::SceneObjectNavigationDesc{});
+    source.visible = object.visible || (hasExplicitNavigation && navigation.include);
     source.includeInNavigation = navigation.include;
     source.navigationStatic = navigation.static_object;
     source.navigationWalkable = navigation.walkable;
@@ -2714,10 +2715,11 @@ bool EditorApp::CreateEditorNavMesh() {
     source.entityId = object.litInst.GetEntityId();
     source.instance = &object.litInst;
     source.worldTransform = object.litInst.Final;
-    source.visible = object.visible;
     source.debugName = object.name;
+    const bool hasExplicitNavigation = object.navigation.has_value();
     const t850::scene::SceneObjectNavigationDesc navigation =
         object.navigation.value_or(t850::scene::SceneObjectNavigationDesc{});
+    source.visible = object.visible || (hasExplicitNavigation && navigation.include);
     source.includeInNavigation = navigation.include;
     source.navigationStatic = navigation.static_object;
     source.navigationWalkable = navigation.walkable;

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -228,6 +228,57 @@ namespace {
   t850::RenderGraph   g_renderGraph;
   t850::PrimitiveInst g_quads[8];
   bool                g_deferredReady = false;
+
+  bool RenderGraphSupportsGodRays(const t850::RenderGraph& graph) {
+    const t850::RenderGraphDesc& desc = graph.GetDescriptor();
+    for (const t850::RenderPassDesc& pass : desc.passes) {
+      for (const t850::DrawCmd& draw : pass.draws) {
+        if (draw.signature == "LIGHT_RAY_MARCHING" || draw.signature == "LIGHT_ADD") {
+          return true;
+        }
+        for (const std::string& extra : draw.extra_signatures) {
+          if (extra == "LIGHT_RAY_MARCHING" || extra == "LIGHT_ADD") {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  bool GodRaysVolumeIsAuthored(const t850::scene::SceneGodRaysVolumeDesc& volume) {
+    return volume.authored || volume.enabled || volume.visible || volume.clip_enabled;
+  }
+
+  bool IsValidGodRaysLightCamera(int index) {
+    return index >= 0 &&
+           index < static_cast<int>(g_lightCameras.size()) &&
+           g_lightCameras[static_cast<std::size_t>(index)].enabled;
+  }
+
+  int FirstEnabledGodRaysLightCamera() {
+    for (int i = 0; i < static_cast<int>(g_lightCameras.size()); ++i) {
+      if (g_lightCameras[static_cast<std::size_t>(i)].enabled) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  void ClampGodRaysVolumeLightCamera(t850::scene::SceneGodRaysVolumeDesc& volume) {
+    if (g_lightCameras.empty()) {
+      volume.light_camera = -1;
+      return;
+    }
+    volume.light_camera = std::clamp(volume.light_camera, 0, static_cast<int>(g_lightCameras.size()) - 1);
+  }
+
+  bool GodRaysVolumeCanBeActive(const t850::scene::SceneGodRaysVolumeDesc& volume,
+                                const t850::RenderGraph& graph) {
+    return GodRaysVolumeIsAuthored(volume) &&
+           RenderGraphSupportsGodRays(graph) &&
+           IsValidGodRaysLightCamera(volume.light_camera);
+  }
   XMATRIX44           g_quadVP;  // persistent identity matrix for screen-space quads
 
   // RT debug: which RT attachment to display (-1 = backbuffer)
@@ -422,6 +473,19 @@ static void AdjustActiveLightCameraAfterErase(int erasedIndex) {
     g_activeCameraIdx = -1;
   } else if (activeLightCameraIndex > erasedIndex) {
     g_activeCameraIdx = EncodeActiveLightCameraIndex(activeLightCameraIndex - 1);
+  }
+}
+
+static void AdjustGodRaysLightCameraAfterErase(int erasedIndex) {
+  if (!GodRaysVolumeIsAuthored(g_godRaysVolume)) {
+    return;
+  }
+  if (g_godRaysVolume.light_camera == erasedIndex) {
+    g_godRaysVolume.enabled = false;
+    g_godRaysVolume.visible = false;
+    g_godRaysVolume.light_camera = -1;
+  } else if (g_godRaysVolume.light_camera > erasedIndex) {
+    --g_godRaysVolume.light_camera;
   }
 }
 
@@ -3547,7 +3611,11 @@ SceneFile EditorApp::BuildEditorSceneSnapshot(const std::string& scenePath, bool
   sf.splines = g_splines;
   sf.light_cameras = g_lightCameras;
   sf.camera_animations = g_cameraAnimations;
-  sf.god_rays_volume = g_godRaysVolume;
+  if (GodRaysVolumeIsAuthored(g_godRaysVolume)) {
+    sf.god_rays_volume = g_godRaysVolume;
+  } else {
+    sf.god_rays_volume.reset();
+  }
 
   sf.physics_entities.clear();
   for (const PhysicsSceneEntity& entity : g_physicsEntities) {
@@ -3790,6 +3858,10 @@ void EditorApp::ApplyEditorUndoState(const EditorUndoState& state) {
   g_lightCameras = sf.light_cameras;
   g_cameraAnimations = sf.camera_animations;
   g_godRaysVolume = sf.god_rays_volume.value_or(t850::scene::SceneGodRaysVolumeDesc{});
+  if (sf.god_rays_volume) {
+    g_godRaysVolume.authored = true;
+    ClampGodRaysVolumeLightCamera(g_godRaysVolume);
+  }
   EnsureInferredGameEntities();
   if (sf.navigation_mesh) {
     RestoreEditorNavMeshFromScene(*sf.navigation_mesh);
@@ -3873,7 +3945,8 @@ void EditorApp::ApplyEditorUndoState(const EditorUndoState& state) {
                                 g_selectedIdx >= static_cast<int>(g_splines.size()) ||
                                 g_selectedSplinePoint < 0 ||
                                 g_selectedSplinePoint >= static_cast<int>(g_splines[static_cast<std::size_t>(g_selectedIdx)].points.size()))) ||
-      (g_selectionType == 8 && g_selectedIdx != 0)) {
+      (g_selectionType == 8 && (g_selectedIdx != 0 ||
+                                !GodRaysVolumeCanBeActive(g_godRaysVolume, g_renderGraph)))) {
     g_selectedIdx = -1;
     g_selectedSplinePoint = -1;
     g_selectionType = 0;
@@ -4576,17 +4649,94 @@ void EditorApp::DrawEditorRenderingPanel() {
   intSlider("Far Samples", m_sceneProps.DOF_Far_Samples_squared, 0, 16);
 
   ImGui::SeparatorText("God Rays");
-  bool godRaysEnabled = m_sceneProps.ToogleGodRays != 0;
+  const bool renderGraphHasGodRays = RenderGraphSupportsGodRays(g_renderGraph);
+  const int firstEnabledGodRaysLightCamera = FirstEnabledGodRaysLightCamera();
+  const bool hasEnabledGodRaysLightCamera = firstEnabledGodRaysLightCamera >= 0;
+  bool godRaysEnabled = renderGraphHasGodRays && m_sceneProps.ToogleGodRays != 0;
+  if (!renderGraphHasGodRays) {
+    ImGui::BeginDisabled();
+  }
   if (ImGui::Checkbox("God Rays", &godRaysEnabled)) {
     m_sceneProps.ToogleGodRays = godRaysEnabled ? 1 : 0;
+  }
+  if (!renderGraphHasGodRays) {
+    ImGui::EndDisabled();
+    ImGui::TextDisabled("The active render graph has no God Rays pass.");
   }
   intSlider("Ray March Steps", m_sceneProps.LightVolumeSteps, 2, 512);
   ImGui::SliderFloat("God Rays Factor", &m_sceneProps.GodRaysFactor, 0.0f, 5.0f, "%.3f");
   if (intSlider("God Rays Resolution", m_sceneProps.GoodRaysResolution, 0, 4096)) {
     recreateRenderTargets = true;
   }
-  ImGui::Checkbox("Clip to authored volume", &g_godRaysVolume.clip_enabled);
-  ImGui::TextDisabled("Select Rendering Volumes > God Rays Volume to place and resize the volume.");
+  const bool hasGodRaysVolume = GodRaysVolumeIsAuthored(g_godRaysVolume);
+  const bool canCreateGodRaysVolume = renderGraphHasGodRays &&
+                                      hasEnabledGodRaysLightCamera &&
+                                      !hasGodRaysVolume;
+  if (!canCreateGodRaysVolume) {
+    ImGui::BeginDisabled();
+  }
+  if (ImGui::Button("Create God Rays Volume")) {
+    g_godRaysVolume = t850::scene::SceneGodRaysVolumeDesc{};
+    g_godRaysVolume.authored = true;
+    g_godRaysVolume.enabled = true;
+    g_godRaysVolume.visible = true;
+    g_godRaysVolume.clip_enabled = true;
+    g_godRaysVolume.show_wire = true;
+    g_godRaysVolume.light_camera = firstEnabledGodRaysLightCamera;
+    g_selectionType = 8;
+    g_selectedIdx = 0;
+    g_selectedSplinePoint = -1;
+    ClearMixedSelection();
+  }
+  if (!canCreateGodRaysVolume) {
+    ImGui::EndDisabled();
+  }
+  if (hasGodRaysVolume) {
+    ClampGodRaysVolumeLightCamera(g_godRaysVolume);
+    if (g_lightCameras.size() > 1) {
+      const int selectedLightCamera = std::clamp(
+          g_godRaysVolume.light_camera,
+          0,
+          static_cast<int>(g_lightCameras.size()) - 1);
+      const std::string preview = g_lightCameras[static_cast<std::size_t>(selectedLightCamera)].name;
+      if (ImGui::BeginCombo("Volume Light Camera", preview.c_str())) {
+        for (int i = 0; i < static_cast<int>(g_lightCameras.size()); ++i) {
+          const auto& lightCamera = g_lightCameras[static_cast<std::size_t>(i)];
+          std::string label = lightCamera.name;
+          if (!lightCamera.enabled) {
+            label += " (disabled)";
+          }
+          const bool selected = i == g_godRaysVolume.light_camera;
+          if (ImGui::Selectable(label.c_str(), selected)) {
+            g_godRaysVolume.light_camera = i;
+          }
+          if (selected) {
+            ImGui::SetItemDefaultFocus();
+          }
+        }
+        ImGui::EndCombo();
+      }
+    } else if (!g_lightCameras.empty()) {
+      ImGui::TextDisabled("Volume Light Camera: %s", g_lightCameras.front().name.c_str());
+      g_godRaysVolume.light_camera = 0;
+    }
+    const bool volumeCanBeActive = GodRaysVolumeCanBeActive(g_godRaysVolume, g_renderGraph);
+    if (!volumeCanBeActive) {
+      ImGui::BeginDisabled();
+    }
+    ImGui::Checkbox("Volume Enabled", &g_godRaysVolume.enabled);
+    ImGui::Checkbox("Clip to authored volume", &g_godRaysVolume.clip_enabled);
+    ImGui::Checkbox("Show Volume Cube", &g_godRaysVolume.visible);
+    if (!volumeCanBeActive) {
+      ImGui::EndDisabled();
+    }
+    ImGui::TextDisabled("Select Rendering Volumes > God Rays Volume to place and resize the volume.");
+    if (!hasEnabledGodRaysLightCamera) {
+      ImGui::TextDisabled("A God Rays volume requires an enabled light camera.");
+    }
+  } else if (renderGraphHasGodRays && !hasEnabledGodRaysLightCamera) {
+    ImGui::TextDisabled("Create a light camera before creating a God Rays volume.");
+  }
 
   ImGui::SeparatorText("Advanced Scene Rendering");
   int activeLights = m_sceneProps.ActiveLights;
@@ -6024,6 +6174,10 @@ void EditorApp::LoadPendingScene() {
       g_lightCameras = sf.light_cameras;
       g_cameraAnimations = sf.camera_animations;
       g_godRaysVolume = sf.god_rays_volume.value_or(t850::scene::SceneGodRaysVolumeDesc{});
+      if (sf.god_rays_volume) {
+        g_godRaysVolume.authored = true;
+        ClampGodRaysVolumeLightCamera(g_godRaysVolume);
+      }
       EnsureInferredGameEntities();
       if (sf.navigation_mesh) {
         t850::LoadingProgress::ScopedStep navMeshStep("Loading scene", "NavMesh", 4.0f);
@@ -6305,6 +6459,7 @@ void EditorApp::OnInput() {
     }
     else if (g_selectionType == 6 && g_selectedIdx < static_cast<int>(g_lightCameras.size())) {
       AdjustActiveLightCameraAfterErase(g_selectedIdx);
+      AdjustGodRaysLightCameraAfterErase(g_selectedIdx);
       if (g_selectedIdx >= 0 && g_selectedIdx < static_cast<int>(g_lightCameraGizmoCameras.size())) {
         if (t850::g_pBaseDriver) {
           t850::g_pBaseDriver->WaitForGPU();
@@ -6331,8 +6486,10 @@ void EditorApp::OnInput() {
       T8_LOG_INFO("[T8ditor] NavMesh deleted");
     }
     else if (g_selectionType == 8 && g_selectedIdx == 0) {
+      g_godRaysVolume.authored = false;
       g_godRaysVolume.enabled = false;
       g_godRaysVolume.visible = false;
+      g_godRaysVolume.clip_enabled = false;
       g_selectedIdx = -1;
       g_selectionType = 0;
       T8_LOG_INFO("[T8ditor] God Rays volume disabled");
@@ -6960,8 +7117,12 @@ static void SyncLightCameraFromRuntimeCamera(const ::Camera& runtimeCamera,
 }
 
 static void ApplyGodRaysVolumeToSceneProps(const t850::scene::SceneGodRaysVolumeDesc& volume,
-                                           SceneProps& sceneProps) {
-  sceneProps.GodRaysVolumeEnabled = (volume.enabled && volume.clip_enabled) ? 1 : 0;
+                                           SceneProps& sceneProps,
+                                           bool canBeActive) {
+  sceneProps.GodRaysVolumeEnabled = (canBeActive && volume.enabled && volume.clip_enabled) ? 1 : 0;
+  if (canBeActive) {
+    sceneProps.ActiveLightCamera = volume.light_camera;
+  }
   sceneProps.GodRaysVolumeCenter = XVECTOR3(volume.position.x, volume.position.y, volume.position.z, 1.0f);
   sceneProps.GodRaysVolumeHalfExtents = XVECTOR3((std::max)(0.001f, std::abs(volume.half_extents.x)),
                                                  (std::max)(0.001f, std::abs(volume.half_extents.y)),
@@ -7764,7 +7925,8 @@ single_pick:
   }
 
   // Test God Rays volume.
-  if (g_godRaysVolume.enabled && g_godRaysVolume.visible && !g_godRaysVolume.frozen) {
+  if (GodRaysVolumeCanBeActive(g_godRaysVolume, g_renderGraph) &&
+      g_godRaysVolume.enabled && g_godRaysVolume.visible && !g_godRaysVolume.frozen) {
     const auto& p = g_godRaysVolume.position;
     const auto& h = g_godRaysVolume.half_extents;
     t850::AABB box(
@@ -7886,20 +8048,29 @@ void EditorApp::SyncEditorSceneLights(const ::Camera& cam) {
       requestedActiveLights,
       0,
       static_cast<int>(m_sceneProps.Lights.size()));
-  bool appliedAuthoredLightCamera = false;
-  for (const auto& lightCamera : g_lightCameras) {
+  m_sceneProps.pLightCameras.clear();
+  m_editorRuntimeLightCameras.clear();
+  m_editorRuntimeLightCameras.resize(g_lightCameras.size());
+
+  int firstEnabledLightCamera = -1;
+  for (std::size_t lightCameraIndex = 0; lightCameraIndex < g_lightCameras.size(); ++lightCameraIndex) {
+    const auto& lightCamera = g_lightCameras[lightCameraIndex];
+    Camera& runtimeLightCamera = m_editorRuntimeLightCameras[lightCameraIndex];
+    ApplySceneLightCameraToRuntimeCamera(lightCamera, runtimeLightCamera, 1.0f);
+    m_sceneProps.AddLightCamera(&runtimeLightCamera);
     if (!lightCamera.enabled) continue;
-    ApplySceneLightCameraToRuntimeCamera(lightCamera, m_editorLightCamera, 1.0f);
+    if (firstEnabledLightCamera < 0) {
+      firstEnabledLightCamera = static_cast<int>(lightCameraIndex);
+      m_editorLightCamera = runtimeLightCamera;
+    }
     if (lightCamera.attached_light >= 0 &&
         lightCamera.attached_light < static_cast<int>(m_sceneProps.Lights.size())) {
       Light& attachedLight = m_sceneProps.Lights[static_cast<std::size_t>(lightCamera.attached_light)];
-      attachedLight.Position = m_editorLightCamera.Eye;
-      attachedLight.Direction = m_editorLightCamera.Look;
+      attachedLight.Position = runtimeLightCamera.Eye;
+      attachedLight.Direction = runtimeLightCamera.Look;
     }
-    appliedAuthoredLightCamera = true;
-    break;
   }
-  if (!appliedAuthoredLightCamera) {
+  if (firstEnabledLightCamera < 0) {
     for (const Light& light : m_sceneProps.Lights) {
       if (light.Type == LIGHT_DIRECTIONAL && light.Enabled) {
         XVECTOR3 direction = light.Direction;
@@ -7916,7 +8087,7 @@ void EditorApp::SyncEditorSceneLights(const ::Camera& cam) {
   if (m_sceneProps.pLightCameras.empty()) {
     m_sceneProps.AddLightCamera(&m_editorLightCamera);
   }
-  m_sceneProps.ActiveLightCamera = 0;
+  m_sceneProps.ActiveLightCamera = firstEnabledLightCamera >= 0 ? firstEnabledLightCamera : 0;
   m_sceneProps.pCullingCamera = m_sceneProps.GetPrimaryCamera();
 }
 
@@ -7954,7 +8125,9 @@ void EditorApp::RenderEditorSceneFrame(t850::BaseDriver* drv, bool captureFrozen
   // Sync scene lights from editor lights.
   // Use real scene lights by default; keep the camera headlamp only as an explicit/fallback light.
   SyncEditorSceneLights(cam);
-  ApplyGodRaysVolumeToSceneProps(g_godRaysVolume, m_sceneProps);
+  ClampGodRaysVolumeLightCamera(g_godRaysVolume);
+  const bool godRaysVolumeCanBeActive = GodRaysVolumeCanBeActive(g_godRaysVolume, g_renderGraph);
+  ApplyGodRaysVolumeToSceneProps(g_godRaysVolume, m_sceneProps, godRaysVolumeCanBeActive);
 
   // Update all mesh transforms
   SyncSceneObjectTransforms();
@@ -8205,12 +8378,14 @@ void EditorApp::RenderEditorSceneFrame(t850::BaseDriver* drv, bool captureFrozen
       SyncLightCameraGizmoCamera(lightCameraDesc, lightCamera);
       DrawCameraGizmo(m_lines, cam.VP, lightCamera, g_selectionType == 6 && i == g_selectedIdx);
     }
-    DrawGodRaysVolume(
-        m_lines,
-        cam.VP,
-        g_godRaysVolume,
-        g_selectionType == 8,
-        g_godRaysVolumeGizmo);
+    if (godRaysVolumeCanBeActive) {
+      DrawGodRaysVolume(
+          m_lines,
+          cam.VP,
+          g_godRaysVolume,
+          g_selectionType == 8,
+          g_godRaysVolumeGizmo);
+    }
     if (g_splineGizmos.size() < g_splines.size()) {
       g_splineGizmos.resize(g_splines.size());
     }
@@ -8427,6 +8602,7 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
         g_selectedIdx = -1;
       } else if (g_selectionType == 6 && g_selectedIdx < static_cast<int>(g_lightCameras.size())) {
         AdjustActiveLightCameraAfterErase(g_selectedIdx);
+        AdjustGodRaysLightCameraAfterErase(g_selectedIdx);
         if (g_selectedIdx >= 0 && g_selectedIdx < static_cast<int>(g_lightCameraGizmoCameras.size())) {
           if (t850::g_pBaseDriver) {
             t850::g_pBaseDriver->WaitForGPU();
@@ -8441,8 +8617,10 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
       } else if (g_selectionType == 4 && g_selectedIdx == 0) {
         DestroyEditorNavMesh();
       } else if (g_selectionType == 8 && g_selectedIdx == 0) {
+        g_godRaysVolume.authored = false;
         g_godRaysVolume.enabled = false;
         g_godRaysVolume.visible = false;
+        g_godRaysVolume.clip_enabled = false;
         g_selectedIdx = -1;
         g_selectionType = 0;
       }
@@ -9599,15 +9777,19 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
           ImGui::TreePop();
         }
         // Rendering Volumes
-        if (ImGui::TreeNodeEx("Rendering Volumes", ImGuiTreeNodeFlags_DefaultOpen)) {
+        if (RenderGraphSupportsGodRays(g_renderGraph) && GodRaysVolumeIsAuthored(g_godRaysVolume) &&
+            ImGui::TreeNodeEx("Rendering Volumes", ImGuiTreeNodeFlags_DefaultOpen)) {
+          const bool volumeCanBeActive = GodRaysVolumeCanBeActive(g_godRaysVolume, g_renderGraph);
+          if (!volumeCanBeActive) ImGui::BeginDisabled();
           ImGui::Checkbox("##godRaysVolumeEnabled", &g_godRaysVolume.enabled); ImGui::SameLine();
           ImGui::Checkbox("##godRaysVolumeVisible", &g_godRaysVolume.visible); ImGui::SameLine();
+          if (!volumeCanBeActive) ImGui::EndDisabled();
           ImGui::Checkbox("##godRaysVolumeFrozen", &g_godRaysVolume.frozen); ImGui::SameLine();
           ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_SpanAvailWidth;
           if (g_selectionType == 8) flags |= ImGuiTreeNodeFlags_Selected;
           if (g_godRaysVolume.frozen) ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f,0.5f,0.5f,1));
           const bool nodeOpen = ImGui::TreeNodeEx("[GR] God Rays Volume", flags);
-          if (ImGui::IsItemClicked() && !g_godRaysVolume.frozen) {
+          if (ImGui::IsItemClicked() && !g_godRaysVolume.frozen && volumeCanBeActive) {
             g_selectionType = 8;
             g_selectedIdx = 0;
             g_selectedSplinePoint = -1;
@@ -10196,6 +10378,7 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
         ImGui::TextDisabled("SceneTemplate uses the first enabled light camera as the shadow camera source.");
         if (ImGui::Button("Delete Light Camera")) {
           AdjustActiveLightCameraAfterErase(g_selectedIdx);
+          AdjustGodRaysLightCameraAfterErase(g_selectedIdx);
           if (g_selectedIdx >= 0 && g_selectedIdx < static_cast<int>(g_lightCameraGizmoCameras.size())) {
             if (t850::g_pBaseDriver) {
               t850::g_pBaseDriver->WaitForGPU();
@@ -10209,14 +10392,46 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
         }
       } else if (g_selectionType == 8 && g_selectedIdx == 0) {
         ImGui::SeparatorText("God Rays Volume");
+        const bool renderGraphHasGodRays = RenderGraphSupportsGodRays(g_renderGraph);
+        ClampGodRaysVolumeLightCamera(g_godRaysVolume);
+        const bool volumeCanBeActive = GodRaysVolumeCanBeActive(g_godRaysVolume, g_renderGraph);
         char nameBuffer[256] = {};
         std::snprintf(nameBuffer, sizeof(nameBuffer), "%s", g_godRaysVolume.name.c_str());
         if (ImGui::InputText("Name", nameBuffer, sizeof(nameBuffer))) {
           g_godRaysVolume.name = nameBuffer;
         }
+        if (g_lightCameras.size() > 1) {
+          const int selectedLightCamera = std::clamp(
+              g_godRaysVolume.light_camera,
+              0,
+              static_cast<int>(g_lightCameras.size()) - 1);
+          const std::string preview = g_lightCameras[static_cast<std::size_t>(selectedLightCamera)].name;
+          if (ImGui::BeginCombo("Light Camera", preview.c_str())) {
+            for (int i = 0; i < static_cast<int>(g_lightCameras.size()); ++i) {
+              const auto& lightCamera = g_lightCameras[static_cast<std::size_t>(i)];
+              std::string label = lightCamera.name;
+              if (!lightCamera.enabled) label += " (disabled)";
+              const bool selected = i == g_godRaysVolume.light_camera;
+              if (ImGui::Selectable(label.c_str(), selected)) {
+                g_godRaysVolume.light_camera = i;
+              }
+              if (selected) ImGui::SetItemDefaultFocus();
+            }
+            ImGui::EndCombo();
+          }
+        } else if (!g_lightCameras.empty()) {
+          ImGui::TextDisabled("Light Camera: %s", g_lightCameras.front().name.c_str());
+          g_godRaysVolume.light_camera = 0;
+        }
+        if (!volumeCanBeActive) {
+          ImGui::BeginDisabled();
+        }
         ImGui::Checkbox("Enabled", &g_godRaysVolume.enabled);
         ImGui::Checkbox("Clip God Rays to Volume", &g_godRaysVolume.clip_enabled);
         ImGui::Checkbox("Visible", &g_godRaysVolume.visible);
+        if (!volumeCanBeActive) {
+          ImGui::EndDisabled();
+        }
         ImGui::Checkbox("Frozen", &g_godRaysVolume.frozen);
         ImGui::Checkbox("Wireframe", &g_godRaysVolume.show_wire);
         float position[3] = {g_godRaysVolume.position.x, g_godRaysVolume.position.y, g_godRaysVolume.position.z};
@@ -10233,6 +10448,11 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
             t850::g_pBaseDriver->WaitForGPU();
           }
           ReleaseGizmoCache(g_godRaysVolumeGizmo);
+        }
+        if (!renderGraphHasGodRays) {
+          ImGui::TextDisabled("The active render graph has no God Rays pass.");
+        } else if (!IsValidGodRaysLightCamera(g_godRaysVolume.light_camera)) {
+          ImGui::TextDisabled("Enable and assign a light camera to activate this volume.");
         }
         ImGui::TextDisabled("DayScene's original shader has no spatial clip; clip is off by default to preserve parity.");
       } else if (g_selectionType == 7 &&

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -2366,6 +2366,7 @@ void EditorApp::ResetEditorNavMeshState(bool keepSettings) {
   m_editorNavMeshDebugShapeMode = 0;
   m_editorNavMeshLastBuildMs = 0.0f;
   m_editorNavMeshDirty = false;
+  m_editorNavMeshVolumes.clear();
   m_editorNavMeshLinks.clear();
   m_editorNavMeshNodes.clear();
   m_editorSelectedNavLink = -1;
@@ -2427,6 +2428,16 @@ bool EditorApp::CreateEditorNavMesh() {
       return t850::ValidateNavOffMeshLinkWithPhysics(m_physics, m_editorNavMeshBuildSettings, link);
     };
     geometry.offMeshHybridLinkValidator = geometry.offMeshLinkValidator;
+  }
+  for (const t850::scene::SceneNavMeshVolumeDesc& volumeDesc : m_editorNavMeshVolumes) {
+    t850::navigation::NavMeshVolumeModifier modifier = NavVolumeModifierFromScene(volumeDesc);
+    if (!modifier.enabled) {
+      continue;
+    }
+    geometry.volumeModifiers.push_back(modifier);
+    if (modifier.mode == t850::navigation::NavMeshModifierMode::Area) {
+      geometry.areaCosts.push_back({modifier.area, modifier.cost});
+    }
   }
   for (const t850::scene::SceneNavMeshLinkDesc& linkDesc : m_editorNavMeshLinks) {
     if (IsUsableAuthoredNavLink(linkDesc)) {
@@ -2493,6 +2504,7 @@ void EditorApp::RestoreEditorNavMeshFromScene(const t850::scene::SceneNavigation
   m_editorNavMeshShowWire = desc.show_wire;
   m_editorNavMeshDebugOffset = desc.debug_offset;
   m_editorNavMeshDebugShapeMode = std::clamp(desc.debug_shape_mode, 0, 1);
+  m_editorNavMeshVolumes = desc.volumes;
   m_editorNavMeshLinks = desc.authored_links;
   m_editorNavMeshDirty = false;
   m_editorSelectedNavLink = m_editorNavMeshLinks.empty() ? -1 : std::clamp(m_editorSelectedNavLink, 0, static_cast<int>(m_editorNavMeshLinks.size()) - 1);
@@ -2518,6 +2530,7 @@ t850::scene::SceneNavigationMeshDesc EditorApp::BuildEditorNavMeshDesc() const {
   desc.debug_offset = m_editorNavMeshDebugOffset;
   desc.debug_shape_mode = m_editorNavMeshDebugShapeMode;
   desc.build_settings = NavMeshBuildSettingsToScene(m_editorNavMeshBuildSettings);
+  desc.volumes = m_editorNavMeshVolumes;
   desc.authored_links = m_editorNavMeshLinks;
   return desc;
 }

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -2380,6 +2380,8 @@ void EditorApp::ResetEditorNavMeshState(bool keepSettings) {
   ReleaseGizmoCaches(g_navMeshVolumeGizmos);
   m_editorNavMeshVolumes.clear();
   m_editorNavMeshLinks.clear();
+  m_editorNavMeshRuntimeMode = "build_cached";
+  m_editorNavMeshBakedAsset.clear();
   m_editorNavMeshNodes.clear();
   m_editorSelectedNavVolume = -1;
   m_editorSelectedNavLink = -1;
@@ -2811,6 +2813,8 @@ void EditorApp::DestroyEditorNavMesh() {
   ReleaseGizmoCaches(g_navMeshVolumeGizmos);
   m_editorNavMeshVolumes.clear();
   m_editorNavMeshLinks.clear();
+  m_editorNavMeshRuntimeMode = "build_cached";
+  m_editorNavMeshBakedAsset.clear();
   m_editorSelectedNavVolume = -1;
   m_editorSelectedNavLink = -1;
   m_editorNavLinkPickMode = 0;
@@ -2830,6 +2834,8 @@ void EditorApp::RestoreEditorNavMeshFromScene(const t850::scene::SceneNavigation
   m_editorNavMeshShowWire = desc.show_wire;
   m_editorNavMeshDebugOffset = desc.debug_offset;
   m_editorNavMeshDebugShapeMode = std::clamp(desc.debug_shape_mode, 0, 1);
+  m_editorNavMeshRuntimeMode = desc.runtime_mode.empty() ? "build_cached" : desc.runtime_mode;
+  m_editorNavMeshBakedAsset = desc.baked_asset;
   m_editorNavMeshVolumes = desc.volumes;
   m_editorNavMeshLinks = desc.authored_links;
   if (m_editorSelectedNavVolume < 0 ||
@@ -2859,6 +2865,8 @@ t850::scene::SceneNavigationMeshDesc EditorApp::BuildEditorNavMeshDesc() const {
   desc.show_wire = m_editorNavMeshShowWire;
   desc.debug_offset = m_editorNavMeshDebugOffset;
   desc.debug_shape_mode = m_editorNavMeshDebugShapeMode;
+  desc.runtime_mode = m_editorNavMeshRuntimeMode.empty() ? "build_cached" : m_editorNavMeshRuntimeMode;
+  desc.baked_asset = m_editorNavMeshBakedAsset;
   desc.build_settings = NavMeshBuildSettingsToScene(m_editorNavMeshBuildSettings);
   desc.volumes = m_editorNavMeshVolumes;
   desc.authored_links = m_editorNavMeshLinks;
@@ -3197,6 +3205,21 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
   ImGui::SameLine();
   ImGui::Checkbox("Wireframe", &m_editorNavMeshShowWire);
   ImGui::Checkbox("NavMesh Authoring Mode", &m_editorNavMeshAuthoringMode);
+  const char* runtimeModes[] = { "build_cached", "build", "baked_asset" };
+  int runtimeModeIndex = 0;
+  for (int i = 0; i < static_cast<int>(sizeof(runtimeModes) / sizeof(runtimeModes[0])); ++i) {
+    if (m_editorNavMeshRuntimeMode == runtimeModes[i]) runtimeModeIndex = i;
+  }
+  if (ImGui::Combo("Runtime Mode", &runtimeModeIndex, runtimeModes, static_cast<int>(sizeof(runtimeModes) / sizeof(runtimeModes[0])))) {
+    m_editorNavMeshRuntimeMode = runtimeModes[runtimeModeIndex];
+    MarkEditorNavMeshDirty("NavMesh runtime mode changed. Save the scene to persist it.");
+  }
+  if (m_editorNavMeshRuntimeMode == "baked_asset") {
+    if (InputTextString("Baked Asset", m_editorNavMeshBakedAsset)) {
+      MarkEditorNavMeshDirty("NavMesh baked asset path changed. Save the scene to persist it.");
+    }
+    ImGui::TextDisabled("Baked asset loading/export is metadata-only for now; runtime falls back to build_cached.");
+  }
 
   if (ImGui::SliderFloat("Debug Vertical Offset", &m_editorNavMeshDebugOffset, 0.0f, 0.25f, "%.3f")) {
     ReleaseNavMeshClassificationGizmos();

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -195,6 +195,7 @@ namespace {
   auto& g_lightCameraGizmoCameras = g_world.lightCameraGizmoCameras;
   auto& g_godRaysVolume = g_world.godRaysVolume;
   auto& g_godRaysVolumeGizmo = g_world.godRaysVolumeGizmo;
+  std::vector<GizmoCache> g_navMeshVolumeGizmos;
   auto& g_splines = g_world.splines;
   auto& g_splineGizmos = g_world.splineGizmos;
   auto& g_selectedSplinePoint = g_world.selectedSplinePoint;
@@ -2368,6 +2369,7 @@ void EditorApp::ResetEditorNavMeshState(bool keepSettings) {
   m_editorNavMeshDebugShapeMode = 0;
   m_editorNavMeshLastBuildMs = 0.0f;
   m_editorNavMeshDirty = false;
+  ReleaseGizmoCaches(g_navMeshVolumeGizmos);
   m_editorNavMeshVolumes.clear();
   m_editorNavMeshLinks.clear();
   m_editorNavMeshNodes.clear();
@@ -2390,6 +2392,10 @@ void EditorApp::MarkEditorNavMeshDirty(const std::string& status) {
 bool EditorApp::DeleteSelectedNavAuthoringChild() {
   if (m_editorSelectedNavVolume >= 0 &&
       m_editorSelectedNavVolume < static_cast<int>(m_editorNavMeshVolumes.size())) {
+    if (m_editorSelectedNavVolume < static_cast<int>(g_navMeshVolumeGizmos.size())) {
+      ReleaseGizmoCache(g_navMeshVolumeGizmos[static_cast<std::size_t>(m_editorSelectedNavVolume)]);
+      g_navMeshVolumeGizmos.erase(g_navMeshVolumeGizmos.begin() + m_editorSelectedNavVolume);
+    }
     m_editorNavMeshVolumes.erase(m_editorNavMeshVolumes.begin() + m_editorSelectedNavVolume);
     m_editorSelectedNavVolume = m_editorNavMeshVolumes.empty()
         ? -1
@@ -2524,6 +2530,7 @@ void EditorApp::DestroyEditorNavMesh() {
   m_editorNavMeshAuthored = false;
   m_editorNavMeshLastBuildMs = 0.0f;
   m_editorNavMeshDirty = false;
+  ReleaseGizmoCaches(g_navMeshVolumeGizmos);
   m_editorNavMeshVolumes.clear();
   m_editorNavMeshLinks.clear();
   m_editorSelectedNavVolume = -1;
@@ -7714,6 +7721,76 @@ static void DrawGodRaysVolume(EditorLineRenderer& lines,
   }
 }
 
+static XMATRIX44 BuildNavMeshVolumeWorld(const t850::scene::SceneNavMeshVolumeDesc& volume) {
+  XMATRIX44 S, Rx, Ry, Rz, T;
+  XMatScaling(S,
+              (std::max)(0.001f, std::abs(volume.half_extents.x)),
+              (std::max)(0.001f, std::abs(volume.half_extents.y)),
+              (std::max)(0.001f, std::abs(volume.half_extents.z)));
+  XMatRotationX(Rx, volume.rotation.x);
+  XMatRotationY(Ry, volume.rotation.y);
+  XMatRotationZ(Rz, volume.rotation.z);
+  XMatTranslation(T, volume.position.x, volume.position.y, volume.position.z);
+  return S * Rx * Ry * Rz * T;
+}
+
+static t850::AABB NavMeshVolumeWorldAABB(const t850::scene::SceneNavMeshVolumeDesc& volume) {
+  const t850::AABB local(XVECTOR3(-1.0f, -1.0f, -1.0f, 1.0f),
+                         XVECTOR3( 1.0f,  1.0f,  1.0f, 1.0f));
+  return local.Transformed(BuildNavMeshVolumeWorld(volume));
+}
+
+static XVECTOR3 NavMeshVolumeColor(const t850::scene::SceneNavMeshVolumeDesc& volume, bool selected) {
+  if (selected) {
+    return XVECTOR3(1.0f, 0.85f, 0.12f, 1.0f);
+  }
+  if (volume.type == "include_bounds" || volume.type == "include" || volume.type == "bounds") {
+    return XVECTOR3(0.2f, 0.55f, 1.0f, 1.0f);
+  }
+  if (volume.type == "area_cost" || volume.type == "area" || volume.type == "cost") {
+    return XVECTOR3(0.9f, 0.35f, 1.0f, 1.0f);
+  }
+  return XVECTOR3(1.0f, 0.18f, 0.12f, 1.0f);
+}
+
+static void DrawNavMeshVolume(EditorLineRenderer& lines,
+                              const XMATRIX44& vp,
+                              const t850::scene::SceneNavMeshVolumeDesc& volume,
+                              bool selected,
+                              GizmoCache& cache) {
+  if (!lines.IsReady() || !volume.enabled || !volume.visible || !volume.show_wire) {
+    return;
+  }
+  const float verts[] = {
+      -1,-1,-1,1,  1,-1,-1,1,  1, 1,-1,1, -1, 1,-1,1,
+      -1,-1, 1,1,  1,-1, 1,1,  1, 1, 1,1, -1, 1, 1,1};
+  const unsigned short indices[] = {
+      0,1, 1,2, 2,3, 3,0,
+      4,5, 5,6, 6,7, 7,4,
+      0,4, 1,5, 2,6, 3,7};
+  const unsigned indexCount = static_cast<unsigned>(sizeof(indices) / sizeof(indices[0]));
+  if (!cache.vb || !cache.ib || cache.count != indexCount) {
+    if (cache.vb || cache.ib) {
+      if (t850::g_pBaseDriver) {
+        t850::g_pBaseDriver->WaitForGPU();
+      }
+      ReleaseGizmoCache(cache);
+    }
+    cache.vb = EditorLineRenderer::CreatePositionVB(verts, 8);
+    cache.ib = EditorLineRenderer::CreateIndexBuffer16(indices, indexCount);
+    cache.count = indexCount;
+  }
+  if (cache.vb && cache.ib) {
+    lines.DrawLines(BuildNavMeshVolumeWorld(volume),
+                    vp,
+                    NavMeshVolumeColor(volume, selected),
+                    cache.vb,
+                    cache.ib,
+                    cache.count,
+                    sizeof(float) * 4);
+  }
+}
+
 static void DrawEditorSpline(EditorLineRenderer& lines,
                              const XMATRIX44& vp,
                              const t850::scene::SceneSplineDesc& desc,
@@ -8020,6 +8097,7 @@ single_pick:
   float bestT = FLT_MAX;
   int   bestIdx  = -1;
   int   bestType = 0;
+  int   bestNavVolume = -1;
 
   // Test meshes
   for (int i = 0; i < (int)g_objects.size(); ++i) {
@@ -8135,6 +8213,21 @@ single_pick:
     }
   }
 
+  // Test NavMesh authoring volumes.
+  for (int volumeIndex = 0; volumeIndex < static_cast<int>(m_editorNavMeshVolumes.size()); ++volumeIndex) {
+    const auto& volume = m_editorNavMeshVolumes[static_cast<std::size_t>(volumeIndex)];
+    if (!volume.enabled || !volume.visible || volume.frozen) {
+      continue;
+    }
+    float t = 0.0f;
+    if (t850::RayIntersectsAABB(ray, NavMeshVolumeWorldAABB(volume), t) && t < bestT) {
+      bestT = t;
+      bestIdx = 0;
+      bestType = 4;
+      bestNavVolume = volumeIndex;
+    }
+  }
+
   // Test spline control points with a screen-space threshold so the small markers are easy to select.
   const float pointPickRadiusPx = 14.0f;
   float bestPointScreenDist2 = pointPickRadiusPx * pointPickRadiusPx;
@@ -8171,6 +8264,13 @@ single_pick:
     g_selectedIdx   = bestIdx;
     g_selectionType = bestType;
     g_selectedSplinePoint = (bestType == 7) ? bestSplinePoint : -1;
+    if (bestType == 4) {
+      m_editorSelectedNavVolume = bestNavVolume;
+      m_editorSelectedNavLink = -1;
+    } else if (!shiftDown) {
+      m_editorSelectedNavVolume = -1;
+      m_editorSelectedNavLink = -1;
+    }
 
     if (bestType == 0 || bestType == 3) {
       if (shiftDown) {
@@ -8199,6 +8299,8 @@ single_pick:
   } else {
     g_selectedIdx = -1;
     g_selectedSplinePoint = -1;
+    m_editorSelectedNavVolume = -1;
+    m_editorSelectedNavLink = -1;
     // Auto-switch to Select mode when deselecting (hides orphaned gizmo)
     m_gizmo.SetMode(GizmoMode::Select);
     if (!shiftDown)
@@ -8580,6 +8682,22 @@ void EditorApp::RenderEditorSceneFrame(t850::BaseDriver* drv, bool captureFrozen
           g_godRaysVolume,
           g_selectionType == 8,
           g_godRaysVolumeGizmo);
+    }
+    if (g_navMeshVolumeGizmos.size() > m_editorNavMeshVolumes.size()) {
+      for (std::size_t i = m_editorNavMeshVolumes.size(); i < g_navMeshVolumeGizmos.size(); ++i) {
+        ReleaseGizmoCache(g_navMeshVolumeGizmos[i]);
+      }
+      g_navMeshVolumeGizmos.resize(m_editorNavMeshVolumes.size());
+    } else if (g_navMeshVolumeGizmos.size() < m_editorNavMeshVolumes.size()) {
+      g_navMeshVolumeGizmos.resize(m_editorNavMeshVolumes.size());
+    }
+    for (int i = 0; i < static_cast<int>(m_editorNavMeshVolumes.size()); ++i) {
+      DrawNavMeshVolume(
+          m_lines,
+          cam.VP,
+          m_editorNavMeshVolumes[static_cast<std::size_t>(i)],
+          g_selectionType == 4 && g_selectedIdx == 0 && i == m_editorSelectedNavVolume,
+          g_navMeshVolumeGizmos[static_cast<std::size_t>(i)]);
     }
     if (g_splineGizmos.size() < g_splines.size()) {
       g_splineGizmos.resize(g_splines.size());
@@ -9263,6 +9381,32 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
         float t[3], r[3], s[3];
         ImGuizmo::DecomposeMatrixToComponents(&worldMat.m[0][0], t, r, s);
         point.position = {t[0], t[1], t[2]};
+      }
+    }
+  }
+  else if (g_selectionType == 4 &&
+           g_selectedIdx == 0 &&
+           m_editorSelectedNavVolume >= 0 &&
+           m_editorSelectedNavVolume < static_cast<int>(m_editorNavMeshVolumes.size())) {
+    t850::scene::SceneNavMeshVolumeDesc& volume =
+        m_editorNavMeshVolumes[static_cast<std::size_t>(m_editorSelectedNavVolume)];
+    if (!volume.frozen) {
+      XMATRIX44 worldMat = BuildNavMeshVolumeWorld(volume);
+      const bool manipulated = ImGuizmoManipulate(
+          &cam2.View.m[0][0], &cam2.Projection.m[0][0],
+          mode, &worldMat.m[0][0]);
+      if (manipulated) {
+        float t[3], r[3], s[3];
+        ImGuizmo::DecomposeMatrixToComponents(&worldMat.m[0][0], t, r, s);
+        volume.position = {t[0], t[1], t[2]};
+        volume.rotation = {r[0] * kDegToRad, r[1] * kDegToRad, r[2] * kDegToRad};
+        if (mode == 2) {
+          volume.half_extents = {
+              (std::max)(0.001f, std::abs(s[0])),
+              (std::max)(0.001f, std::abs(s[1])),
+              (std::max)(0.001f, std::abs(s[2]))};
+        }
+        MarkEditorNavMeshDirty("NavMesh volume transformed. Click Re-generate.");
       }
     }
   }

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -3221,10 +3221,27 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
     MarkEditorNavMeshDirty("NavMesh runtime mode changed. Save the scene to persist it.");
   }
   if (m_editorNavMeshRuntimeMode == "baked_asset") {
+    if (m_editorNavMeshBakedAsset.empty()) {
+      m_editorNavMeshBakedAsset = "Navigation/EditorNavMesh.t8nav";
+    }
     if (InputTextString("Baked Asset", m_editorNavMeshBakedAsset)) {
       MarkEditorNavMeshDirty("NavMesh baked asset path changed. Save the scene to persist it.");
     }
-    ImGui::TextDisabled("Baked asset loading/export is metadata-only for now; runtime falls back to build_cached.");
+    if (!m_editorNavMesh.IsReady()) {
+      ImGui::BeginDisabled();
+    }
+    if (ImGui::Button("Bake NavMesh Asset")) {
+      std::string bakeError;
+      if (m_editorNavMesh.SaveBaked(m_editorNavMeshBakedAsset, &bakeError)) {
+        m_editorNavMeshStatus = "Baked NavMesh asset: " + m_editorNavMeshBakedAsset;
+      } else {
+        m_editorNavMeshStatus = "Bake failed: " + bakeError;
+      }
+    }
+    if (!m_editorNavMesh.IsReady()) {
+      ImGui::EndDisabled();
+      ImGui::TextDisabled("Build or Re-generate the NavMesh before baking.");
+    }
   }
 
   if (ImGui::SliderFloat("Debug Vertical Offset", &m_editorNavMeshDebugOffset, 0.0f, 0.25f, "%.3f")) {

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -2364,6 +2364,43 @@ static bool ShouldDrawPhysicsDebug() {
   return false;
 }
 
+static XVECTOR3 RotateInverseEulerXYZ(const XVECTOR3& point, const t850::scene::Vec3f& rotation) {
+  XVECTOR3 p = point;
+  auto rotateZ = [](XVECTOR3 v, float angle) {
+    const float c = std::cos(angle);
+    const float s = std::sin(angle);
+    return XVECTOR3(v.x * c - v.y * s, v.x * s + v.y * c, v.z, 0.0f);
+  };
+  auto rotateY = [](XVECTOR3 v, float angle) {
+    const float c = std::cos(angle);
+    const float s = std::sin(angle);
+    return XVECTOR3(v.x * c + v.z * s, v.y, -v.x * s + v.z * c, 0.0f);
+  };
+  auto rotateX = [](XVECTOR3 v, float angle) {
+    const float c = std::cos(angle);
+    const float s = std::sin(angle);
+    return XVECTOR3(v.x, v.y * c - v.z * s, v.y * s + v.z * c, 0.0f);
+  };
+  p = rotateZ(p, -rotation.z);
+  p = rotateY(p, -rotation.y);
+  p = rotateX(p, -rotation.x);
+  return p;
+}
+
+static bool NavVolumeContainsPoint(const t850::scene::SceneNavMeshVolumeDesc& volume, const XVECTOR3& point) {
+  if (!volume.enabled || volume.shape != "box") {
+    return false;
+  }
+  XVECTOR3 local(point.x - volume.position.x,
+                 point.y - volume.position.y,
+                 point.z - volume.position.z,
+                 0.0f);
+  local = RotateInverseEulerXYZ(local, volume.rotation);
+  return std::abs(local.x) <= (std::max)(0.001f, std::abs(volume.half_extents.x)) &&
+         std::abs(local.y) <= (std::max)(0.001f, std::abs(volume.half_extents.y)) &&
+         std::abs(local.z) <= (std::max)(0.001f, std::abs(volume.half_extents.z));
+}
+
 void EditorApp::ResetEditorNavMeshState(bool keepSettings) {
   m_editorNavMesh.Clear();
   m_editorNavMeshDebugRenderer.ReleaseCachedGeometry();
@@ -3284,6 +3321,91 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
                         m_editorNavMeshClassification.excludedByVolumeCount,
                         m_editorNavMeshClassification.outsideIncludeVolumeCount,
                         m_editorNavMeshClassification.excludedBySlopeCount);
+  }
+  if (!m_editorNavMeshVolumes.empty() && ImGui::CollapsingHeader("Validation Report", ImGuiTreeNodeFlags_DefaultOpen)) {
+    UpdateEditorNavMeshClassification();
+    std::vector<int> triangleHits(m_editorNavMeshVolumes.size(), 0);
+    std::vector<int> linkHits(m_editorNavMeshVolumes.size(), 0);
+    if (m_editorNavMeshClassificationReady) {
+      for (const t850::navigation::NavTriangleClassification& tri : m_editorNavMeshClassification.triangles) {
+        for (int volumeIndex = 0; volumeIndex < static_cast<int>(m_editorNavMeshVolumes.size()); ++volumeIndex) {
+          if (NavVolumeContainsPoint(m_editorNavMeshVolumes[static_cast<std::size_t>(volumeIndex)], tri.centroid)) {
+            ++triangleHits[static_cast<std::size_t>(volumeIndex)];
+          }
+        }
+      }
+    }
+    if (m_editorNavMesh.IsReady()) {
+      auto countLinksForType = [&](t850::navigation::NavTraversalType type) {
+        std::vector<XVECTOR3> vertices;
+        std::vector<unsigned int> indices;
+        if (!m_editorNavMesh.GetDebugOffMeshLinks(type, vertices, indices, 0.0f)) {
+          return;
+        }
+        for (std::size_t index = 0; index + 1 < indices.size(); index += 6) {
+          const XVECTOR3 start = vertices[indices[index + 0]];
+          const XVECTOR3 end = vertices[indices[index + 1]];
+          const XVECTOR3 mid((start.x + end.x) * 0.5f,
+                             (start.y + end.y) * 0.5f,
+                             (start.z + end.z) * 0.5f,
+                             1.0f);
+          for (int volumeIndex = 0; volumeIndex < static_cast<int>(m_editorNavMeshVolumes.size()); ++volumeIndex) {
+            const auto& volume = m_editorNavMeshVolumes[static_cast<std::size_t>(volumeIndex)];
+            if (NavVolumeContainsPoint(volume, start) ||
+                NavVolumeContainsPoint(volume, end) ||
+                NavVolumeContainsPoint(volume, mid)) {
+              ++linkHits[static_cast<std::size_t>(volumeIndex)];
+            }
+          }
+        }
+      };
+      countLinksForType(t850::navigation::NavTraversalType::Drop);
+      countLinksForType(t850::navigation::NavTraversalType::Jump);
+      countLinksForType(t850::navigation::NavTraversalType::JumpPad);
+      countLinksForType(t850::navigation::NavTraversalType::JumpIntent);
+    }
+
+    bool hasLinkIncludeVolume = false;
+    for (const auto& volume : m_editorNavMeshVolumes) {
+      if (volume.enabled && (volume.type == "link_include" || volume.type == "link_add" || volume.type == "add_links")) {
+        hasLinkIncludeVolume = true;
+        break;
+      }
+    }
+    if (hasLinkIncludeVolume && m_editorNavMesh.IsReady() && m_editorNavMesh.GetStats().offMeshLinkCount == 0) {
+      ImGui::TextColored(ImVec4(1.0f, 0.45f, 0.1f, 1.0f),
+                         "Warning: link_include volumes are active but no off-mesh links survived generation.");
+    }
+
+    if (ImGui::BeginTable("NavVolumeValidation", 4, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV)) {
+      ImGui::TableSetupColumn("Volume");
+      ImGui::TableSetupColumn("Type");
+      ImGui::TableSetupColumn("Triangles");
+      ImGui::TableSetupColumn("Links");
+      ImGui::TableHeadersRow();
+      for (int volumeIndex = 0; volumeIndex < static_cast<int>(m_editorNavMeshVolumes.size()); ++volumeIndex) {
+        const auto& volume = m_editorNavMeshVolumes[static_cast<std::size_t>(volumeIndex)];
+        const int triCount = triangleHits[static_cast<std::size_t>(volumeIndex)];
+        const int linkCount = linkHits[static_cast<std::size_t>(volumeIndex)];
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::TextUnformatted(volume.name.c_str());
+        ImGui::TableSetColumnIndex(1);
+        ImGui::TextUnformatted(volume.type.c_str());
+        ImGui::TableSetColumnIndex(2);
+        ImGui::Text("%d", triCount);
+        ImGui::TableSetColumnIndex(3);
+        ImGui::Text("%d", linkCount);
+        if (volume.enabled && triCount == 0 && linkCount == 0) {
+          ImGui::TableNextRow();
+          ImGui::TableSetColumnIndex(0);
+          ImGui::TextColored(ImVec4(1.0f, 0.45f, 0.1f, 1.0f), "Warning");
+          ImGui::TableSetColumnIndex(1);
+          ImGui::TextDisabled("No affected triangles or links.");
+        }
+      }
+      ImGui::EndTable();
+    }
   }
   if (m_editorNavMeshAuthoringMode) {
     ImGui::TextColored(ImVec4(0.25f, 0.75f, 1.0f, 1.0f), "NavMesh Authoring Mode: click source preview triangles to select them.");

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -2383,6 +2383,7 @@ void EditorApp::ResetEditorNavMeshState(bool keepSettings) {
   m_editorNavMeshNodes.clear();
   m_editorSelectedNavVolume = -1;
   m_editorSelectedNavLink = -1;
+  m_editorSelectedNavTriangle = -1;
   m_editorNavLinkPickMode = 0;
   InvalidateEditorNavMeshClassification();
   if (!keepSettings) {
@@ -2403,6 +2404,7 @@ void EditorApp::InvalidateEditorNavMeshClassification() {
   m_editorNavMeshClassificationReady = false;
   m_editorNavMeshClassificationDirty = true;
   m_editorNavMeshClassification = t850::navigation::NavMeshClassificationResult{};
+  m_editorSelectedNavTriangle = -1;
   ReleaseNavMeshClassificationGizmos();
 }
 
@@ -2428,6 +2430,7 @@ bool EditorApp::DeleteSelectedNavAuthoringChild() {
         ? -1
         : std::clamp(m_editorSelectedNavLink, 0, static_cast<int>(m_editorNavMeshLinks.size()) - 1);
     m_editorSelectedNavVolume = -1;
+    m_editorSelectedNavTriangle = -1;
     MarkEditorNavMeshDirty("Authored link deleted. Click Re-generate.");
     return true;
   }
@@ -2499,6 +2502,83 @@ bool EditorApp::UpdateEditorNavMeshClassification() {
   return true;
 }
 
+bool EditorApp::PickEditorNavMeshTriangleFromMouse(int mouseX, int mouseY, int& outTriangleIndex) const {
+  outTriangleIndex = -1;
+  if (!m_editorNavMeshClassificationReady || !m_sceneProps.GetPrimaryCamera()) {
+    return false;
+  }
+  const Camera& cam = *m_sceneProps.GetPrimaryCamera();
+  const t850::Ray ray = BuildEditorCameraRay(cam,
+                                             static_cast<float>(mouseX),
+                                             static_cast<float>(mouseY),
+                                             m_lastW,
+                                             m_lastH);
+  float bestT = FLT_MAX;
+  for (const t850::navigation::NavTriangleClassification& tri : m_editorNavMeshClassification.triangles) {
+    float t = 0.0f;
+    float u = 0.0f;
+    float v = 0.0f;
+    if (t850::RayIntersectsTriangle(ray, tri.vertices[0], tri.vertices[1], tri.vertices[2], t, u, v) && t < bestT) {
+      bestT = t;
+      outTriangleIndex = tri.triangleIndex;
+    }
+  }
+  return outTriangleIndex >= 0;
+}
+
+bool EditorApp::CreateNavVolumeFromSelectedTriangle(const char* type) {
+  if (m_editorSelectedNavTriangle < 0) {
+    return false;
+  }
+  if (!UpdateEditorNavMeshClassification()) {
+    return false;
+  }
+  const auto it = std::find_if(
+      m_editorNavMeshClassification.triangles.begin(),
+      m_editorNavMeshClassification.triangles.end(),
+      [&](const t850::navigation::NavTriangleClassification& tri) {
+        return tri.triangleIndex == m_editorSelectedNavTriangle;
+      });
+  if (it == m_editorNavMeshClassification.triangles.end()) {
+    return false;
+  }
+
+  t850::AABB bounds;
+  for (const XVECTOR3& p : it->vertices) {
+    bounds.ExpandToInclude(p);
+  }
+  const XVECTOR3 center = bounds.Center();
+  const XVECTOR3 extents = bounds.Extents();
+  t850::scene::SceneNavMeshVolumeDesc volume;
+  volume.name = std::string(type && std::strcmp(type, "area_cost") == 0 ? "Area Cost From Triangle " : "Exclude From Triangle ") +
+      std::to_string(m_editorNavMeshVolumes.size() + 1);
+  volume.type = type && *type ? type : "exclude";
+  volume.shape = "box";
+  volume.position = {center.x, center.y, center.z};
+  volume.half_extents = {
+      (std::max)(1.0f, extents.x * 0.5f + 0.5f),
+      (std::max)(1.0f, extents.y * 0.5f + m_editorNavMeshBuildSettings.agentHeight * 0.5f),
+      (std::max)(1.0f, extents.z * 0.5f + 0.5f)};
+  volume.enabled = true;
+  volume.visible = true;
+  volume.show_wire = true;
+  if (volume.type == "area_cost") {
+    volume.area = "mud";
+    volume.cost = 3.0f;
+  }
+
+  m_editorNavMeshVolumes.push_back(volume);
+  m_editorSelectedNavVolume = static_cast<int>(m_editorNavMeshVolumes.size()) - 1;
+  m_editorSelectedNavLink = -1;
+  g_selectionType = 4;
+  g_selectedIdx = 0;
+  ClearMixedSelection();
+  MarkEditorNavMeshDirty(volume.type == "area_cost"
+      ? "Area-cost volume created from selected source triangle. Click Re-generate."
+      : "Exclude volume created from selected source triangle. Click Re-generate.");
+  return true;
+}
+
 void EditorApp::DrawNavMeshClassificationOverlay(EditorLineRenderer& lines, const XMATRIX44& vp) {
   if (!m_editorNavMeshShowSourcePreview || !lines.IsReady()) {
     return;
@@ -2521,7 +2601,8 @@ void EditorApp::DrawNavMeshClassificationOverlay(EditorLineRenderer& lines, cons
     ExcludedVolume = 2,
     OutsideInclude = 3,
     ExcludedSlope = 4,
-    Count = 5
+    Selected = 5,
+    Count = 6
   };
   struct BucketGeometry {
     std::vector<float> vertices;
@@ -2546,6 +2627,9 @@ void EditorApp::DrawNavMeshClassificationOverlay(EditorLineRenderer& lines, cons
     };
 
     for (const t850::navigation::NavTriangleClassification& tri : m_editorNavMeshClassification.triangles) {
+      if (tri.triangleIndex == m_editorSelectedNavTriangle) {
+        appendTriangle(Selected, tri);
+      }
       if (tri.included) {
         appendTriangle(tri.area == 0 ? Included : AreaCost, tri);
         continue;
@@ -2580,7 +2664,8 @@ void EditorApp::DrawNavMeshClassificationOverlay(EditorLineRenderer& lines, cons
       XVECTOR3(0.95f, 0.45f, 1.0f, 1.0f),
       XVECTOR3(1.0f, 0.15f, 0.08f, 1.0f),
       XVECTOR3(0.22f, 0.22f, 0.22f, 1.0f),
-      XVECTOR3(0.55f, 0.55f, 0.55f, 1.0f)
+      XVECTOR3(0.55f, 0.55f, 0.55f, 1.0f),
+      XVECTOR3(1.0f, 1.0f, 0.1f, 1.0f)
   };
   XMATRIX44 identity;
   XMatIdentity(identity);
@@ -3111,6 +3196,7 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
   ImGui::Checkbox("Frozen", &m_editorNavMeshFrozen);
   ImGui::SameLine();
   ImGui::Checkbox("Wireframe", &m_editorNavMeshShowWire);
+  ImGui::Checkbox("NavMesh Authoring Mode", &m_editorNavMeshAuthoringMode);
 
   if (ImGui::SliderFloat("Debug Vertical Offset", &m_editorNavMeshDebugOffset, 0.0f, 0.25f, "%.3f")) {
     ReleaseNavMeshClassificationGizmos();
@@ -3150,6 +3236,19 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
                         m_editorNavMeshClassification.excludedByVolumeCount,
                         m_editorNavMeshClassification.outsideIncludeVolumeCount,
                         m_editorNavMeshClassification.excludedBySlopeCount);
+  }
+  if (m_editorNavMeshAuthoringMode) {
+    ImGui::TextColored(ImVec4(0.25f, 0.75f, 1.0f, 1.0f), "NavMesh Authoring Mode: click source preview triangles to select them.");
+  }
+  if (m_editorSelectedNavTriangle >= 0) {
+    ImGui::Text("Selected Source Triangle: %d", m_editorSelectedNavTriangle);
+    if (ImGui::Button("Exclude Selected Triangle")) {
+      CreateNavVolumeFromSelectedTriangle("exclude");
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Area Cost Selected Triangle")) {
+      CreateNavVolumeFromSelectedTriangle("area_cost");
+    }
   }
   if (m_editorNavMeshDirty) {
     ImGui::TextColored(ImVec4(1.0f, 0.75f, 0.1f, 1.0f), "Preview is stale. Click Re-generate.");
@@ -8304,6 +8403,22 @@ single_pick:
                                        m_lastW,
                                        m_lastH);
 
+  if (m_editorNavMeshAuthoringMode && m_editorNavMeshShowSourcePreview) {
+    UpdateEditorNavMeshClassification();
+    int triangleIndex = -1;
+    if (PickEditorNavMeshTriangleFromMouse(IManager.mouseX, IManager.mouseY, triangleIndex)) {
+      m_editorSelectedNavTriangle = triangleIndex;
+      m_editorSelectedNavVolume = -1;
+      m_editorSelectedNavLink = -1;
+      g_selectedIdx = 0;
+      g_selectionType = 4;
+      ClearMixedSelection();
+      ReleaseNavMeshClassificationGizmos();
+      m_editorNavMeshStatus = "Source triangle selected. Use Exclude Selected Triangle or Area Cost Selected Triangle.";
+      return;
+    }
+  }
+
   // Test all objects, pick the closest
   float bestT = FLT_MAX;
   int   bestIdx  = -1;
@@ -9062,11 +9177,24 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
   int addCamera = -1, addLight = -1;
   bool wantsClone = false, wantsGroup = false, wantsUngroup = false, wantsPlayScene = false;
   int toolbarCameraMode = static_cast<int>(m_editorCameraMode);
+  const bool wasNavMeshAuthoringMode = m_editorNavMeshAuthoringMode;
   int mode = ImGuiDrawToolbar((int)m_gizmo.Mode(), addCamera, addLight,
                                 wantsClone, wantsGroup, wantsUngroup, wantsPlayScene,
                                 g_selectedIdx >= 0, g_multiSelect.size() >= 2,
-                                toolbarCameraMode);
+                                toolbarCameraMode,
+                                m_editorNavMeshAuthoringMode);
   m_gizmo.SetMode((GizmoMode)mode);
+  if (m_editorNavMeshAuthoringMode) {
+    m_panels.showHierarchy = true;
+    m_panels.showInspector = true;
+    m_editorNavMeshShowSourcePreview = true;
+    if (!wasNavMeshAuthoringMode) {
+      g_selectionType = 4;
+      g_selectedIdx = 0;
+      g_selectedSplinePoint = -1;
+      ClearMixedSelection();
+    }
+  }
   toolbarCameraMode = std::clamp(toolbarCameraMode, 0, 1);
   const EditorCameraMode newCameraMode = static_cast<EditorCameraMode>(toolbarCameraMode);
   if (newCameraMode != m_editorCameraMode) {

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -7313,24 +7313,6 @@ static uint64_t HashEditorSplineDrawData(const t850::scene::SceneSplineDesc& des
   return hash;
 }
 
-static uint64_t HashGodRaysVolumeDrawData(const t850::scene::SceneGodRaysVolumeDesc& desc, bool selected) {
-  uint64_t hash = 1469598103934665603ull;
-  auto mix = [&](uint64_t value) {
-    hash ^= value;
-    hash *= 1099511628211ull;
-  };
-  mix(selected ? 1ull : 0ull);
-  mix(desc.enabled ? 1ull : 0ull);
-  mix(desc.clip_enabled ? 1ull : 0ull);
-  mix(HashSplineFloat(desc.position.x));
-  mix(HashSplineFloat(desc.position.y));
-  mix(HashSplineFloat(desc.position.z));
-  mix(HashSplineFloat(desc.half_extents.x));
-  mix(HashSplineFloat(desc.half_extents.y));
-  mix(HashSplineFloat(desc.half_extents.z));
-  return hash;
-}
-
 static void DrawGodRaysVolume(EditorLineRenderer& lines,
                               const XMATRIX44& vp,
                               const t850::scene::SceneGodRaysVolumeDesc& desc,
@@ -7339,28 +7321,13 @@ static void DrawGodRaysVolume(EditorLineRenderer& lines,
   if (!lines.IsReady() || !desc.enabled || !desc.visible || !desc.show_wire) {
     return;
   }
-  const uint64_t drawHash = HashGodRaysVolumeDrawData(desc, selected);
   const XVECTOR3 color = selected
       ? XVECTOR3(1.0f, 0.82f, 0.18f, 1.0f)
       : XVECTOR3(1.0f, 0.45f, 0.05f, 1.0f);
-  if (cache.vb && cache.ib && cache.hash == drawHash) {
-    XMATRIX44 identity;
-    identity.Identity();
-    lines.DrawLines(identity, vp, color, cache.vb, cache.ib, cache.count, sizeof(float) * 4);
-    return;
-  }
 
-  const auto& p = desc.position;
-  const t850::scene::Vec3f h{
-      (std::max)(0.001f, std::abs(desc.half_extents.x)),
-      (std::max)(0.001f, std::abs(desc.half_extents.y)),
-      (std::max)(0.001f, std::abs(desc.half_extents.z))};
-  const float x0 = p.x - h.x, x1 = p.x + h.x;
-  const float y0 = p.y - h.y, y1 = p.y + h.y;
-  const float z0 = p.z - h.z, z1 = p.z + h.z;
   const float verts[] = {
-      x0,y0,z0,1,  x1,y0,z0,1,  x1,y1,z0,1,  x0,y1,z0,1,
-      x0,y0,z1,1,  x1,y0,z1,1,  x1,y1,z1,1,  x0,y1,z1,1};
+      -1,-1,-1,1,  1,-1,-1,1,  1, 1,-1,1, -1, 1,-1,1,
+      -1,-1, 1,1,  1,-1, 1,1,  1, 1, 1,1, -1, 1, 1,1};
   const unsigned short indices[] = {
       0,1, 1,2, 2,3, 3,0,
       4,5, 5,6, 6,7, 7,4,
@@ -7373,17 +7340,21 @@ static void DrawGodRaysVolume(EditorLineRenderer& lines,
       }
       ReleaseGizmoCache(cache);
     }
-    cache.vb = EditorLineRenderer::CreatePositionVB(verts, 8, t850::BufferUsage::DINAMIC);
+    cache.vb = EditorLineRenderer::CreatePositionVB(verts, 8);
     cache.ib = EditorLineRenderer::CreateIndexBuffer16(indices, indexCount);
     cache.count = indexCount;
-  } else {
-    cache.vb->UpdateFromBuffer(*t850::T8DeviceContext, verts);
   }
-  cache.hash = drawHash;
   if (cache.vb && cache.ib) {
-    XMATRIX44 identity;
-    identity.Identity();
-    lines.DrawLines(identity, vp, color, cache.vb, cache.ib, cache.count, sizeof(float) * 4);
+    const t850::scene::Vec3f h{
+        (std::max)(0.001f, std::abs(desc.half_extents.x)),
+        (std::max)(0.001f, std::abs(desc.half_extents.y)),
+        (std::max)(0.001f, std::abs(desc.half_extents.z))};
+    XMATRIX44 world;
+    XMatScaling(world, h.x, h.y, h.z);
+    world.m[3][0] = desc.position.x;
+    world.m[3][1] = desc.position.y;
+    world.m[3][2] = desc.position.z;
+    lines.DrawLines(world, vp, color, cache.vb, cache.ib, cache.count, sizeof(float) * 4);
   }
 }
 

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -2423,6 +2423,7 @@ void EditorApp::ResetEditorNavMeshState(bool keepSettings) {
   m_editorSelectedNavVolume = -1;
   m_editorSelectedNavLink = -1;
   m_editorSelectedNavTriangle = -1;
+  m_editorSelectedNavTriangles.clear();
   m_editorNavLinkPickMode = 0;
   InvalidateEditorNavMeshClassification();
   if (!keepSettings) {
@@ -2444,6 +2445,7 @@ void EditorApp::InvalidateEditorNavMeshClassification() {
   m_editorNavMeshClassificationDirty = true;
   m_editorNavMeshClassification = t850::navigation::NavMeshClassificationResult{};
   m_editorSelectedNavTriangle = -1;
+  m_editorSelectedNavTriangles.clear();
   ReleaseNavMeshClassificationGizmos();
 }
 
@@ -2567,25 +2569,33 @@ bool EditorApp::PickEditorNavMeshTriangleFromMouse(int mouseX, int mouseY, int& 
 }
 
 bool EditorApp::CreateNavVolumeFromSelectedTriangle(const char* type) {
-  if (m_editorSelectedNavTriangle < 0) {
+  if (m_editorSelectedNavTriangle >= 0 && m_editorSelectedNavTriangles.empty()) {
+    m_editorSelectedNavTriangles.insert(m_editorSelectedNavTriangle);
+  }
+  return CreateNavVolumeFromSelectedTriangles(type);
+}
+
+bool EditorApp::CreateNavVolumeFromSelectedTriangles(const char* type) {
+  if (m_editorSelectedNavTriangles.empty()) {
     return false;
   }
   if (!UpdateEditorNavMeshClassification()) {
     return false;
   }
-  const auto it = std::find_if(
-      m_editorNavMeshClassification.triangles.begin(),
-      m_editorNavMeshClassification.triangles.end(),
-      [&](const t850::navigation::NavTriangleClassification& tri) {
-        return tri.triangleIndex == m_editorSelectedNavTriangle;
-      });
-  if (it == m_editorNavMeshClassification.triangles.end()) {
-    return false;
-  }
 
   t850::AABB bounds;
-  for (const XVECTOR3& p : it->vertices) {
-    bounds.ExpandToInclude(p);
+  int usedTriangles = 0;
+  for (const t850::navigation::NavTriangleClassification& tri : m_editorNavMeshClassification.triangles) {
+    if (m_editorSelectedNavTriangles.count(tri.triangleIndex) == 0) {
+      continue;
+    }
+    for (const XVECTOR3& p : tri.vertices) {
+      bounds.ExpandToInclude(p);
+    }
+    ++usedTriangles;
+  }
+  if (usedTriangles <= 0 || !bounds.IsValid()) {
+    return false;
   }
   const XVECTOR3 center = bounds.Center();
   const XVECTOR3 extents = bounds.Extents();
@@ -2616,6 +2626,8 @@ bool EditorApp::CreateNavVolumeFromSelectedTriangle(const char* type) {
   m_editorNavMeshVolumes.push_back(volume);
   m_editorSelectedNavVolume = static_cast<int>(m_editorNavMeshVolumes.size()) - 1;
   m_editorSelectedNavLink = -1;
+  m_editorSelectedNavTriangles.clear();
+  m_editorSelectedNavTriangle = -1;
   g_selectionType = 4;
   g_selectedIdx = 0;
   ClearMixedSelection();
@@ -2673,7 +2685,8 @@ void EditorApp::DrawNavMeshClassificationOverlay(EditorLineRenderer& lines, cons
     };
 
     for (const t850::navigation::NavTriangleClassification& tri : m_editorNavMeshClassification.triangles) {
-      if (tri.triangleIndex == m_editorSelectedNavTriangle) {
+      if (tri.triangleIndex == m_editorSelectedNavTriangle ||
+          m_editorSelectedNavTriangles.count(tri.triangleIndex) != 0) {
         appendTriangle(Selected, tri);
       }
       if (tri.included) {
@@ -3409,22 +3422,31 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
   }
   if (m_editorNavMeshAuthoringMode) {
     ImGui::TextColored(ImVec4(0.25f, 0.75f, 1.0f, 1.0f), "NavMesh Authoring Mode: click source preview triangles to select them.");
+    ImGui::Checkbox("Brush Select Triangles", &m_editorNavMeshBrushSelect);
+    ImGui::SameLine();
+    ImGui::DragFloat("Brush Radius", &m_editorNavMeshBrushRadius, 0.1f, 0.1f, 256.0f, "%.2f");
   }
-  if (m_editorSelectedNavTriangle >= 0) {
+  if (m_editorSelectedNavTriangle >= 0 || !m_editorSelectedNavTriangles.empty()) {
     ImGui::Text("Selected Source Triangle: %d", m_editorSelectedNavTriangle);
+    ImGui::Text("Selected Source Triangles: %d", static_cast<int>(m_editorSelectedNavTriangles.size()));
+    if (ImGui::Button("Clear Triangle Selection")) {
+      m_editorSelectedNavTriangle = -1;
+      m_editorSelectedNavTriangles.clear();
+      ReleaseNavMeshClassificationGizmos();
+    }
     if (ImGui::Button("Exclude Selected Triangle")) {
-      CreateNavVolumeFromSelectedTriangle("exclude");
+      CreateNavVolumeFromSelectedTriangles("exclude");
     }
     ImGui::SameLine();
     if (ImGui::Button("Area Cost Selected Triangle")) {
-      CreateNavVolumeFromSelectedTriangle("area_cost");
+      CreateNavVolumeFromSelectedTriangles("area_cost");
     }
     if (ImGui::Button("Link Include Selected Triangle")) {
-      CreateNavVolumeFromSelectedTriangle("link_include");
+      CreateNavVolumeFromSelectedTriangles("link_include");
     }
     ImGui::SameLine();
     if (ImGui::Button("Link Exclude Selected Triangle")) {
-      CreateNavVolumeFromSelectedTriangle("link_exclude");
+      CreateNavVolumeFromSelectedTriangles("link_exclude");
     }
   }
   if (m_editorNavMeshDirty) {
@@ -8594,13 +8616,41 @@ single_pick:
     int triangleIndex = -1;
     if (PickEditorNavMeshTriangleFromMouse(IManager.mouseX, IManager.mouseY, triangleIndex)) {
       m_editorSelectedNavTriangle = triangleIndex;
+      const bool appendSelection = shiftDown || m_editorNavMeshBrushSelect;
+      if (!appendSelection) {
+        m_editorSelectedNavTriangles.clear();
+      }
+      auto selectedIt = std::find_if(
+          m_editorNavMeshClassification.triangles.begin(),
+          m_editorNavMeshClassification.triangles.end(),
+          [&](const t850::navigation::NavTriangleClassification& tri) {
+            return tri.triangleIndex == triangleIndex;
+          });
+      if (selectedIt != m_editorNavMeshClassification.triangles.end()) {
+        const float radiusSq = (std::max)(0.001f, m_editorNavMeshBrushRadius) *
+            (std::max)(0.001f, m_editorNavMeshBrushRadius);
+        for (const t850::navigation::NavTriangleClassification& tri : m_editorNavMeshClassification.triangles) {
+          const float dx = tri.centroid.x - selectedIt->centroid.x;
+          const float dy = tri.centroid.y - selectedIt->centroid.y;
+          const float dz = tri.centroid.z - selectedIt->centroid.z;
+          if (!m_editorNavMeshBrushSelect || (dx * dx + dy * dy + dz * dz) <= radiusSq) {
+            if (shiftDown && !m_editorNavMeshBrushSelect && m_editorSelectedNavTriangles.count(tri.triangleIndex)) {
+              m_editorSelectedNavTriangles.erase(tri.triangleIndex);
+            } else {
+              m_editorSelectedNavTriangles.insert(tri.triangleIndex);
+            }
+          }
+        }
+      } else {
+        m_editorSelectedNavTriangles.insert(triangleIndex);
+      }
       m_editorSelectedNavVolume = -1;
       m_editorSelectedNavLink = -1;
       g_selectedIdx = 0;
       g_selectionType = 4;
       ClearMixedSelection();
       ReleaseNavMeshClassificationGizmos();
-      m_editorNavMeshStatus = "Source triangle selected. Use Exclude Selected Triangle or Area Cost Selected Triangle.";
+      m_editorNavMeshStatus = "Source triangle selection updated. Use selected-triangle volume tools.";
       return;
     }
   }

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -299,6 +299,7 @@ namespace {
   // Pending scene load — deferred to execute before next frame's BeginFrame
   std::string g_pendingLoadPath;
   std::string g_pendingDeleteAfterLoadPath;
+  std::string g_loadedScenePath;
   auto& g_loadedSceneFile = g_world.loadedSceneFile;
   auto& g_hasLoadedSceneFile = g_world.hasLoadedSceneFile;
   auto& g_unloadedSceneObjects = g_world.unloadedSceneObjects;
@@ -2401,6 +2402,17 @@ static bool NavVolumeContainsPoint(const t850::scene::SceneNavMeshVolumeDesc& vo
          std::abs(local.z) <= (std::max)(0.001f, std::abs(volume.half_extents.z));
 }
 
+static std::string SuggestedNavMeshBakedAssetPath() {
+  std::string baseName = "EditorNavMesh";
+  if (!g_loadedScenePath.empty()) {
+    baseName = std::filesystem::path(g_loadedScenePath).stem().string();
+  }
+  if (baseName.empty()) {
+    baseName = "EditorNavMesh";
+  }
+  return "Navigation/" + baseName + ".t8nav";
+}
+
 void EditorApp::ResetEditorNavMeshState(bool keepSettings) {
   m_editorNavMesh.Clear();
   m_editorNavMeshDebugRenderer.ReleaseCachedGeometry();
@@ -3274,11 +3286,19 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
   }
   if (m_editorNavMeshRuntimeMode == "baked_asset") {
     if (m_editorNavMeshBakedAsset.empty()) {
-      m_editorNavMeshBakedAsset = "Navigation/EditorNavMesh.t8nav";
+      m_editorNavMeshBakedAsset = SuggestedNavMeshBakedAssetPath();
     }
     if (InputTextString("Baked Asset", m_editorNavMeshBakedAsset)) {
       MarkEditorNavMeshDirty("NavMesh baked asset path changed. Save the scene to persist it.");
     }
+    ImGui::SameLine();
+    if (ImGui::Button("Suggest Path")) {
+      m_editorNavMeshBakedAsset = SuggestedNavMeshBakedAssetPath();
+      MarkEditorNavMeshDirty("NavMesh baked asset path changed. Save the scene to persist it.");
+    }
+    const bool bakedExists = !m_editorNavMeshBakedAsset.empty() &&
+        t850::ResourceLocator::Instance().Exists(m_editorNavMeshBakedAsset);
+    ImGui::TextDisabled("Baked Asset Status: %s", bakedExists ? "Found" : "Missing / not baked yet");
     if (!m_editorNavMesh.IsReady()) {
       ImGui::BeginDisabled();
     }
@@ -3293,6 +3313,26 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
     if (!m_editorNavMesh.IsReady()) {
       ImGui::EndDisabled();
       ImGui::TextDisabled("Build or Re-generate the NavMesh before baking.");
+    }
+    ImGui::SameLine();
+    if (!m_editorNavMesh.IsReady() || g_loadedScenePath.empty()) {
+      ImGui::BeginDisabled();
+    }
+    if (ImGui::Button("Bake + Save Scene")) {
+      std::string bakeError;
+      if (!m_editorNavMesh.SaveBaked(m_editorNavMeshBakedAsset, &bakeError)) {
+        m_editorNavMeshStatus = "Bake failed: " + bakeError;
+      } else if (!SaveEditorSceneSnapshot(g_loadedScenePath, true)) {
+        m_editorNavMeshStatus = "Baked asset written, but scene save failed.";
+      } else {
+        m_editorNavMeshStatus = "Baked NavMesh asset and saved scene: " + m_editorNavMeshBakedAsset;
+      }
+    }
+    if (!m_editorNavMesh.IsReady() || g_loadedScenePath.empty()) {
+      ImGui::EndDisabled();
+      if (g_loadedScenePath.empty()) {
+        ImGui::TextDisabled("Load or save a scene before using Bake + Save Scene.");
+      }
     }
   }
 
@@ -4400,6 +4440,7 @@ bool EditorApp::SaveEditorSceneSnapshot(const std::string& path, bool updateLoad
   if (updateLoadedScene) {
     g_loadedSceneFile = sf;
     g_hasLoadedSceneFile = true;
+    g_loadedScenePath = path;
     g_sceneCollisionResourcePath = sf.collision;
     g_sceneProfiles = sf.profiles;
   }
@@ -6414,6 +6455,7 @@ void EditorApp::DestroyAssets() {
   g_activeGroupIdx = -1;
   g_loadedSceneFile = SceneFile{};
   g_hasLoadedSceneFile = false;
+  g_loadedScenePath.clear();
   g_unloadedSceneObjects.clear();
   g_sceneCollisionResourcePath.clear();
   g_sceneProfiles.clear();
@@ -6716,6 +6758,7 @@ void EditorApp::LoadPendingScene() {
 
       g_loadedSceneFile = sf;
       g_hasLoadedSceneFile = true;
+      g_loadedScenePath = loadPath;
       g_sceneProfiles = sf.profiles;
       LoadEditorSceneProfiles();
 

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -9015,7 +9015,8 @@ void EditorApp::RenderEditorSceneFrame(t850::BaseDriver* drv, bool captureFrozen
 
   // Camera and light viewport gizmos (only if visible)
   if (m_lines.IsReady()) {
-    for (int i = 0; i < static_cast<int>(g_objects.size()); ++i) {
+    if (!m_editorNavMeshAuthoringMode) {
+      for (int i = 0; i < static_cast<int>(g_objects.size()); ++i) {
       SceneObject& obj = g_objects[static_cast<std::size_t>(i)];
       if (!obj.visible || !obj.showOrientation) {
         continue;
@@ -9063,13 +9064,14 @@ void EditorApp::RenderEditorSceneFrame(t850::BaseDriver* drv, bool captureFrozen
       SyncLightCameraGizmoCamera(lightCameraDesc, lightCamera);
       DrawCameraGizmo(m_lines, cam.VP, lightCamera, g_selectionType == 6 && i == g_selectedIdx);
     }
-    if (godRaysVolumeCanBeActive) {
-      DrawGodRaysVolume(
-          m_lines,
-          cam.VP,
-          g_godRaysVolume,
-          g_selectionType == 8,
-          g_godRaysVolumeGizmo);
+      if (godRaysVolumeCanBeActive) {
+        DrawGodRaysVolume(
+            m_lines,
+            cam.VP,
+            g_godRaysVolume,
+            g_selectionType == 8,
+            g_godRaysVolumeGizmo);
+      }
     }
     if (m_editorNavMeshAuthored && m_editorNavMeshVisible) {
       DrawNavMeshClassificationOverlay(m_lines, cam.VP);
@@ -9090,17 +9092,19 @@ void EditorApp::RenderEditorSceneFrame(t850::BaseDriver* drv, bool captureFrozen
           g_selectionType == 4 && g_selectedIdx == 0 && i == m_editorSelectedNavVolume,
           g_navMeshVolumeGizmos[static_cast<std::size_t>(i)]);
     }
-    if (g_splineGizmos.size() < g_splines.size()) {
-      g_splineGizmos.resize(g_splines.size());
+    if (!m_editorNavMeshAuthoringMode) {
+      if (g_splineGizmos.size() < g_splines.size()) {
+        g_splineGizmos.resize(g_splines.size());
+      }
+      for (int i = 0; i < static_cast<int>(g_splines.size()); ++i)
+        DrawEditorSpline(
+            m_lines,
+            cam.VP,
+            g_splines[static_cast<std::size_t>(i)],
+            (g_selectionType == 5 || g_selectionType == 7) && i == g_selectedIdx,
+            g_selectionType == 7 && i == g_selectedIdx ? g_selectedSplinePoint : -1,
+            g_splineGizmos[static_cast<std::size_t>(i)]);
     }
-    for (int i = 0; i < static_cast<int>(g_splines.size()); ++i)
-      DrawEditorSpline(
-          m_lines,
-          cam.VP,
-          g_splines[static_cast<std::size_t>(i)],
-          (g_selectionType == 5 || g_selectionType == 7) && i == g_selectedIdx,
-          g_selectionType == 7 && i == g_selectedIdx ? g_selectedSplinePoint : -1,
-          g_splineGizmos[static_cast<std::size_t>(i)]);
   }
 
   // Grid
@@ -9233,6 +9237,7 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
     m_panels.showInspector = true;
     m_panels.showRendering = true;
     m_panels.showConsole = true;
+    m_panels.showNavMeshAuthoring = m_editorNavMeshAuthoringMode;
     m_panels.showRTDebug = false;
   }
 
@@ -9249,6 +9254,7 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
   if (m_editorNavMeshAuthoringMode) {
     m_panels.showHierarchy = true;
     m_panels.showInspector = true;
+    m_panels.showNavMeshAuthoring = true;
     m_editorNavMeshShowSourcePreview = true;
     if (!wasNavMeshAuthoringMode) {
       g_selectionType = 4;
@@ -10967,7 +10973,18 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
         }
       } else if (g_selectionType == 4 && g_selectedIdx == 0) {
         ImGui::SeparatorText("Navigation Mesh");
-        DrawNavMeshAuthoringPanel();
+        if (m_panels.showNavMeshAuthoring) {
+          ImGui::TextWrapped("NavMesh Authoring is open in its dedicated panel.");
+          if (ImGui::Button("Focus NavMesh Authoring")) {
+            m_panels.showNavMeshAuthoring = true;
+          }
+        } else {
+          if (ImGui::Button("Open NavMesh Authoring Panel")) {
+            m_panels.showNavMeshAuthoring = true;
+          }
+          ImGui::Separator();
+          DrawNavMeshAuthoringPanel();
+        }
       } else if (g_selectionType == 5 && g_selectedIdx >= 0 && g_selectedIdx < static_cast<int>(g_splines.size())) {
         t850::scene::SceneSplineDesc& spline = g_splines[static_cast<std::size_t>(g_selectedIdx)];
         ImGui::SeparatorText("Spline");
@@ -11266,6 +11283,26 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
           }
         }
       }
+    }
+    ImGui::End();
+  }
+
+  if (m_panels.showNavMeshAuthoring) {
+    if (ImGuiViewport* viewport = ImGui::GetMainViewport()) {
+      const float margin = 12.0f;
+      const ImGuiCond layoutCond = g_resetArtistLayout ? ImGuiCond_Always : ImGuiCond_FirstUseEver;
+      const float rightPanelWidth = (std::min)(440.0f, (std::max)(360.0f, viewport->WorkSize.x * 0.27f));
+      const float width = (std::min)(520.0f, (std::max)(420.0f, viewport->WorkSize.x * 0.34f));
+      const float height = (std::max)(420.0f, viewport->WorkSize.y * 0.58f);
+      ImGui::SetNextWindowPos(
+          ImVec2(viewport->WorkPos.x + viewport->WorkSize.x - rightPanelWidth - width - margin * 2.0f,
+                 viewport->WorkPos.y + margin),
+          layoutCond);
+      ImGui::SetNextWindowSize(ImVec2(width, height), layoutCond);
+    }
+    if (ImGui::Begin("NavMesh Authoring", &m_panels.showNavMeshAuthoring, ImGuiWindowFlags_NoCollapse)) {
+      ImGuiClampCurrentWindowToEditorWorkArea();
+      DrawNavMeshAuthoringPanel();
     }
     ImGui::End();
   }

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -42,6 +42,7 @@
 #include <Descriptors.h>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cctype>
@@ -196,6 +197,7 @@ namespace {
   auto& g_godRaysVolume = g_world.godRaysVolume;
   auto& g_godRaysVolumeGizmo = g_world.godRaysVolumeGizmo;
   std::vector<GizmoCache> g_navMeshVolumeGizmos;
+  std::array<GizmoCache, 5> g_navMeshClassificationGizmos;
   auto& g_splines = g_world.splines;
   auto& g_splineGizmos = g_world.splineGizmos;
   auto& g_selectedSplinePoint = g_world.selectedSplinePoint;
@@ -374,6 +376,12 @@ namespace {
       ReleaseGizmoCache(cache);
     }
     caches.clear();
+  }
+
+  void ReleaseNavMeshClassificationGizmos() {
+    for (GizmoCache& cache : g_navMeshClassificationGizmos) {
+      ReleaseGizmoCache(cache);
+    }
   }
 
   void ReleaseCameraGizmoCaches(std::vector<SceneCamera>& cameras) {
@@ -2376,6 +2384,7 @@ void EditorApp::ResetEditorNavMeshState(bool keepSettings) {
   m_editorSelectedNavVolume = -1;
   m_editorSelectedNavLink = -1;
   m_editorNavLinkPickMode = 0;
+  InvalidateEditorNavMeshClassification();
   if (!keepSettings) {
     m_editorNavMeshBuildSettings = DefaultEditorNavMeshBuildSettings();
   }
@@ -2384,9 +2393,17 @@ void EditorApp::ResetEditorNavMeshState(bool keepSettings) {
 void EditorApp::MarkEditorNavMeshDirty(const std::string& status) {
   m_editorNavMeshDirty = true;
   m_editorNavMeshAuthored = true;
+  InvalidateEditorNavMeshClassification();
   m_editorNavMeshStatus = status.empty()
       ? "NavMesh authoring changed. Click Re-generate to update the preview."
       : status;
+}
+
+void EditorApp::InvalidateEditorNavMeshClassification() {
+  m_editorNavMeshClassificationReady = false;
+  m_editorNavMeshClassificationDirty = true;
+  m_editorNavMeshClassification = t850::navigation::NavMeshClassificationResult{};
+  ReleaseNavMeshClassificationGizmos();
 }
 
 bool EditorApp::DeleteSelectedNavAuthoringChild() {
@@ -2415,6 +2432,172 @@ bool EditorApp::DeleteSelectedNavAuthoringChild() {
     return true;
   }
   return false;
+}
+
+bool EditorApp::UpdateEditorNavMeshClassification() {
+  if (!m_editorNavMeshClassificationDirty) {
+    return m_editorNavMeshClassificationReady;
+  }
+  m_editorNavMeshClassificationDirty = false;
+  m_editorNavMeshClassificationReady = false;
+  m_editorNavMeshClassification = t850::navigation::NavMeshClassificationResult{};
+  ReleaseNavMeshClassificationGizmos();
+
+  if (g_objects.empty()) {
+    return false;
+  }
+
+  SyncSceneObjectTransforms();
+  std::vector<t850::navigation::NavSourceInstance> navSources;
+  navSources.reserve(g_objects.size());
+  for (const SceneObject& object : g_objects) {
+    if (object.transient) {
+      continue;
+    }
+    t850::navigation::NavSourceInstance source;
+    source.entityId = object.litInst.GetEntityId();
+    source.instance = &object.litInst;
+    source.worldTransform = object.litInst.Final;
+    source.visible = object.visible;
+    source.debugName = object.name;
+    const t850::scene::SceneObjectNavigationDesc navigation =
+        object.navigation.value_or(t850::scene::SceneObjectNavigationDesc{});
+    source.includeInNavigation = navigation.include;
+    source.navigationStatic = navigation.static_object;
+    source.navigationWalkable = navigation.walkable;
+    source.area = navigation.walkable ? 0 : -1;
+    navSources.push_back(source);
+  }
+
+  t850::navigation::NavMeshGeometry geometry;
+  t850::navigation::NavSourceBuildStats sourceStats;
+  std::string error;
+  if (!t850::navigation::BuildGeometryFromNavSources(navSources, geometry, &sourceStats, &error)) {
+    m_editorNavMeshStatus = "Source preview skipped: " + error;
+    return false;
+  }
+  for (const t850::scene::SceneNavMeshVolumeDesc& volumeDesc : m_editorNavMeshVolumes) {
+    t850::navigation::NavMeshVolumeModifier modifier = NavVolumeModifierFromScene(volumeDesc);
+    if (!modifier.enabled) {
+      continue;
+    }
+    geometry.volumeModifiers.push_back(modifier);
+    if (modifier.mode == t850::navigation::NavMeshModifierMode::Area) {
+      geometry.areaCosts.push_back({modifier.area, modifier.cost});
+    }
+  }
+
+  if (!t850::navigation::ClassifyNavMeshTriangles(
+          geometry,
+          m_editorNavMeshBuildSettings,
+          m_editorNavMeshClassification,
+          &error)) {
+    m_editorNavMeshStatus = "Source preview failed: " + error;
+    return false;
+  }
+  m_editorNavMeshClassificationReady = true;
+  return true;
+}
+
+void EditorApp::DrawNavMeshClassificationOverlay(EditorLineRenderer& lines, const XMATRIX44& vp) {
+  if (!m_editorNavMeshShowSourcePreview || !lines.IsReady()) {
+    return;
+  }
+  if (!UpdateEditorNavMeshClassification()) {
+    return;
+  }
+
+  bool hasCachedGeometry = false;
+  for (const GizmoCache& cache : g_navMeshClassificationGizmos) {
+    if (cache.vb && cache.ib && cache.count > 0) {
+      hasCachedGeometry = true;
+      break;
+    }
+  }
+
+  enum Bucket {
+    Included = 0,
+    AreaCost = 1,
+    ExcludedVolume = 2,
+    OutsideInclude = 3,
+    ExcludedSlope = 4,
+    Count = 5
+  };
+  struct BucketGeometry {
+    std::vector<float> vertices;
+    std::vector<unsigned int> indices;
+  };
+  if (!hasCachedGeometry) {
+    std::array<BucketGeometry, Bucket::Count> buckets;
+
+    auto appendTriangle = [&](Bucket bucket, const t850::navigation::NavTriangleClassification& tri) {
+      BucketGeometry& geometry = buckets[static_cast<std::size_t>(bucket)];
+      const unsigned int base = static_cast<unsigned int>(geometry.vertices.size() / 4u);
+      for (const XVECTOR3& point : tri.vertices) {
+        geometry.vertices.push_back(point.x);
+        geometry.vertices.push_back(point.y + m_editorNavMeshDebugOffset + 0.02f);
+        geometry.vertices.push_back(point.z);
+        geometry.vertices.push_back(1.0f);
+      }
+      geometry.indices.insert(geometry.indices.end(), {
+          base + 0u, base + 1u,
+          base + 1u, base + 2u,
+          base + 2u, base + 0u});
+    };
+
+    for (const t850::navigation::NavTriangleClassification& tri : m_editorNavMeshClassification.triangles) {
+      if (tri.included) {
+        appendTriangle(tri.area == 0 ? Included : AreaCost, tri);
+        continue;
+      }
+      if (tri.reason == t850::navigation::NavTriangleClassificationReason::ExcludedByVolume) {
+        appendTriangle(ExcludedVolume, tri);
+      } else if (tri.reason == t850::navigation::NavTriangleClassificationReason::OutsideIncludeVolume) {
+        appendTriangle(OutsideInclude, tri);
+      } else {
+        appendTriangle(ExcludedSlope, tri);
+      }
+    }
+
+    for (std::size_t bucketIndex = 0; bucketIndex < buckets.size(); ++bucketIndex) {
+      const BucketGeometry& bucket = buckets[bucketIndex];
+      if (bucket.vertices.empty() || bucket.indices.empty()) {
+        continue;
+      }
+      GizmoCache& cache = g_navMeshClassificationGizmos[bucketIndex];
+      cache.vb = EditorLineRenderer::CreatePositionVB(
+          bucket.vertices.data(),
+          static_cast<unsigned>(bucket.vertices.size() / 4u));
+      cache.ib = EditorLineRenderer::CreateIndexBuffer32(
+          bucket.indices.data(),
+          static_cast<unsigned>(bucket.indices.size()));
+      cache.count = static_cast<unsigned>(bucket.indices.size());
+    }
+  }
+
+  const XVECTOR3 colors[Bucket::Count] = {
+      XVECTOR3(0.18f, 0.42f, 0.95f, 1.0f),
+      XVECTOR3(0.95f, 0.45f, 1.0f, 1.0f),
+      XVECTOR3(1.0f, 0.15f, 0.08f, 1.0f),
+      XVECTOR3(0.22f, 0.22f, 0.22f, 1.0f),
+      XVECTOR3(0.55f, 0.55f, 0.55f, 1.0f)
+  };
+  XMATRIX44 identity;
+  XMatIdentity(identity);
+  for (std::size_t bucketIndex = 0; bucketIndex < g_navMeshClassificationGizmos.size(); ++bucketIndex) {
+    GizmoCache& cache = g_navMeshClassificationGizmos[bucketIndex];
+    if (!cache.vb || !cache.ib || cache.count == 0) {
+      continue;
+    }
+    lines.DrawLines(identity,
+                    vp,
+                    colors[bucketIndex],
+                    cache.vb,
+                    cache.ib,
+                    cache.count,
+                    sizeof(float) * 4,
+                    t850::IndexBufferFormat::R32);
+  }
 }
 
 bool EditorApp::CreateEditorNavMesh() {
@@ -2486,6 +2669,16 @@ bool EditorApp::CreateEditorNavMesh() {
     }
   }
 
+  if (t850::navigation::ClassifyNavMeshTriangles(
+          geometry,
+          m_editorNavMeshBuildSettings,
+          m_editorNavMeshClassification,
+          &error)) {
+    m_editorNavMeshClassificationReady = true;
+    m_editorNavMeshClassificationDirty = false;
+    ReleaseNavMeshClassificationGizmos();
+  }
+
   t850::navigation::NavMesh builtNavMesh;
   if (!builtNavMesh.Build(geometry, m_editorNavMeshBuildSettings, &error)) {
     m_editorNavMeshStatus = "Build failed: " + error;
@@ -2536,6 +2729,7 @@ void EditorApp::DestroyEditorNavMesh() {
   m_editorSelectedNavVolume = -1;
   m_editorSelectedNavLink = -1;
   m_editorNavLinkPickMode = 0;
+  InvalidateEditorNavMeshClassification();
   m_editorNavMeshStatus = "NavMesh destroyed.";
   DumpEditorNavMeshWireGeometry("destroy");
   if (g_selectionType == 4) {
@@ -2918,9 +3112,19 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
   ImGui::SameLine();
   ImGui::Checkbox("Wireframe", &m_editorNavMeshShowWire);
 
-  ImGui::SliderFloat("Debug Vertical Offset", &m_editorNavMeshDebugOffset, 0.0f, 0.25f, "%.3f");
+  if (ImGui::SliderFloat("Debug Vertical Offset", &m_editorNavMeshDebugOffset, 0.0f, 0.25f, "%.3f")) {
+    ReleaseNavMeshClassificationGizmos();
+  }
   const char* debugShapeOptions[] = { "Geometry", "Nodes" };
   ImGui::Combo("Debug Shape", &m_editorNavMeshDebugShapeMode, debugShapeOptions, 2);
+  if (ImGui::Checkbox("Source Preview Overlay", &m_editorNavMeshShowSourcePreview)) {
+    InvalidateEditorNavMeshClassification();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Refresh Source Preview")) {
+    InvalidateEditorNavMeshClassification();
+    UpdateEditorNavMeshClassification();
+  }
 
   if (m_editorNavMesh.IsReady()) {
     const t850::navigation::NavMeshBuildStats& stats = m_editorNavMesh.GetStats();
@@ -2939,6 +3143,13 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
   }
   if (!m_editorNavMeshStatus.empty()) {
     ImGui::TextWrapped("%s", m_editorNavMeshStatus.c_str());
+  }
+  if (m_editorNavMeshClassificationReady) {
+    ImGui::TextDisabled("Source preview: included=%d excluded volume=%d outside bounds=%d slope=%d",
+                        m_editorNavMeshClassification.includedCount,
+                        m_editorNavMeshClassification.excludedByVolumeCount,
+                        m_editorNavMeshClassification.outsideIncludeVolumeCount,
+                        m_editorNavMeshClassification.excludedBySlopeCount);
   }
   if (m_editorNavMeshDirty) {
     ImGui::TextColored(ImVec4(1.0f, 0.75f, 0.1f, 1.0f), "Preview is stale. Click Re-generate.");
@@ -8682,6 +8893,9 @@ void EditorApp::RenderEditorSceneFrame(t850::BaseDriver* drv, bool captureFrozen
           g_godRaysVolume,
           g_selectionType == 8,
           g_godRaysVolumeGizmo);
+    }
+    if (m_editorNavMeshAuthored && m_editorNavMeshVisible) {
+      DrawNavMeshClassificationOverlay(m_lines, cam.VP);
     }
     if (g_navMeshVolumeGizmos.size() > m_editorNavMeshVolumes.size()) {
       for (std::size_t i = m_editorNavMeshVolumes.size(); i < g_navMeshVolumeGizmos.size(); ++i) {

--- a/T850/T8ditor/EditorApp.cpp
+++ b/T850/T8ditor/EditorApp.cpp
@@ -143,6 +143,8 @@ struct EditorUndoState {
   int selectionType = 0;
   int selectedIdx = -1;
   int selectedSplinePoint = -1;
+  int selectedNavVolume = -1;
+  int selectedNavLink = -1;
   int activeCameraIdx = -1;
 };
 
@@ -2369,11 +2371,44 @@ void EditorApp::ResetEditorNavMeshState(bool keepSettings) {
   m_editorNavMeshVolumes.clear();
   m_editorNavMeshLinks.clear();
   m_editorNavMeshNodes.clear();
+  m_editorSelectedNavVolume = -1;
   m_editorSelectedNavLink = -1;
   m_editorNavLinkPickMode = 0;
   if (!keepSettings) {
     m_editorNavMeshBuildSettings = DefaultEditorNavMeshBuildSettings();
   }
+}
+
+void EditorApp::MarkEditorNavMeshDirty(const std::string& status) {
+  m_editorNavMeshDirty = true;
+  m_editorNavMeshAuthored = true;
+  m_editorNavMeshStatus = status.empty()
+      ? "NavMesh authoring changed. Click Re-generate to update the preview."
+      : status;
+}
+
+bool EditorApp::DeleteSelectedNavAuthoringChild() {
+  if (m_editorSelectedNavVolume >= 0 &&
+      m_editorSelectedNavVolume < static_cast<int>(m_editorNavMeshVolumes.size())) {
+    m_editorNavMeshVolumes.erase(m_editorNavMeshVolumes.begin() + m_editorSelectedNavVolume);
+    m_editorSelectedNavVolume = m_editorNavMeshVolumes.empty()
+        ? -1
+        : std::clamp(m_editorSelectedNavVolume, 0, static_cast<int>(m_editorNavMeshVolumes.size()) - 1);
+    m_editorSelectedNavLink = -1;
+    MarkEditorNavMeshDirty("NavMesh volume deleted. Click Re-generate.");
+    return true;
+  }
+  if (m_editorSelectedNavLink >= 0 &&
+      m_editorSelectedNavLink < static_cast<int>(m_editorNavMeshLinks.size())) {
+    m_editorNavMeshLinks.erase(m_editorNavMeshLinks.begin() + m_editorSelectedNavLink);
+    m_editorSelectedNavLink = m_editorNavMeshLinks.empty()
+        ? -1
+        : std::clamp(m_editorSelectedNavLink, 0, static_cast<int>(m_editorNavMeshLinks.size()) - 1);
+    m_editorSelectedNavVolume = -1;
+    MarkEditorNavMeshDirty("Authored link deleted. Click Re-generate.");
+    return true;
+  }
+  return false;
 }
 
 bool EditorApp::CreateEditorNavMesh() {
@@ -2489,6 +2524,11 @@ void EditorApp::DestroyEditorNavMesh() {
   m_editorNavMeshAuthored = false;
   m_editorNavMeshLastBuildMs = 0.0f;
   m_editorNavMeshDirty = false;
+  m_editorNavMeshVolumes.clear();
+  m_editorNavMeshLinks.clear();
+  m_editorSelectedNavVolume = -1;
+  m_editorSelectedNavLink = -1;
+  m_editorNavLinkPickMode = 0;
   m_editorNavMeshStatus = "NavMesh destroyed.";
   DumpEditorNavMeshWireGeometry("destroy");
   if (g_selectionType == 4) {
@@ -2506,6 +2546,10 @@ void EditorApp::RestoreEditorNavMeshFromScene(const t850::scene::SceneNavigation
   m_editorNavMeshDebugShapeMode = std::clamp(desc.debug_shape_mode, 0, 1);
   m_editorNavMeshVolumes = desc.volumes;
   m_editorNavMeshLinks = desc.authored_links;
+  if (m_editorSelectedNavVolume < 0 ||
+      m_editorSelectedNavVolume >= static_cast<int>(m_editorNavMeshVolumes.size())) {
+    m_editorSelectedNavVolume = -1;
+  }
   m_editorNavMeshDirty = false;
   m_editorSelectedNavLink = m_editorNavMeshLinks.empty() ? -1 : std::clamp(m_editorSelectedNavLink, 0, static_cast<int>(m_editorNavMeshLinks.size()) - 1);
   m_editorNavLinkPickMode = 0;
@@ -2896,6 +2940,131 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
   if (m_editorNavMesh.IsReady() && m_editorNavMeshNodes.empty()) {
     RefreshEditorNavMeshNodes();
   }
+  ImGui::SeparatorText("Authoring Volumes");
+  ImGui::TextDisabled("Volumes are saved in .t8scene as NavMesh build helpers, not game objects.");
+  auto makeDefaultVolume = [&](const char* type, const char* label) {
+    t850::scene::SceneNavMeshVolumeDesc volume;
+    volume.name = std::string(label) + " " + std::to_string(m_editorNavMeshVolumes.size() + 1);
+    volume.type = type;
+    volume.shape = "box";
+    volume.enabled = true;
+    volume.visible = true;
+    volume.show_wire = true;
+    if (std::strcmp(type, "include_bounds") == 0) {
+      t850::AABB bounds;
+      if (GetEditorNavMeshWorldAABB(bounds)) {
+        const XVECTOR3 center = bounds.Center();
+        const XVECTOR3 extents = bounds.Extents();
+        volume.position = {center.x, center.y, center.z};
+        volume.half_extents = {
+            (std::max)(1.0f, extents.x * 0.55f),
+            (std::max)(1.0f, extents.y * 0.55f),
+            (std::max)(1.0f, extents.z * 0.55f)};
+      } else {
+        volume.half_extents = {32.0f, 16.0f, 32.0f};
+      }
+    } else if (std::strcmp(type, "area_cost") == 0) {
+      volume.area = "mud";
+      volume.cost = 3.0f;
+    }
+    m_editorNavMeshVolumes.push_back(volume);
+    m_editorSelectedNavVolume = static_cast<int>(m_editorNavMeshVolumes.size()) - 1;
+    m_editorSelectedNavLink = -1;
+    g_selectionType = 4;
+    g_selectedIdx = 0;
+    ClearMixedSelection();
+    MarkEditorNavMeshDirty("NavMesh volume added. Click Re-generate.");
+  };
+  if (ImGui::Button("Add Include Bounds")) makeDefaultVolume("include_bounds", "Include Bounds");
+  ImGui::SameLine();
+  if (ImGui::Button("Add Exclude Volume")) makeDefaultVolume("exclude", "Exclude Volume");
+  if (ImGui::Button("Add Area Cost Volume")) makeDefaultVolume("area_cost", "Area Cost Volume");
+
+  if (!m_editorNavMeshVolumes.empty()) {
+    if (m_editorSelectedNavVolume >= static_cast<int>(m_editorNavMeshVolumes.size())) {
+      m_editorSelectedNavVolume = -1;
+    }
+    const char* volumePreview = m_editorSelectedNavVolume >= 0
+        ? m_editorNavMeshVolumes[static_cast<std::size_t>(m_editorSelectedNavVolume)].name.c_str()
+        : "None";
+    if (ImGui::BeginCombo("Selected Volume", volumePreview)) {
+      for (int volumeIndex = 0; volumeIndex < static_cast<int>(m_editorNavMeshVolumes.size()); ++volumeIndex) {
+        const bool selected = volumeIndex == m_editorSelectedNavVolume;
+        if (ImGui::Selectable(m_editorNavMeshVolumes[static_cast<std::size_t>(volumeIndex)].name.c_str(), selected)) {
+          m_editorSelectedNavVolume = volumeIndex;
+          m_editorSelectedNavLink = -1;
+          g_selectionType = 4;
+          g_selectedIdx = 0;
+          ClearMixedSelection();
+        }
+        if (selected) ImGui::SetItemDefaultFocus();
+      }
+      ImGui::EndCombo();
+    }
+
+    if (m_editorSelectedNavVolume < 0) {
+      ImGui::TextDisabled("Select or create a volume to edit it.");
+    } else {
+      t850::scene::SceneNavMeshVolumeDesc& volume = m_editorNavMeshVolumes[static_cast<std::size_t>(m_editorSelectedNavVolume)];
+      bool volumeChanged = false;
+      volumeChanged |= InputTextString("Volume Name", volume.name);
+      const char* volumeTypes[] = { "include_bounds", "exclude", "area_cost" };
+      int typeIndex = 1;
+      for (int i = 0; i < 3; ++i) {
+        if (volume.type == volumeTypes[i]) typeIndex = i;
+      }
+      if (ImGui::Combo("Volume Type", &typeIndex, volumeTypes, 3)) {
+        volume.type = volumeTypes[typeIndex];
+        if (volume.type == "area_cost" && volume.area == "walkable") {
+          volume.area = "mud";
+          volume.cost = (std::max)(volume.cost, 3.0f);
+        }
+        volumeChanged = true;
+      }
+      volumeChanged |= ImGui::Checkbox("Volume Enabled", &volume.enabled);
+      volumeChanged |= ImGui::Checkbox("Volume Visible", &volume.visible);
+      volumeChanged |= ImGui::Checkbox("Volume Frozen", &volume.frozen);
+      volumeChanged |= ImGui::Checkbox("Volume Wireframe", &volume.show_wire);
+      float volumePosition[3] = {volume.position.x, volume.position.y, volume.position.z};
+      if (ImGui::DragFloat3("Volume Position", volumePosition, 0.1f, -100000.0f, 100000.0f, "%.3f")) {
+        volume.position = {volumePosition[0], volumePosition[1], volumePosition[2]};
+        volumeChanged = true;
+      }
+      float volumeRotation[3] = {volume.rotation.x, volume.rotation.y, volume.rotation.z};
+      if (ImGui::DragFloat3("Volume Rotation", volumeRotation, 0.01f, -1000.0f, 1000.0f, "%.3f")) {
+        volume.rotation = {volumeRotation[0], volumeRotation[1], volumeRotation[2]};
+        volumeChanged = true;
+      }
+      float volumeHalfExtents[3] = {volume.half_extents.x, volume.half_extents.y, volume.half_extents.z};
+      if (ImGui::DragFloat3("Volume Half Extents", volumeHalfExtents, 0.1f, 0.001f, 100000.0f, "%.3f")) {
+        volume.half_extents = {
+            (std::max)(0.001f, volumeHalfExtents[0]),
+            (std::max)(0.001f, volumeHalfExtents[1]),
+            (std::max)(0.001f, volumeHalfExtents[2])};
+        volumeChanged = true;
+      }
+      if (volume.type == "area_cost") {
+        const char* areaOptions[] = { "walkable", "drop", "jump", "jump_pad", "jump_intent", "water", "door", "mud", "custom" };
+        int areaIndex = 7;
+        for (int i = 0; i < static_cast<int>(sizeof(areaOptions) / sizeof(areaOptions[0])); ++i) {
+          if (volume.area == areaOptions[i]) areaIndex = i;
+        }
+        if (ImGui::Combo("Area", &areaIndex, areaOptions, static_cast<int>(sizeof(areaOptions) / sizeof(areaOptions[0])))) {
+          volume.area = areaOptions[areaIndex];
+          volumeChanged = true;
+        }
+        volumeChanged |= ImGui::DragFloat("Area Cost", &volume.cost, 0.05f, 0.01f, 100.0f, "%.2f");
+      }
+      if (ImGui::Button("Delete Volume")) {
+        DeleteSelectedNavAuthoringChild();
+      } else if (volumeChanged) {
+        MarkEditorNavMeshDirty("NavMesh volume changed. Click Re-generate.");
+      }
+    }
+  } else {
+    ImGui::TextDisabled("No authored volumes.");
+  }
+
   ImGui::SeparatorText("Authored Links");
   ImGui::TextDisabled("Links snap to Detour polygon-center nodes. Use Pick Start/Pick End, then click the viewport.");
   if (ImGui::Button("Refresh Nodes")) {
@@ -2927,6 +3096,7 @@ void EditorApp::DrawNavMeshAuthoringPanel() {
     link.end = { end.x, end.y, end.z };
     m_editorNavMeshLinks.push_back(link);
     m_editorSelectedNavLink = static_cast<int>(m_editorNavMeshLinks.size()) - 1;
+    m_editorSelectedNavVolume = -1;
     markNavMeshDirty();
     m_editorNavMeshStatus = "Authored link added. Click Re-generate.";
   };
@@ -3726,6 +3896,8 @@ EditorUndoState EditorApp::CaptureEditorUndoState(std::string* outKey) {
   state.selectionType = g_selectionType;
   state.selectedIdx = g_selectedIdx;
   state.selectedSplinePoint = g_selectedSplinePoint;
+  state.selectedNavVolume = m_editorSelectedNavVolume;
+  state.selectedNavLink = m_editorSelectedNavLink;
   state.activeCameraIdx = g_activeCameraIdx;
   if (outKey) {
     *outKey = EditorUndoStateKey(state);
@@ -3947,6 +4119,8 @@ void EditorApp::ApplyEditorUndoState(const EditorUndoState& state) {
   g_selectionType = state.selectionType;
   g_selectedIdx = state.selectedIdx;
   g_selectedSplinePoint = state.selectedSplinePoint;
+  m_editorSelectedNavVolume = state.selectedNavVolume;
+  m_editorSelectedNavLink = state.selectedNavLink;
   if ((g_selectionType == 0 && (g_selectedIdx < 0 || g_selectedIdx >= static_cast<int>(g_objects.size()))) ||
       (g_selectionType == 1 && (g_selectedIdx < 0 || g_selectedIdx >= static_cast<int>(g_cameras.size()))) ||
       (g_selectionType == 2 && (g_selectedIdx < 0 || g_selectedIdx >= static_cast<int>(g_lights.size()))) ||
@@ -3963,6 +4137,12 @@ void EditorApp::ApplyEditorUndoState(const EditorUndoState& state) {
     g_selectedIdx = -1;
     g_selectedSplinePoint = -1;
     g_selectionType = 0;
+  }
+  if (m_editorSelectedNavVolume < -1 || m_editorSelectedNavVolume >= static_cast<int>(m_editorNavMeshVolumes.size())) {
+    m_editorSelectedNavVolume = -1;
+  }
+  if (m_editorSelectedNavLink < -1 || m_editorSelectedNavLink >= static_cast<int>(m_editorNavMeshLinks.size())) {
+    m_editorSelectedNavLink = -1;
   }
   if (g_multiEntitySelect.empty() && (g_selectionType == 0 || g_selectionType == 3)) {
     AddMixedSelection(g_selectionType, g_selectedIdx);
@@ -6495,8 +6675,10 @@ void EditorApp::OnInput() {
       T8_LOG_INFO("[T8ditor] Physics entity deleted");
     }
     else if (g_selectionType == 4 && g_selectedIdx == 0) {
-      DestroyEditorNavMesh();
-      T8_LOG_INFO("[T8ditor] NavMesh deleted");
+      if (!DeleteSelectedNavAuthoringChild()) {
+        DestroyEditorNavMesh();
+        T8_LOG_INFO("[T8ditor] NavMesh deleted");
+      }
     }
     else if (g_selectionType == 8 && g_selectedIdx == 0) {
       g_godRaysVolume.authored = false;
@@ -8628,7 +8810,9 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
       } else if (g_selectionType == 3 && g_selectedIdx < (int)g_physicsEntities.size()) {
         DestroyPhysicsEntity(m_physics, g_selectedIdx);
       } else if (g_selectionType == 4 && g_selectedIdx == 0) {
-        DestroyEditorNavMesh();
+        if (!DeleteSelectedNavAuthoringChild()) {
+          DestroyEditorNavMesh();
+        }
       } else if (g_selectionType == 8 && g_selectedIdx == 0) {
         g_godRaysVolume.authored = false;
         g_godRaysVolume.enabled = false;
@@ -9591,30 +9775,63 @@ void EditorApp::DrawEditorUI(t850::BaseDriver* drv) {
             if (ImGui::IsItemClicked() && !m_editorNavMeshFrozen) {
               g_selectedIdx = 0;
               g_selectionType = 4;
+              m_editorSelectedNavVolume = -1;
+              m_editorSelectedNavLink = -1;
               ClearMixedSelection();
             }
             if (m_editorNavMeshFrozen) ImGui::PopStyleColor();
             if (nodeOpen) {
-              for (int linkIndex = 0; linkIndex < static_cast<int>(m_editorNavMeshLinks.size()); ++linkIndex) {
-                t850::scene::SceneNavMeshLinkDesc& link = m_editorNavMeshLinks[static_cast<std::size_t>(linkIndex)];
-                ImGui::PushID(linkIndex + 61000);
-                ImGui::Checkbox("##linkVis", &link.visible); ImGui::SameLine();
-                ImGui::Checkbox("##linkFrz", &link.frozen); ImGui::SameLine();
-                ImGui::Checkbox("##linkWir", &link.show_wire); ImGui::SameLine();
-                ImGuiTreeNodeFlags linkFlags = ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_SpanAvailWidth;
-                if (linkIndex == m_editorSelectedNavLink) linkFlags |= ImGuiTreeNodeFlags_Selected;
-                if (link.frozen) ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f,0.5f,0.5f,1));
-                const std::string linkLabel = "[L] " + link.name + " (" + link.type + ")";
-                const bool linkOpen = ImGui::TreeNodeEx(linkLabel.c_str(), linkFlags);
-                if (ImGui::IsItemClicked() && !link.frozen) {
-                  m_editorSelectedNavLink = linkIndex;
-                  g_selectedIdx = 0;
-                  g_selectionType = 4;
-                  ClearMixedSelection();
+              if (!m_editorNavMeshVolumes.empty() &&
+                  ImGui::TreeNodeEx("Volumes", ImGuiTreeNodeFlags_DefaultOpen)) {
+                for (int volumeIndex = 0; volumeIndex < static_cast<int>(m_editorNavMeshVolumes.size()); ++volumeIndex) {
+                  t850::scene::SceneNavMeshVolumeDesc& volume = m_editorNavMeshVolumes[static_cast<std::size_t>(volumeIndex)];
+                  ImGui::PushID(volumeIndex + 60500);
+                  ImGui::Checkbox("##volumeVis", &volume.visible); ImGui::SameLine();
+                  ImGui::Checkbox("##volumeFrz", &volume.frozen); ImGui::SameLine();
+                  ImGui::Checkbox("##volumeWir", &volume.show_wire); ImGui::SameLine();
+                  ImGuiTreeNodeFlags volumeFlags = ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_SpanAvailWidth;
+                  if (volumeIndex == m_editorSelectedNavVolume) volumeFlags |= ImGuiTreeNodeFlags_Selected;
+                  if (volume.frozen) ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f,0.5f,0.5f,1));
+                  const std::string volumeLabel = "[V] " + volume.name + " (" + volume.type + ")";
+                  const bool volumeOpen = ImGui::TreeNodeEx(volumeLabel.c_str(), volumeFlags);
+                  if (ImGui::IsItemClicked() && !volume.frozen) {
+                    m_editorSelectedNavVolume = volumeIndex;
+                    m_editorSelectedNavLink = -1;
+                    g_selectedIdx = 0;
+                    g_selectionType = 4;
+                    ClearMixedSelection();
+                  }
+                  if (volume.frozen) ImGui::PopStyleColor();
+                  if (volumeOpen) ImGui::TreePop();
+                  ImGui::PopID();
                 }
-                if (link.frozen) ImGui::PopStyleColor();
-                if (linkOpen) ImGui::TreePop();
-                ImGui::PopID();
+                ImGui::TreePop();
+              }
+              if (!m_editorNavMeshLinks.empty() &&
+                  ImGui::TreeNodeEx("Links", ImGuiTreeNodeFlags_DefaultOpen)) {
+                for (int linkIndex = 0; linkIndex < static_cast<int>(m_editorNavMeshLinks.size()); ++linkIndex) {
+                  t850::scene::SceneNavMeshLinkDesc& link = m_editorNavMeshLinks[static_cast<std::size_t>(linkIndex)];
+                  ImGui::PushID(linkIndex + 61000);
+                  ImGui::Checkbox("##linkVis", &link.visible); ImGui::SameLine();
+                  ImGui::Checkbox("##linkFrz", &link.frozen); ImGui::SameLine();
+                  ImGui::Checkbox("##linkWir", &link.show_wire); ImGui::SameLine();
+                  ImGuiTreeNodeFlags linkFlags = ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_SpanAvailWidth;
+                  if (linkIndex == m_editorSelectedNavLink) linkFlags |= ImGuiTreeNodeFlags_Selected;
+                  if (link.frozen) ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f,0.5f,0.5f,1));
+                  const std::string linkLabel = "[L] " + link.name + " (" + link.type + ")";
+                  const bool linkOpen = ImGui::TreeNodeEx(linkLabel.c_str(), linkFlags);
+                  if (ImGui::IsItemClicked() && !link.frozen) {
+                    m_editorSelectedNavLink = linkIndex;
+                    m_editorSelectedNavVolume = -1;
+                    g_selectedIdx = 0;
+                    g_selectionType = 4;
+                    ClearMixedSelection();
+                  }
+                  if (link.frozen) ImGui::PopStyleColor();
+                  if (linkOpen) ImGui::TreePop();
+                  ImGui::PopID();
+                }
+                ImGui::TreePop();
               }
               ImGui::TreePop();
             }

--- a/T850/T8ditor/EditorApp.h
+++ b/T850/T8ditor/EditorApp.h
@@ -241,6 +241,8 @@ namespace t8ditor {
     bool m_editorNavMeshShowWire = true;
     bool m_editorNavMeshShowSourcePreview = true;
     bool m_editorNavMeshAuthoringMode = false;
+    std::string m_editorNavMeshRuntimeMode = "build_cached";
+    std::string m_editorNavMeshBakedAsset;
     float m_editorNavMeshDebugOffset = 0.01f;
     int m_editorNavMeshDebugShapeMode = 0;
     float m_editorNavMeshLastBuildMs = 0.0f;

--- a/T850/T8ditor/EditorApp.h
+++ b/T850/T8ditor/EditorApp.h
@@ -165,6 +165,8 @@ namespace t8ditor {
     bool CreateEditorNavMesh();
     void DestroyEditorNavMesh();
     void ResetEditorNavMeshState(bool keepSettings = false);
+    void MarkEditorNavMeshDirty(const std::string& status);
+    bool DeleteSelectedNavAuthoringChild();
     void RestoreEditorNavMeshFromScene(const t850::scene::SceneNavigationMeshDesc& desc);
     t850::scene::SceneNavigationMeshDesc BuildEditorNavMeshDesc() const;
     bool GetEditorNavMeshWorldAABB(t850::AABB& outBounds) const;
@@ -239,6 +241,7 @@ namespace t8ditor {
     std::vector<t850::scene::SceneNavMeshVolumeDesc> m_editorNavMeshVolumes;
     std::vector<t850::scene::SceneNavMeshLinkDesc> m_editorNavMeshLinks;
     std::vector<XVECTOR3> m_editorNavMeshNodes;
+    int m_editorSelectedNavVolume = -1;
     int m_editorSelectedNavLink = -1;
     int m_editorNavLinkPickMode = 0; // 0=none, 1=start, 2=end
     t850::VertexBuffer* m_editorNavLinkOverlayVB = nullptr;

--- a/T850/T8ditor/EditorApp.h
+++ b/T850/T8ditor/EditorApp.h
@@ -236,6 +236,7 @@ namespace t8ditor {
     int m_editorNavMeshDebugShapeMode = 0;
     float m_editorNavMeshLastBuildMs = 0.0f;
     bool m_editorNavMeshDirty = false;
+    std::vector<t850::scene::SceneNavMeshVolumeDesc> m_editorNavMeshVolumes;
     std::vector<t850::scene::SceneNavMeshLinkDesc> m_editorNavMeshLinks;
     std::vector<XVECTOR3> m_editorNavMeshNodes;
     int m_editorSelectedNavLink = -1;

--- a/T850/T8ditor/EditorApp.h
+++ b/T850/T8ditor/EditorApp.h
@@ -172,6 +172,9 @@ namespace t8ditor {
     bool GetEditorNavMeshWorldAABB(t850::AABB& outBounds) const;
     void DrawNavMeshAuthoringPanel();
     void RefreshEditorNavMeshNodes();
+    void InvalidateEditorNavMeshClassification();
+    bool UpdateEditorNavMeshClassification();
+    void DrawNavMeshClassificationOverlay(EditorLineRenderer& lines, const XMATRIX44& vp);
     bool PickEditorNavMeshNodeFromMouse(int mouseX, int mouseY, int& outNodeIndex, XVECTOR3& outNodePosition) const;
     void DrawSelectedNavLinkOverlay(t850::Texture* depthTexture, t850::Texture* secondaryDepthTexture, const Camera& cam);
     void UpdateEditorSplinePreview(float deltaSeconds);
@@ -234,12 +237,16 @@ namespace t8ditor {
     bool m_editorNavMeshVisible = true;
     bool m_editorNavMeshFrozen = false;
     bool m_editorNavMeshShowWire = true;
+    bool m_editorNavMeshShowSourcePreview = true;
     float m_editorNavMeshDebugOffset = 0.01f;
     int m_editorNavMeshDebugShapeMode = 0;
     float m_editorNavMeshLastBuildMs = 0.0f;
     bool m_editorNavMeshDirty = false;
     std::vector<t850::scene::SceneNavMeshVolumeDesc> m_editorNavMeshVolumes;
     std::vector<t850::scene::SceneNavMeshLinkDesc> m_editorNavMeshLinks;
+    t850::navigation::NavMeshClassificationResult m_editorNavMeshClassification;
+    bool m_editorNavMeshClassificationReady = false;
+    bool m_editorNavMeshClassificationDirty = true;
     std::vector<XVECTOR3> m_editorNavMeshNodes;
     int m_editorSelectedNavVolume = -1;
     int m_editorSelectedNavLink = -1;

--- a/T850/T8ditor/EditorApp.h
+++ b/T850/T8ditor/EditorApp.h
@@ -216,6 +216,7 @@ namespace t8ditor {
     int                   m_meshPrimId = -1;  // -1 = no lit mesh loaded
     XMATRIX44             m_vp;               // VP matrix for the prim mgr
     Camera                m_editorLightCamera;
+    std::vector<Camera>   m_editorRuntimeLightCameras;
     t850::SceneSetup      m_editorSceneSetup;
     GaussFilter           m_editorShadowFilter;
     GaussFilter           m_editorBloomFilter;

--- a/T850/T8ditor/EditorApp.h
+++ b/T850/T8ditor/EditorApp.h
@@ -175,6 +175,8 @@ namespace t8ditor {
     void InvalidateEditorNavMeshClassification();
     bool UpdateEditorNavMeshClassification();
     void DrawNavMeshClassificationOverlay(EditorLineRenderer& lines, const XMATRIX44& vp);
+    bool PickEditorNavMeshTriangleFromMouse(int mouseX, int mouseY, int& outTriangleIndex) const;
+    bool CreateNavVolumeFromSelectedTriangle(const char* type);
     bool PickEditorNavMeshNodeFromMouse(int mouseX, int mouseY, int& outNodeIndex, XVECTOR3& outNodePosition) const;
     void DrawSelectedNavLinkOverlay(t850::Texture* depthTexture, t850::Texture* secondaryDepthTexture, const Camera& cam);
     void UpdateEditorSplinePreview(float deltaSeconds);
@@ -238,6 +240,7 @@ namespace t8ditor {
     bool m_editorNavMeshFrozen = false;
     bool m_editorNavMeshShowWire = true;
     bool m_editorNavMeshShowSourcePreview = true;
+    bool m_editorNavMeshAuthoringMode = false;
     float m_editorNavMeshDebugOffset = 0.01f;
     int m_editorNavMeshDebugShapeMode = 0;
     float m_editorNavMeshLastBuildMs = 0.0f;
@@ -250,6 +253,7 @@ namespace t8ditor {
     std::vector<XVECTOR3> m_editorNavMeshNodes;
     int m_editorSelectedNavVolume = -1;
     int m_editorSelectedNavLink = -1;
+    int m_editorSelectedNavTriangle = -1;
     int m_editorNavLinkPickMode = 0; // 0=none, 1=start, 2=end
     t850::VertexBuffer* m_editorNavLinkOverlayVB = nullptr;
     t850::IndexBuffer* m_editorNavLinkOverlayIB = nullptr;

--- a/T850/T8ditor/EditorApp.h
+++ b/T850/T8ditor/EditorApp.h
@@ -53,6 +53,7 @@
 #include <string>
 #include <memory>
 #include <chrono>
+#include <set>
 
 #include "EditorCamera.h"
 #include "EditorLineRenderer.h"
@@ -177,6 +178,7 @@ namespace t8ditor {
     void DrawNavMeshClassificationOverlay(EditorLineRenderer& lines, const XMATRIX44& vp);
     bool PickEditorNavMeshTriangleFromMouse(int mouseX, int mouseY, int& outTriangleIndex) const;
     bool CreateNavVolumeFromSelectedTriangle(const char* type);
+    bool CreateNavVolumeFromSelectedTriangles(const char* type);
     bool PickEditorNavMeshNodeFromMouse(int mouseX, int mouseY, int& outNodeIndex, XVECTOR3& outNodePosition) const;
     void DrawSelectedNavLinkOverlay(t850::Texture* depthTexture, t850::Texture* secondaryDepthTexture, const Camera& cam);
     void UpdateEditorSplinePreview(float deltaSeconds);
@@ -256,6 +258,9 @@ namespace t8ditor {
     int m_editorSelectedNavVolume = -1;
     int m_editorSelectedNavLink = -1;
     int m_editorSelectedNavTriangle = -1;
+    std::set<int> m_editorSelectedNavTriangles;
+    bool m_editorNavMeshBrushSelect = false;
+    float m_editorNavMeshBrushRadius = 4.0f;
     int m_editorNavLinkPickMode = 0; // 0=none, 1=start, 2=end
     t850::VertexBuffer* m_editorNavLinkOverlayVB = nullptr;
     t850::IndexBuffer* m_editorNavLinkOverlayIB = nullptr;

--- a/T850/T8ditor/EditorImGui.cpp
+++ b/T850/T8ditor/EditorImGui.cpp
@@ -645,7 +645,8 @@ int ImGuiDrawToolbar(int currentMode, int& addCamera, int& addLight,
                      bool& wantsClone, bool& wantsGroup, bool& wantsUngroup,
                      bool& wantsPlayScene,
                      bool hasSelection, bool hasMultiSelect,
-                     int& cameraMode) {
+                     int& cameraMode,
+                     bool& navMeshAuthoringMode) {
   addCamera = -1;
   addLight  = -1;
   wantsClone = false;
@@ -696,6 +697,18 @@ int ImGuiDrawToolbar(int currentMode, int& addCamera, int& addLight,
 
     if (ImGui::Button("Play Scene", ImVec2(ToolbarButtonWidth("Play Scene", 98.0f), 0)))
       wantsPlayScene = true;
+
+    ImGui::SameLine();
+    ImGui::TextColored(mutedText, "  |  ");
+    ImGui::SameLine();
+
+    const bool navModeActive = navMeshAuthoringMode;
+    if (navModeActive)
+      ImGui::PushStyleColor(ImGuiCol_Button, activeCol);
+    if (ImGui::Button("NavMesh", ImVec2(ToolbarButtonWidth("NavMesh", 86.0f), 0)))
+      navMeshAuthoringMode = !navMeshAuthoringMode;
+    if (navModeActive)
+      ImGui::PopStyleColor();
 
     ImGui::SameLine();
     ImGui::TextColored(mutedText, "  |  ");

--- a/T850/T8ditor/EditorImGui.cpp
+++ b/T850/T8ditor/EditorImGui.cpp
@@ -604,6 +604,7 @@ MenuAction ImGuiDrawMenuBar(PanelVisibility& panels) {
       ImGui::MenuItem("Console",   nullptr, &panels.showConsole);
       ImGui::MenuItem("Rendering", nullptr, &panels.showRendering);
       ImGui::MenuItem("Timeline",  nullptr, &panels.showTimeline);
+      ImGui::MenuItem("NavMesh Authoring", nullptr, &panels.showNavMeshAuthoring);
       ImGui::Separator();
       ImGui::MenuItem("Wireframe Overlay", nullptr, &panels.showWireframe);
       ImGui::MenuItem("Show Skybox",       nullptr, &panels.showSkybox);

--- a/T850/T8ditor/EditorImGui.h
+++ b/T850/T8ditor/EditorImGui.h
@@ -57,6 +57,7 @@ namespace t8ditor {
     bool showConsole    = true;
     bool showRendering  = true;
     bool showTimeline   = true;
+    bool showNavMeshAuthoring = false;
     bool showWireframe  = false;
     bool showSkybox     = true;
     bool showRTDebug    = false;

--- a/T850/T8ditor/EditorImGui.h
+++ b/T850/T8ditor/EditorImGui.h
@@ -75,7 +75,8 @@ namespace t8ditor {
                        bool& wantsClone, bool& wantsGroup, bool& wantsUngroup,
                        bool& wantsPlayScene,
                        bool hasSelection, bool hasMultiSelect,
-                       int& cameraMode);
+                       int& cameraMode,
+                       bool& navMeshAuthoringMode);
 
   // ── Context menu (right-click) ─────────────────────
   struct ContextAction {

--- a/T850/T8ditor/EditorLineRenderer.cpp
+++ b/T850/T8ditor/EditorLineRenderer.cpp
@@ -5,6 +5,7 @@
 #include "EditorLineRenderer.h"
 
 #include <Config.h>
+#include <scene/RenderQueue.h>
 #include <video/BaseDriver.h>
 #include <utils/Utils.h>
 #include <utils/Log.h>
@@ -111,19 +112,22 @@ void EditorLineRenderer::DrawLines(const XMATRIX44& world,
     m_farPlane,
     0.005f);  // proportional depth bias (wireDepth *= 1 - bias)
 
-  ib->Set(*t850::T8DeviceContext, 0, ibFormat);
-  vb->Set(*t850::T8DeviceContext, vertexStride, 0);
-
-  // Set topology BEFORE shader (Vulkan bakes topology into the pipeline at Set time)
-  t850::T8DeviceContext->SetPrimitiveTopology(t850::Topology::LINE_LIST);
+  t850::MeshDrawStateTracker& tracker = t850::MeshDrawStateTracker::Get();
+  tracker.BindIndexedGeometry(*t850::T8DeviceContext,
+                              vb,
+                              vertexStride,
+                              0,
+                              ib,
+                              ibFormat,
+                              t850::Topology::LINE_LIST);
 
   m_shader->Set(*t850::T8DeviceContext);
-  m_cb->UpdateFromBuffer(*t850::T8DeviceContext, &cb);
-  m_cb->Set(*t850::T8DeviceContext);
+  tracker.OnShaderChanged(m_shader);
+  tracker.UpdateAndBindConstantBuffer(*t850::T8DeviceContext, m_cb, 0, &cb, sizeof(cb));
 #if defined(USING_VULKAN) || defined(USING_VULKAN_ONLY)
   // Vulkan reflection can map VS/FS cbuffers to different bindings when the
   // fragment shader also samples depth. Populate both logical slots.
-  m_cb->Set(*t850::T8DeviceContext, 1);
+  tracker.UpdateAndBindConstantBuffer(*t850::T8DeviceContext, m_cb, 1, &cb, sizeof(cb));
 #endif
 
   // Bind depth texture AFTER shader is set (D3D12 needs active root signature)
@@ -135,9 +139,6 @@ void EditorLineRenderer::DrawLines(const XMATRIX44& world,
   }
 
   t850::T8DeviceContext->DrawIndexed(indexCount, 0, 0);
-
-  // Reset topology back to triangle list for subsequent draws (meshes, ImGui, etc.)
-  t850::T8DeviceContext->SetPrimitiveTopology(t850::Topology::TRIANLE_LIST);
 }
 
 t850::VertexBuffer* EditorLineRenderer::CreatePositionVB(const float* positionsXYZW,

--- a/T850/T8ditor/EditorMesh.cpp
+++ b/T850/T8ditor/EditorMesh.cpp
@@ -118,22 +118,8 @@ bool EditorMesh::Load(const std::string& path) {
   }
 
   unsigned numVerts = (unsigned)(verts.size() / 4);
-  m_vb = EditorLineRenderer::CreatePositionVB(verts.data(), numVerts);
-
-  // Use 16-bit IB when possible (saves memory), 32-bit for large meshes
-  if (numVerts <= 65535) {
-    std::vector<unsigned short> idx16(idx.size());
-    for (size_t i = 0; i < idx.size(); i++)
-      idx16[i] = (unsigned short)idx[i];
-    m_ib = EditorLineRenderer::CreateIndexBuffer16(idx16.data(), (unsigned)idx16.size());
-    m_use32BitIB = false;
-  } else {
-    m_ib = EditorLineRenderer::CreateIndexBuffer32(idx.data(), (unsigned)idx.size());
-    m_use32BitIB = true;
-  }
-
-  m_indexCount = (unsigned)idx.size();
-  if (!m_vb || !m_ib) {
+  if (!m_geometry.CreatePositionBuffer(verts.data(), numVerts) ||
+      !m_geometry.CreateLineIndexBuffer(idx, numVerts)) {
     T8_LOG_ERROR("[T8ditor] EditorMesh: GPU buffer creation failed for '%s'", path.c_str());
     Destroy();
     return false;
@@ -149,7 +135,7 @@ bool EditorMesh::Load(const std::string& path) {
   );
 
   T8_LOG_INFO("[T8ditor] EditorMesh: loaded '%s' (%u verts, %u line indices)",
-              path.c_str(), (unsigned)(verts.size() / 4), m_indexCount);
+              path.c_str(), (unsigned)(verts.size() / 4), m_geometry.GetIndexCount());
   return true;
 }
 
@@ -210,21 +196,8 @@ bool EditorMesh::LoadFromTriangles(const std::string& name,
   }
 
   const unsigned numVerts = static_cast<unsigned>(verts.size() / 4u);
-  m_vb = EditorLineRenderer::CreatePositionVB(verts.data(), numVerts);
-  if (numVerts <= 65535) {
-    std::vector<unsigned short> idx16(idx.size());
-    for (std::size_t i = 0; i < idx.size(); ++i) {
-      idx16[i] = static_cast<unsigned short>(idx[i]);
-    }
-    m_ib = EditorLineRenderer::CreateIndexBuffer16(idx16.data(), static_cast<unsigned>(idx16.size()));
-    m_use32BitIB = false;
-  } else {
-    m_ib = EditorLineRenderer::CreateIndexBuffer32(idx.data(), static_cast<unsigned>(idx.size()));
-    m_use32BitIB = true;
-  }
-
-  m_indexCount = static_cast<unsigned>(idx.size());
-  if (!m_vb || !m_ib) {
+  if (!m_geometry.CreatePositionBuffer(verts.data(), numVerts) ||
+      !m_geometry.CreateLineIndexBuffer(idx, numVerts)) {
     T8_LOG_ERROR("[T8ditor] EditorMesh: GPU buffer creation failed for generated mesh '%s'", name.c_str());
     Destroy();
     return false;
@@ -237,7 +210,7 @@ bool EditorMesh::LoadFromTriangles(const std::string& name,
       XVECTOR3(bbMin[0], bbMin[1], bbMin[2]),
       XVECTOR3(bbMax[0], bbMax[1], bbMax[2]));
   T8_LOG_INFO("[T8ditor] EditorMesh: generated '%s' (%zu verts, %u line indices)",
-              name.c_str(), vertices.size(), m_indexCount);
+              name.c_str(), vertices.size(), m_geometry.GetIndexCount());
   return true;
 }
 
@@ -259,9 +232,7 @@ bool EditorMesh::CloneFrom(const EditorMesh& source) {
 }
 
 void EditorMesh::Destroy() {
-  m_vb = nullptr;
-  m_ib = nullptr;
-  m_indexCount = 0;
+  m_geometry.Destroy();
   m_path.clear();
   m_pickVertices.clear();
   m_pickIndices.clear();
@@ -320,8 +291,14 @@ bool EditorMesh::RaycastSurface(const t850::Ray& ray, float& tOut) const {
 void EditorMesh::Draw(EditorLineRenderer& lines, const XMATRIX44& vp) {
   if (!IsLoaded() || !lines.IsReady()) return;
   XMATRIX44 world = BuildWorld();
-  auto ibFmt = m_use32BitIB ? t850::IndexBufferFormat::R32 : t850::IndexBufferFormat::R16;
-  lines.DrawLines(world, vp, WireColor, m_vb, m_ib, m_indexCount, /*stride=*/16, ibFmt);
+  lines.DrawLines(world,
+                  vp,
+                  WireColor,
+                  m_geometry.GetVertexBuffer(),
+                  m_geometry.GetIndexBuffer(),
+                  m_geometry.GetIndexCount(),
+                  /*stride=*/16,
+                  m_geometry.GetIndexFormat());
 }
 
 } // namespace t8ditor

--- a/T850/T8ditor/EditorMesh.h
+++ b/T850/T8ditor/EditorMesh.h
@@ -18,6 +18,7 @@
 
 #include "EditorLineRenderer.h"
 
+#include <scene/WireframeGeometry.h>
 #include <utils/Picking.h>
 #include <string>
 #include <vector>
@@ -28,6 +29,10 @@ class EditorMesh {
 public:
   EditorMesh()  = default;
   ~EditorMesh() { Destroy(); }
+  EditorMesh(const EditorMesh&) = delete;
+  EditorMesh& operator=(const EditorMesh&) = delete;
+  EditorMesh(EditorMesh&&) noexcept = default;
+  EditorMesh& operator=(EditorMesh&&) noexcept = default;
 
   // Load a mesh file (.x, .glb, .gltf) and build the wireframe buffers.
   // Returns false on any parse/IO/buffer-creation failure.
@@ -38,7 +43,7 @@ public:
   bool CloneFrom(const EditorMesh& source);
   void Destroy();
 
-  bool IsLoaded() const { return m_vb != nullptr && m_ib != nullptr; }
+  bool IsLoaded() const { return m_geometry.IsReady(); }
   const std::string& Path() const { return m_path; }
 
   // Transform — owned by the mesh, mutated by the editor.
@@ -71,10 +76,7 @@ public:
 private:
   std::string m_path;
 
-  t850::VertexBuffer* m_vb = nullptr;
-  t850::IndexBuffer*  m_ib = nullptr;
-  unsigned m_indexCount = 0;
-  bool     m_use32BitIB = false;
+  t850::WireframeGeometry m_geometry;
   std::vector<XVECTOR3> m_pickVertices;
   std::vector<unsigned int> m_pickIndices;
 

--- a/T850/T8ditor/EditorSceneSerialization.cpp
+++ b/T850/T8ditor/EditorSceneSerialization.cpp
@@ -125,6 +125,12 @@ t850::navigation::NavMeshModifierMode NavModifierModeFromName(const std::string&
   if (name == "area" || name == "area_cost" || name == "cost") {
     return t850::navigation::NavMeshModifierMode::Area;
   }
+  if (name == "link_include" || name == "link_add" || name == "add_links") {
+    return t850::navigation::NavMeshModifierMode::LinkInclude;
+  }
+  if (name == "link_exclude" || name == "exclude_links") {
+    return t850::navigation::NavMeshModifierMode::LinkExclude;
+  }
   return t850::navigation::NavMeshModifierMode::Exclude;
 }
 

--- a/T850/T8ditor/EditorSceneSerialization.cpp
+++ b/T850/T8ditor/EditorSceneSerialization.cpp
@@ -105,6 +105,29 @@ t850::navigation::NavTraversalType NavLinkTypeFromName(const std::string& name) 
   return t850::navigation::NavTraversalType::Jump;
 }
 
+int NavAreaFromName(const std::string& name) {
+  if (name == "walkable") return 0;
+  if (name == "drop") return 1;
+  if (name == "jump") return 2;
+  if (name == "jump_pad") return 3;
+  if (name == "jump_intent") return 4;
+  if (name == "water") return 5;
+  if (name == "door") return 6;
+  if (name == "mud") return 7;
+  if (name == "custom") return 8;
+  return 8;
+}
+
+t850::navigation::NavMeshModifierMode NavModifierModeFromName(const std::string& name) {
+  if (name == "include" || name == "include_bounds" || name == "bounds") {
+    return t850::navigation::NavMeshModifierMode::Include;
+  }
+  if (name == "area" || name == "area_cost" || name == "cost") {
+    return t850::navigation::NavMeshModifierMode::Area;
+  }
+  return t850::navigation::NavMeshModifierMode::Exclude;
+}
+
 t850::navigation::NavOffMeshLink NavOffMeshLinkFromScene(const t850::scene::SceneNavMeshLinkDesc& desc) {
   t850::navigation::NavOffMeshLink link;
   link.start = XVECTOR3(desc.start.x, desc.start.y, desc.start.z, 1.0f);
@@ -113,6 +136,23 @@ t850::navigation::NavOffMeshLink NavOffMeshLinkFromScene(const t850::scene::Scen
   link.bidirectional = desc.bidirectional;
   link.type = NavLinkTypeFromName(desc.type);
   return link;
+}
+
+t850::navigation::NavMeshVolumeModifier NavVolumeModifierFromScene(const t850::scene::SceneNavMeshVolumeDesc& desc) {
+  t850::navigation::NavMeshVolumeModifier modifier;
+  modifier.name = desc.name;
+  modifier.mode = NavModifierModeFromName(desc.type);
+  modifier.position = XVECTOR3(desc.position.x, desc.position.y, desc.position.z, 1.0f);
+  modifier.rotation = XVECTOR3(desc.rotation.x, desc.rotation.y, desc.rotation.z, 0.0f);
+  modifier.halfExtents = XVECTOR3(
+      (std::max)(0.001f, std::abs(desc.half_extents.x)),
+      (std::max)(0.001f, std::abs(desc.half_extents.y)),
+      (std::max)(0.001f, std::abs(desc.half_extents.z)),
+      0.0f);
+  modifier.area = NavAreaFromName(desc.area);
+  modifier.cost = (std::max)(0.01f, desc.cost);
+  modifier.enabled = desc.enabled && desc.shape == "box";
+  return modifier;
 }
 
 bool IsFiniteNavPoint(const t850::scene::Vec3f& point) {

--- a/T850/T8ditor/EditorSceneSerialization.h
+++ b/T850/T8ditor/EditorSceneSerialization.h
@@ -29,6 +29,7 @@ t850::navigation::NavMeshBuildSettings NavMeshBuildSettingsFromScene(
 const char* NavLinkTypeName(t850::navigation::NavTraversalType type);
 t850::navigation::NavTraversalType NavLinkTypeFromName(const std::string& name);
 t850::navigation::NavOffMeshLink NavOffMeshLinkFromScene(const t850::scene::SceneNavMeshLinkDesc& desc);
+t850::navigation::NavMeshVolumeModifier NavVolumeModifierFromScene(const t850::scene::SceneNavMeshVolumeDesc& desc);
 bool IsFiniteNavPoint(const t850::scene::Vec3f& point);
 bool IsUsableAuthoredNavLink(const t850::scene::SceneNavMeshLinkDesc& link);
 

--- a/T850/cmake/AndroidBuild.cmake
+++ b/T850/cmake/AndroidBuild.cmake
@@ -136,6 +136,7 @@ set(T850_ANDROID_FRAMEWORK_SOURCES
   ${T850_SOURCE_DIR}/Framework/src/scene/RenderMesh.cpp
   ${T850_SOURCE_DIR}/Framework/src/scene/RenderSkinnedMesh.cpp
   ${T850_SOURCE_DIR}/Framework/src/scene/LineRenderer.cpp
+  ${T850_SOURCE_DIR}/Framework/src/scene/WireframeGeometry.cpp
   ${T850_SOURCE_DIR}/Framework/src/scene/MeshAssetCache.cpp
   ${T850_SOURCE_DIR}/Framework/src/scene/MaterialAssetCache.cpp
   ${T850_SOURCE_DIR}/Framework/src/scene/MeshPool.cpp


### PR DESCRIPTION
## Summary
- Refactor wireframe/line geometry state tracking through shared Framework draw-state handling.
- Add God Rays volume authoring gates and light-camera association.
- Add staged NavMesh authoring workflow: modifier volumes, source classification overlay, viewport gizmos, link-control volumes, baked .t8nav support, validation reports, and authoring-mode tools.
- Fix hidden-but-explicit NavMesh sources so scenes like Nexus can build navigation even when render meshes are hidden.

## Validation
- Built full solution x64 Release locally.