### PR TITLE
Add engine documentation stages 7 through 18

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,59 @@
+# T850 Engine Documentation
+
+This folder is the long-form technical documentation for T850. It is separate from the root `docs/` folder and is intended to explain the engine deeply enough that a new developer can continue work without losing architectural context.
+
+## Documentation map
+
+| Area | File | Status |
+|---|---|---|
+| Documentation conventions | [doc-conventions.md](doc-conventions.md) | Stage 0 skeleton |
+| Glossary | [glossary.md](glossary.md) | Stage 0 skeleton |
+| Full documentation plan | [stage-plan.md](stage-plan.md) | Stage 0 skeleton |
+| Main architecture | [architecture/main-architecture.md](architecture/main-architecture.md) | Stage 1 draft |
+| Platform event loop and windows | [architecture/platform-event-loop.md](architecture/platform-event-loop.md) | Stage 1 draft |
+| Geometry loading | [geometry/loading-geometry.md](geometry/loading-geometry.md) | Planned |
+| Shader management | [rendering/shader-management.md](rendering/shader-management.md) | Planned |
+| Render graph | [rendering/render-graph.md](rendering/render-graph.md) | Planned |
+| Geometry rendering flow | [rendering/geometry-rendering-flow.md](rendering/geometry-rendering-flow.md) | Planned |
+| Animation | [animation/animation-system.md](animation/animation-system.md) | Planned |
+| Physics | [physics/jolt-physics.md](physics/jolt-physics.md) | Planned |
+| Navigation | [navigation/navmesh-detour.md](navigation/navmesh-detour.md) | Planned |
+| Editor | [editor/editor-overview.md](editor/editor-overview.md) | Planned |
+| Scenes and formats | [scenes/scene-format-and-runtime.md](scenes/scene-format-and-runtime.md) | Planned |
+
+## Reading path
+
+1. Start with [glossary.md](glossary.md) for naming and subsystem terms.
+2. Read [architecture/main-architecture.md](architecture/main-architecture.md) to understand the high-level engine layers.
+3. Read [architecture/platform-event-loop.md](architecture/platform-event-loop.md) to understand platform/window/API ownership.
+4. Continue through geometry, shaders, render graph, and geometry rendering flow.
+5. Read animation, physics, navigation, editor, and scene-format docs as needed.
+
+## Expectations for each document
+
+Every subsystem document should include:
+
+- Purpose and responsibilities.
+- Key classes/files.
+- Ownership and lifetime rules.
+- Data flow and frame/update flow.
+- Mermaid diagrams for flowcharts, sequence diagrams, or dependencies.
+- Runtime/editor differences.
+- Extension points.
+- Known limitations.
+- Debugging and common failure modes.
+- Links to related documents.
+
+## Mermaid diagram policy
+
+Use Mermaid diagrams directly in Markdown. Prefer small diagrams that explain one flow clearly over one large diagram that tries to cover everything.
+
+Example:
+
+```mermaid
+flowchart LR
+  SceneFile[".t8scene"] --> Editor["T8ditor"]
+  SceneFile --> SceneTemplate["SceneTemplate runtime"]
+  Editor --> Framework["Framework systems"]
+  SceneTemplate --> Framework
+```

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -4,30 +4,67 @@ This folder is the long-form technical documentation for T850. It is separate fr
 
 ## Documentation map
 
+### Index, conventions, and audit
+
 | Area | File | Status |
 |---|---|---|
 | Documentation conventions | [doc-conventions.md](doc-conventions.md) | Stage 0 skeleton |
 | Glossary | [glossary.md](glossary.md) | Stage 0 skeleton |
 | Full documentation plan | [stage-plan.md](stage-plan.md) | Stage 0 skeleton |
+| Dependency map | [dependency-map.md](dependency-map.md) | Stage 11 draft |
+| Review and gaps | [review-and-gaps.md](review-and-gaps.md) | Stage 12 draft |
+
+### Core architecture and platform
+
+| Area | File | Status |
+|---|---|---|
 | Main architecture | [architecture/main-architecture.md](architecture/main-architecture.md) | Stage 1 draft |
 | Platform event loop and windows | [architecture/platform-event-loop.md](architecture/platform-event-loop.md) | Stage 1 draft |
+| Resource lookup and cache paths | [architecture/resource-locator.md](architecture/resource-locator.md) | Stage 14 draft |
+| Input, camera, and controls | [input/camera-and-controls.md](input/camera-and-controls.md) | Stage 15 draft |
+| Debug and diagnostics | [debug/diagnostics.md](debug/diagnostics.md) | Stage 13 draft |
+
+### Rendering and assets
+
+| Area | File | Status |
+|---|---|---|
 | Geometry loading | [geometry/loading-geometry.md](geometry/loading-geometry.md) | Stage 2 draft |
 | Shader management | [rendering/shader-management.md](rendering/shader-management.md) | Stage 3 draft |
 | Render graph | [rendering/render-graph.md](rendering/render-graph.md) | Stage 4 draft |
 | Geometry rendering flow | [rendering/geometry-rendering-flow.md](rendering/geometry-rendering-flow.md) | Stage 5 draft |
+| Textures, samplers, and IBL | [rendering/textures-and-ibl.md](rendering/textures-and-ibl.md) | Stage 17 draft |
+
+### Runtime systems
+
+| Area | File | Status |
+|---|---|---|
 | Animation | [animation/animation-system.md](animation/animation-system.md) | Stage 6 draft |
-| Physics | [physics/jolt-physics.md](physics/jolt-physics.md) | Planned |
-| Navigation | [navigation/navmesh-detour.md](navigation/navmesh-detour.md) | Planned |
-| Editor | [editor/editor-overview.md](editor/editor-overview.md) | Planned |
-| Scenes and formats | [scenes/scene-format-and-runtime.md](scenes/scene-format-and-runtime.md) | Planned |
+| Physics | [physics/jolt-physics.md](physics/jolt-physics.md) | Stage 7 draft |
+| Navigation | [navigation/navmesh-detour.md](navigation/navmesh-detour.md) | Stage 8 draft |
+
+### Editor, UI, and scene formats
+
+| Area | File | Status |
+|---|---|---|
+| Editor overview | [editor/editor-overview.md](editor/editor-overview.md) | Stage 9 draft |
+| FrameworkImGui runtime UI | [editor/imgui-system.md](editor/imgui-system.md) | Stage 16 draft |
+| Scenes and formats | [scenes/scene-format-and-runtime.md](scenes/scene-format-and-runtime.md) | Stage 10 draft |
+| SceneSetup descriptors | [scenes/scene-setup-descriptors.md](scenes/scene-setup-descriptors.md) | Stage 18 draft |
 
 ## Reading path
 
 1. Start with [glossary.md](glossary.md) for naming and subsystem terms.
 2. Read [architecture/main-architecture.md](architecture/main-architecture.md) to understand the high-level engine layers.
 3. Read [architecture/platform-event-loop.md](architecture/platform-event-loop.md) to understand platform/window/API ownership.
-4. Continue through geometry, shaders, render graph, and geometry rendering flow.
-5. Read animation, physics, navigation, editor, and scene-format docs as needed.
+4. Use [architecture/resource-locator.md](architecture/resource-locator.md) when a change touches asset paths, Android packaged assets, or generated caches.
+5. Use [input/camera-and-controls.md](input/camera-and-controls.md) when a change touches input, controllers, camera profiles, hosted viewport input, or Android virtual controls.
+6. Use [editor/imgui-system.md](editor/imgui-system.md) when a change touches runtime/editor ImGui, docking, platform windows, or hosted scene panels.
+7. Continue through geometry, shaders, render graph, geometry rendering flow, and [textures/IBL](rendering/textures-and-ibl.md).
+8. Read animation, physics, and navigation when a feature touches runtime simulation or pathing.
+9. Read editor/UI and scene-format docs when a feature touches authoring, Play Scene, or runtime descriptor controls.
+10. Use [dependency-map.md](dependency-map.md) when a change crosses subsystem boundaries.
+11. Check [review-and-gaps.md](review-and-gaps.md) for known missing docs and troubleshooting entry points.
+12. Use [debug/diagnostics.md](debug/diagnostics.md) when diagnosing load stalls, frame differences, telemetry, dumps, or profiling.
 
 ## Expectations for each document
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -11,11 +11,11 @@ This folder is the long-form technical documentation for T850. It is separate fr
 | Full documentation plan | [stage-plan.md](stage-plan.md) | Stage 0 skeleton |
 | Main architecture | [architecture/main-architecture.md](architecture/main-architecture.md) | Stage 1 draft |
 | Platform event loop and windows | [architecture/platform-event-loop.md](architecture/platform-event-loop.md) | Stage 1 draft |
-| Geometry loading | [geometry/loading-geometry.md](geometry/loading-geometry.md) | Planned |
-| Shader management | [rendering/shader-management.md](rendering/shader-management.md) | Planned |
-| Render graph | [rendering/render-graph.md](rendering/render-graph.md) | Planned |
-| Geometry rendering flow | [rendering/geometry-rendering-flow.md](rendering/geometry-rendering-flow.md) | Planned |
-| Animation | [animation/animation-system.md](animation/animation-system.md) | Planned |
+| Geometry loading | [geometry/loading-geometry.md](geometry/loading-geometry.md) | Stage 2 draft |
+| Shader management | [rendering/shader-management.md](rendering/shader-management.md) | Stage 3 draft |
+| Render graph | [rendering/render-graph.md](rendering/render-graph.md) | Stage 4 draft |
+| Geometry rendering flow | [rendering/geometry-rendering-flow.md](rendering/geometry-rendering-flow.md) | Stage 5 draft |
+| Animation | [animation/animation-system.md](animation/animation-system.md) | Stage 6 draft |
 | Physics | [physics/jolt-physics.md](physics/jolt-physics.md) | Planned |
 | Navigation | [navigation/navmesh-detour.md](navigation/navmesh-detour.md) | Planned |
 | Editor | [editor/editor-overview.md](editor/editor-overview.md) | Planned |

--- a/documentation/animation/animation-system.md
+++ b/documentation/animation/animation-system.md
@@ -1,8 +1,386 @@
 # Animation System
 
-Status: planned.
+Status: Stage 6 draft.
 
-This document will cover animation import, skeletons, clips, interpolation, pose updates, GPU skinning, bone texture upload, and limitations.
+This document explains T850's skeletal animation path: glTF skin/animation import, internal skeleton and clip data, `AnimationController` playback, interpolation and keyframe stepping, pose snapshots, bone texture upload, GPU skinning, debug visualization, and current limitations.
 
-See [stage-plan.md](../stage-plan.md#stage-6--animation).
+Related documents:
+
+- [Loading geometry](../geometry/loading-geometry.md)
+- [Shader management](../rendering/shader-management.md)
+- [Geometry rendering flow](../rendering/geometry-rendering-flow.md)
+- [Jolt physics](../physics/jolt-physics.md)
+
+## Purpose and responsibilities
+
+The animation system turns imported skinning and clip data into per-frame bone matrices that the mesh vertex shader can use for GPU skinning.
+
+At runtime:
+
+1. glTF import fills `xF::xSkeleton`, `xF::xAnimationInfo`, and `xF::xSkinWeights`.
+2. `PrimitiveManager` detects skin/animation data and creates `RenderSkinnedMesh`.
+3. `RenderSkinnedMesh::Create()` initializes `AnimationController` and compiles skinned shader variants.
+4. Each frame, scene/editor code calls `UpdateAnimationPose()` or `UpdateAnimationAndBones()` before rendering.
+5. `RenderSkinnedMesh` uploads final bone matrices to a texture.
+6. `VS_Mesh` samples the bone texture and skins vertices on the GPU.
+
+```mermaid
+flowchart LR
+  GLTF["glTF skins/animations"] --> Import["BuildSkinsAndAnimations"]
+  Import --> XData["xSkeleton + xAnimationInfo + xSkinWeights"]
+  XData --> Skinned["RenderSkinnedMesh::Create"]
+  Skinned --> Ctrl["AnimationController"]
+  Ctrl --> Update["Update / keyframe / snapshot pose"]
+  Update --> Matrices["Final bone matrices"]
+  Matrices --> Texture["RGBA32F bone texture"]
+  Texture --> Shader["VS_Mesh USE_SKINNING_TEXTURE"]
+  Shader --> Draw["GPU-skinned mesh draw"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `Framework/src/utils/gltf/GLTFAnimation.cpp` | Converts glTF skins, joints, inverse bind matrices, and animation channels into engine `xF` structures. |
+| `Framework/src/utils/gltf/GLTFMesh.cpp` | Calls `BuildSkinsAndAnimations()` after geometry conversion when skins or animations exist. |
+| `Framework/include/utils/xDefs.h` | Defines `xBone`, `xSkeleton`, `xAnimationInfo`, `xAnimationSet`, `xAnimationBone`, key structs, and `xSkinWeights`. |
+| `Framework/include/scene/AnimationController.h` | Playback API, final bone output arrays, keyframe mode, pose override APIs, debug dump. |
+| `Framework/src/scene/AnimationController.cpp` | Animation update, interpolation, hierarchy computation, bind pose and final bone matrix computation. |
+| `Framework/include/scene/RenderSkinnedMesh.h` | Skinned mesh renderer API: update/upload, playback controls, snapshots, wireframe/skeleton debug. |
+| `Framework/src/scene/RenderSkinnedMesh.cpp` | Creates skinned shaders/bone texture, updates pose, uploads bone texture, draws skinned meshes and debug geometry. |
+| `Assets/Shaders/VS_Mesh.hlsl` | HLSL skinning paths: texture, matrix, and quaternion/translation. |
+| `Assets/Shaders/VS_Mesh.glsl` | OpenGL GLSL skinning paths. |
+| `Assets/Shaders/FS_WireMesh.*` | Wireframe overlay fragment shaders with depth-texture occlusion. |
+
+## Internal data model
+
+Animation import stores data in the legacy `xF` structures used by the renderer.
+
+| Structure | Meaning |
+|---|---|
+| `xF::xBone` | One skeleton joint. Stores local `Bone`, combined/world `Combined`, `IntermediateTransform`, parent `Dad`, child list `Sons`, and name. |
+| `xF::xSkeleton` | Bone array plus `RootParentWorld`, the world transform of non-skeleton ancestors above the skeleton root. |
+| `xF::xSkinWeights` | Per-bone skin metadata: inverse bind matrix in `MatrixOffset`, node name, and pointers to animated combined matrices. |
+| `xF::xSkinInfo` | Per-geometry skin header and skin weights. |
+| `xF::xAnimationInfo` | Clip list, ticks-per-second, and `isAnimInfo`. |
+| `xF::xAnimationSet` | One clip. Stores animated bones in `BonesRef`, clip duration in ticks, and playback metadata. |
+| `xF::xAnimationBone` | One animated bone channel set: position keys, rotation keys, scale keys, `ActualKey`, and output matrix. |
+| `xF::xAnimationSingleKey` | Mutable per-channel playback indices/timing for one bone. |
+
+The renderer currently supports a maximum of `kMaxBones = 256` bones in `AnimationController`.
+
+## glTF import flow
+
+`BuildSkinsAndAnimations()` is called after glTF geometry has been converted into `XDataBase`.
+
+```mermaid
+flowchart TD
+  Doc["gltf::Document"] --> JointMap["BuildSkinJointMap"]
+  JointMap --> Skeleton["Build xSkeleton and xSkeletonAnimated"]
+  Skeleton --> Parents["Resolve joint parents and non-joint intermediates"]
+  Parents --> IBM["Read inverseBindMatrices"]
+  IBM --> SkinInfo["Attach xSkinInfo to skinned geometries"]
+  Doc --> Channels["Read animation channels"]
+  Channels --> Keys["Convert translation/rotation/scale keys"]
+  Keys --> Defaults["Synthesize missing channel defaults"]
+  Defaults --> AnimInfo["xAnimationInfo / xAnimationSet"]
+```
+
+### Skeleton import
+
+The importer:
+
+- builds a global skin joint map across glTF skins,
+- creates both bind-pose `mc->Skeleton` and runtime `mc->SkeletonAnimated`,
+- maps node names into bones,
+- resolves parent joints by walking the glTF node ancestry,
+- stores non-joint ancestor transforms in `RootParentWorld`,
+- stores non-joint transforms between joints in `xBone::IntermediateTransform`,
+- copies each joint node's local TRS matrix into `xBone::Bone`.
+
+This matters because glTF skeletons can contain helper nodes between joints. T850 preserves those transforms separately so animation keys can overwrite the actual joint local matrix without losing intermediate hierarchy transforms.
+
+### Inverse bind matrices and skin weights
+
+The importer reads every skin's `inverseBindMatrices` accessor, converts glTF column-major matrices to the engine row-major matrix layout, and stores them in global joint order as `xSkinWeights::MatrixOffset`.
+
+Every geometry with skin attributes receives:
+
+- `SkinMeshHeader.NumBones`,
+- `MaxNumWeightPerVertex = 4`,
+- one `xSkinWeights` entry per global joint,
+- pointers from skin weights to `SkeletonAnimated.Bones[j].Combined`.
+
+Vertex `JOINTS_0` data was already remapped from local skin joint indices to this global joint order during mesh conversion.
+
+### Animation clips
+
+For each glTF animation:
+
+- supported target paths are `translation`, `rotation`, and `scale`;
+- each target node is mapped to a joint index;
+- sampler input times are converted to ticks using `kTicksPerSecond = 4800`;
+- sampler output values become `xPositionKey`, `xRotationKey`, or `xScaleKey`;
+- `CUBICSPLINE` data is read by taking the middle value record for each key;
+- unsupported paths are skipped with a log message;
+- missing translation/rotation/scale channels synthesize default keys from the node TRS or identity defaults;
+- clip duration is the maximum final key tick across all channels.
+
+Multiple animations can be converted in parallel through the global thread pool.
+
+## `AnimationController`
+
+`AnimationController` owns runtime playback state for one skinned renderer.
+
+`Init()` deliberately clones the imported `xAnimationInfo`, bind skeleton, and animated skeleton into instance-owned copies. This prevents cloned mesh instances from mutating shared `XDataBase` animation state.
+
+Initialization flow:
+
+1. Copy imported animation/skeleton data into controller-owned instances.
+2. Clamp bone count to `kMaxBones`.
+3. Pick ticks-per-second from imported data, defaulting to `4800`.
+4. Reset per-channel playback locals.
+5. Compute missing animation durations when needed.
+6. Compute bind-pose combined matrices.
+7. Generate controller-owned inverse bind matrices from bind pose.
+8. Initialize animated skeleton from bind pose.
+
+`SetSkinWeights()` points the controller at the geometry's imported glTF inverse bind matrices. Final matrix computation prefers these glTF IBMs when present, falling back to computed bind-pose inverse matrices otherwise.
+
+## Playback and interpolation
+
+`AnimationController::Update(deltaTime)`:
+
+1. Scales `deltaTime` by playback speed.
+2. Adds it to local time.
+3. Converts local seconds to animation ticks.
+4. Wraps or clamps time based on looping.
+5. Interpolates channel keys.
+6. Computes combined hierarchy matrices.
+7. Computes final GPU bone matrices.
+
+```mermaid
+flowchart LR
+  Delta["deltaTime * speed"] --> Time["local seconds"]
+  Time --> Tick["tickTime = seconds * ticksPerSecond"]
+  Tick --> Wrap["loop/clamp to clip duration"]
+  Wrap --> Interp["InterpolateKeys"]
+  Interp --> Hierarchy["ComputeHierarchy"]
+  Hierarchy --> Final["ComputeFinalMatrices"]
+```
+
+Interpolation behavior:
+
+- position: linear interpolation,
+- scale: linear interpolation,
+- rotation: SLERP by default, NLERP when `SetUseSlerp(false)` is used,
+- local transform: `Scale * Rotation * Translation` using row-vector convention.
+
+The controller assumes imported key arrays are sorted by time.
+
+## Keyframe mode
+
+Keyframe stepping is a no-interpolation inspection mode.
+
+`SetKeyframeMode(true)` disables automatic `Update()` in `RenderSkinnedMesh::UpdateAnimationPose()`. `StepKeyframe(delta)` changes `m_currentKeyframe`, finds a tick from the first channel with that key index, snaps every animated channel to the nearest key at or before that tick, then recomputes hierarchy and final matrices.
+
+This is useful for editor inspection, but it assumes channels share a compatible time axis. Odd clips with very different per-channel key layouts can step unexpectedly.
+
+## Hierarchy and final matrices
+
+`ComputeHierarchy()` performs parent-first traversal and writes each animated bone's combined matrix:
+
+```text
+localWithIntermediate = Bone * IntermediateTransform
+Combined = localWithIntermediate * parentCombined
+```
+
+For root bones, `RootParentWorld` is used as the parent transform.
+
+`ComputeFinalMatrices()` then computes the matrix sent to the shader:
+
+```text
+rhResult = inverseBindMatrix * animatedCombined
+final = RH_to_LH_Z_flip(rhResult)
+```
+
+The right-handed to left-handed conversion is applied once at the final product. This keeps imported glTF skeleton/IBM data in its original space until the final shader-facing matrix is produced.
+
+The controller also extracts a quaternion and translation from each final matrix for the alternate quaternion/translation skinning path.
+
+## RenderSkinnedMesh creation
+
+`RenderSkinnedMesh::Create()` starts by calling `RenderMesh::Create()`, so skinned meshes still receive the same geometry, material, mesh-pool, and static shader setup as normal meshes.
+
+It then:
+
+1. Detects skinning by checking for `HAS_SKINWEIGHTS0` and `HAS_SKININDEXES0`.
+2. Adds `ShaderKey::HAS_SKINNING_TEX` to every subset key.
+3. Allocates an RGBA32F bone texture.
+4. Recompiles mesh shader variants with the skinning texture bit.
+5. Compiles skinned wireframe shader variant.
+6. Allocates constant buffers.
+7. Initializes `AnimationController` from `mc->Animation`, `mc->Skeleton`, and `mc->SkeletonAnimated`.
+8. Finds the first geometry with skin weights and calls `SetSkinWeights()`.
+9. Builds skinned wireframe and octahedral skeleton debug buffers.
+
+The bone texture width is chosen as `ceil(sqrt(numBones * 4))`, because every bone matrix uses four RGBA texels.
+
+## Per-frame update and upload
+
+`RenderSkinnedMesh` exposes two update calls:
+
+- `UpdateAnimationPose()` updates the CPU animation pose only.
+- `UpdateAnimationAndBones()` updates the pose and uploads the bone texture.
+
+The header explicitly notes that `UpdateAnimationAndBones()` must run before the render graph and outside any render pass. This is important for Vulkan because texture uploads/copy commands must not happen inside a render pass.
+
+`UpdateAnimationPose()`:
+
+- early-outs when there is no skin,
+- writes one debug bind-pose dump to `anim_debug_bindpose.txt` the first time it runs without a snapshot,
+- advances the controller only when not in snapshot pose, playing is enabled, and keyframe mode is off.
+
+`UploadBoneTexture()`:
+
+- validates device context, texture width, and backing store size,
+- uses snapshot matrices when a snapshot is active,
+- otherwise uses `AnimationController::GetBoneMatrices()`,
+- clamps upload count to `kMaxBones` and texture capacity,
+- writes each matrix row to four RGBA texels,
+- calls `Texture::UpdateFloatData()`.
+
+```mermaid
+sequenceDiagram
+  participant Scene
+  participant Mesh as RenderSkinnedMesh
+  participant Ctrl as AnimationController
+  participant Tex as BoneTexture
+  participant Shader as VS_Mesh
+
+  Scene->>Mesh: UpdateAnimationAndBones()
+  Mesh->>Ctrl: Update(deltaTime)
+  Ctrl-->>Mesh: final bone matrices
+  Mesh->>Tex: UpdateFloatData(RGBA32F rows)
+  Scene->>Mesh: Draw()
+  Mesh->>Shader: bind bone texture at t24 / u_BoneTex
+  Shader->>Shader: sample 4 texels per bone
+```
+
+## GPU skinning
+
+The default active path is texture-based skinning:
+
+- shader key bit: `HAS_SKINNING_TEX`,
+- shader define: `USE_SKINNING_TEXTURE`,
+- HLSL resource: `Texture2D<float4> BoneTexture : register(t24)`,
+- GLSL resource: `uniform highp sampler2D u_BoneTex`,
+- each bone matrix is reconstructed from four texels,
+- vertex position, normal, tangent, and binormal are transformed before world/view/projection.
+
+Alternative shader paths exist:
+
+- `USE_SKINNING`: matrix array in constant/uniform buffer.
+- `USE_SKINNING_QT`: quaternion plus translation arrays.
+
+The current `RenderSkinnedMesh::Create()` path sets `HAS_SKINNING_TEX`, so matrix and QT paths are code-supported but not the default renderer path.
+
+## Rendering relationship
+
+The draw path for skinned meshes mirrors static mesh rendering, with these additions:
+
+- final subset keys include `HAS_SKINNING_TEX`;
+- `RenderSkinnedMesh::Draw()` binds the bone texture with `SetVS()` before `DrawIndexed()`;
+- shader input layout includes `BLENDINDICES` and `BLENDWEIGHT`;
+- CPU-side material, mesh pool, shader selection, texture binding, and `DrawIndexed` follow the same pattern documented in [Geometry rendering flow](../rendering/geometry-rendering-flow.md).
+
+If `m_hasSkin` is false, `RenderSkinnedMesh::Draw()` falls back to `RenderMesh::Draw()`.
+
+## Snapshot and pose override workflows
+
+Snapshot support is used by frame capture/replay, editor tools, and animation-to-physics handoff workflows.
+
+`RenderSkinnedMesh` provides:
+
+- `ExportBoneMatrices(out)`: exports current shader-space matrices, or active snapshot matrices.
+- `ApplySnapshotBoneMatrices(matrices)`: stores matrices, clamps to `kMaxBones`, and activates snapshot pose.
+- `ClearSnapshotBoneMatrices()`: returns to controller-driven pose.
+- `GetBoneTextureData()` and `GetBoneTextureWidth()` for inspecting uploaded texture data.
+
+`AnimationController` also provides:
+
+- `ExportCombinedPose(out)`: exports animated skeleton combined matrices.
+- `ApplyCombinedPoseOverrides(indices, combinedMatrices)`: applies selected combined matrices and reconstructs local bone transforms from parent and intermediate transforms.
+- `ApplyBindPose()`: resets animated skeleton to bind pose.
+
+These APIs are used by scene/editor code for snapshot replay, ragdoll handoff, and skeleton editing.
+
+## Debug visualization
+
+### Matrix dump
+
+On first animation pose update, `RenderSkinnedMesh` calls:
+
+```text
+AnimationController::DumpMatrices("anim_debug_bindpose.txt")
+```
+
+The dump includes skeleton hierarchy, inverse bind matrices, and final GPU matrices.
+
+### Wireframe
+
+`RenderSkinnedMesh::DrawWireframe()` draws the mesh wireframe through the skinned shader path:
+
+- uses the same animated bone texture,
+- binds per-geometry line-list index buffers,
+- can bind GBuffer depth textures for manual depth-tested overlay,
+- uses `FS_WireMesh`.
+
+### Skeleton
+
+`RenderSkinnedMesh::DrawSkeleton()`:
+
+- reads current combined pose from `AnimationController::GetAnimSkeleton()`,
+- CPU-updates octahedral bone line geometry,
+- draws base skeleton and optional highlighted bone sets through `LineRenderer`,
+- disables depth testing for the skeleton overlay.
+
+SceneTemplate, SandboxScene, Quake3Mock, RagdollEditor, T8ditor, and editor panels all call these APIs for animation and skeleton inspection.
+
+## Extension points
+
+To extend animation:
+
+1. Add new glTF channel support in `GLTFAnimation.cpp` if the source data is not translation/rotation/scale.
+2. Preserve the `xF` data model unless replacing all downstream controller/render code.
+3. Add new playback controls to `AnimationController`, then expose them through `RenderSkinnedMesh`.
+4. If adding a new GPU skinning mode, add a `ShaderKey` bit, define mapping, shader code, and draw-time buffer/texture binding.
+5. If changing bone count limits, update `kMaxBones`, shader array/texture assumptions, debug buffers, and validation logs.
+6. Keep `UpdateAnimationAndBones()` before render graph execution to avoid backend upload hazards.
+
+## Known limitations and gotchas
+
+- Bone count is capped at 256.
+- GL uniform matrix fallback is capped lower in shader comments; texture skinning avoids that limit.
+- `UpdateAnimationAndBones()` must run outside render passes.
+- Keyframe stepping assumes a shared time axis across channels.
+- Imported keys are assumed sorted.
+- `CUBICSPLINE` interpolation is not evaluated as cubic; the importer uses the value record and runtime interpolates linearly/SLERP.
+- RH-to-LH conversion is applied only in final bone matrices, so intermediate skeleton debug values may not match final shader-space intuition.
+- Bind-pose AABBs are not conservative for GPU-skinned vertices; the current skinned draw path avoids subset AABB culling.
+- Matrix and quaternion/translation skinning paths exist in shaders but texture-based skinning is the default active renderer path.
+
+## Debugging checklist
+
+1. Confirm the glTF imported skin attributes: `HAS_SKINWEIGHTS0` and `HAS_SKININDEXES0`.
+2. Check logs for `[glTF] Building skeleton`, `Skin weights applied`, and `Converted animations`.
+3. Confirm `RenderSkinnedMesh::Create()` reports a nonzero bone count and animation set count.
+4. Verify `UpdateAnimationAndBones()` runs before the render graph.
+5. If animation is frozen, check playing state, keyframe mode, snapshot pose state, speed, and `FrameDeltaSec`.
+6. Inspect `anim_debug_bindpose.txt` for skeleton hierarchy, inverse bind matrices, and final matrices.
+7. Confirm bone texture width/data has enough capacity and `animation.bonesUploaded` telemetry is nonzero.
+8. Verify the shader key includes `HAS_SKINNING_TEX` and the shader has `USE_SKINNING_TEXTURE`.
+9. Check that `BoneTexture`/`u_BoneTex` is bound to slot 24.
+10. Use `DrawSkeleton()` to validate hierarchy and `DrawWireframe()` to validate GPU-skinned vertex motion.
+11. For snapshot/replay issues, compare `ExportBoneMatrices()` output with the uploaded bone texture data.
 

--- a/documentation/animation/animation-system.md
+++ b/documentation/animation/animation-system.md
@@ -1,0 +1,8 @@
+# Animation System
+
+Status: planned.
+
+This document will cover animation import, skeletons, clips, interpolation, pose updates, GPU skinning, bone texture upload, and limitations.
+
+See [stage-plan.md](../stage-plan.md#stage-6--animation).
+

--- a/documentation/animation/animation-system.md
+++ b/documentation/animation/animation-system.md
@@ -7,6 +7,7 @@ This document explains T850's skeletal animation path: glTF skin/animation impor
 Related documents:
 
 - [Loading geometry](../geometry/loading-geometry.md)
+- [Dependency map](../dependency-map.md)
 - [Shader management](../rendering/shader-management.md)
 - [Geometry rendering flow](../rendering/geometry-rendering-flow.md)
 - [Jolt physics](../physics/jolt-physics.md)
@@ -383,4 +384,3 @@ To extend animation:
 9. Check that `BoneTexture`/`u_BoneTex` is bound to slot 24.
 10. Use `DrawSkeleton()` to validate hierarchy and `DrawWireframe()` to validate GPU-skinned vertex motion.
 11. For snapshot/replay issues, compare `ExportBoneMatrices()` output with the uploaded bone texture data.
-

--- a/documentation/architecture/main-architecture.md
+++ b/documentation/architecture/main-architecture.md
@@ -1,0 +1,401 @@
+# Main Architecture
+
+This document describes the top-level architecture of T850: the Framework layer, scene applications, editor application, dev layer, and shared runtime context. It focuses on ownership and lifecycle rather than subsystem internals.
+
+## Purpose
+
+T850 is organized around a reusable **Framework** plus executable **applications/scenes**:
+
+- The **Framework** owns platform abstraction, graphics backends, common resources, input abstractions, physics, navigation, scene setup, and utilities.
+- Runtime scenes such as **DayScene**, **Quake3Mock**, **SandboxScene**, **RagdollEditor**, and **SceneTemplate** use the Framework to render and simulate content.
+- **T8ditor** is an editor executable that also uses the Framework, but has editor-only UI, gizmos, panels, authoring state, and `.t8scene` save/load workflows.
+
+The key architectural idea is that platform loops and graphics APIs are behind `RootFramework`/`BaseDriver`, while scene/application logic is behind `AppBase` and `SceneBase`.
+
+## Key files and classes
+
+| Area | Key files/classes | Role |
+|---|---|---|
+| Application contract | `T850/Framework/include/core/Core.h` — `AppBase` | Executable-level lifecycle: `InitVars`, `CreateAssets`, `LoadAssets`, `DestroyAssets`, `OnUpdate`, `OnDraw`, `OnInput`, pause/resume/reset. |
+| Scene contract | `T850/Framework/include/core/Core.h` — `SceneBase` | Runtime scene lifecycle and per-frame functions. Owns a `SceneProps` instance. |
+| Platform framework | `T850/Framework/include/core/Core.h` — `RootFramework` | Abstract platform/application loop and API switching interface. |
+| Windows framework | `T850/Framework/src/core/windows/Win32Framework.cpp` | SDL window, Win32 details, D3D11/D3D12/GL/Vulkan selection, input polling, resize, gamepads. |
+| Linux/Steam Deck framework | `T850/Framework/src/core/LinuxFramework.cpp` | SDL + Vulkan-only runtime for Linux/Steam Deck. |
+| Android framework | `T850/Framework/src/core/android/AndroidFramework.cpp` | Native activity glue, Vulkan-only runtime, native window lifecycle, touch/key input. |
+| Global context | `T850/Framework/include/core/EngineContext.h`, `T850/Framework/src/core/EngineContext.cpp` | Lightweight global access to driver/device/context/physics/thread pool/config. |
+| Dev layer | `T850/Framework/include/core/DevLayer.h`, `T850/Framework/src/core/DevLayer.cpp` | Runtime scene forwarding, pause toggle, culling debug visualization, input forwarding. |
+| Runtime app | `T850/DayScene/Application.cpp`, `T850/DayScene/App.cpp` | Runtime application wrapper around active scene and dev layer. |
+| Editor app | `T850/T8ditor/main.cpp`, `T850/T8ditor/EditorApp.cpp`, `T850/T8ditor/EditorApp.h` | Editor executable/application built on the same Framework contract. |
+| Render backend abstraction | `T850/Framework/include/video/BaseDriver.h` | Common graphics API interface for driver creation, frame lifecycle, render targets, resources, states. |
+
+## Layer model
+
+```mermaid
+flowchart TD
+  Entry["Executable main()"] --> Framework["RootFramework implementation"]
+  Framework --> App["AppBase implementation"]
+  App --> SceneLayer["SceneBase / editor scene logic"]
+  SceneLayer --> FrameworkSystems["Framework systems"]
+  FrameworkSystems --> Graphics["BaseDriver + API backend"]
+  FrameworkSystems --> Physics["Jolt physics"]
+  FrameworkSystems --> Navigation["Recast/Detour navigation"]
+  FrameworkSystems --> Resources["ResourceManager / MeshAssetCache / MaterialAssetCache"]
+  Graphics --> GPU["D3D11 / D3D12 / GL / Vulkan"]
+
+  T8ditor["T8ditor EditorApp"] --> App
+  DayScene["DayScene App"] --> App
+```
+
+## Core class relationships
+
+```mermaid
+classDiagram
+  class AppBase {
+    +InitVars()
+    +CreateAssets()
+    +LoadAssets()
+    +DestroyAssets()
+    +OnUpdate()
+    +OnDraw()
+    +OnInput()
+    +OnPause()
+    +OnResume()
+    +OnReset()
+    +LoadScene(int)
+    +InputManager IManager
+    +ResourceManager resourceManager
+  }
+
+  class RootFramework {
+    +OnCreateApplication(ApplicationDesc)
+    +UpdateApplication()
+    +ProcessInput()
+    +ChangeAPI(GraphicsApi)
+    +BaseDriver* pVideoDriver
+    +AppBase* pBaseApp
+  }
+
+  class SceneBase {
+    +OnUpdate(float)
+    +OnDraw()
+    +OnInput(InputManager*)
+    +OnLoadScene()
+    +OnDestoryScene()
+    +DrawDevGui(DevGuiContext&)
+    +SceneProps SceneProp
+  }
+
+  class DevLayer {
+    +SetActiveScene(SceneBase*)
+    +Update(float)
+    +Draw()
+    +ProcessInput(InputManager*)
+    +LoadScene(SceneBase*)
+  }
+
+  class BaseDriver {
+    +InitDriver()
+    +DestroyDriver()
+    +BeginFrame()
+    +EndFrame()
+    +CompleteFrame()
+    +CreateRT()
+    +CreateShader()
+    +CreateTexture()
+    +SetBlendState()
+    +SetDepthStencilState()
+  }
+
+  RootFramework --> AppBase
+  AppBase --> DevLayer
+  DevLayer --> SceneBase
+  RootFramework --> BaseDriver
+  SceneBase --> BaseDriver
+```
+
+## Runtime ownership
+
+### `RootFramework`
+
+`RootFramework` is the platform owner. It owns:
+
+- the selected `BaseDriver` backend through `pVideoDriver`;
+- the application pointer through `pBaseApp`;
+- the active `ApplicationDesc`;
+- the outer application loop.
+
+Platform implementations:
+
+- `Win32Framework` supports D3D11, D3D12, OpenGL, and Vulkan.
+- `LinuxFramework` forces Vulkan and is used for Steam Deck/Linux.
+- `AndroidFramework` forces Vulkan and is driven by native app glue events.
+
+### `AppBase`
+
+`AppBase` is implemented by executable-specific application classes:
+
+- `DayScene/Application.cpp` implements the runtime application `App`.
+- `T8ditor/EditorApp.cpp` implements the editor application `EditorApp`.
+
+`AppBase` owns:
+
+- its `InputManager`;
+- its `ResourceManager`;
+- its lifecycle hooks;
+- state such as pause/init flags.
+
+### `SceneBase`
+
+`SceneBase` represents a runtime scene loaded inside the runtime app. Examples:
+
+- `DayScene`
+- `SceneTemplate`
+- `Quake3Mock`
+- `SandboxScene`
+- `RagdollEditor`
+
+Each scene owns a `SceneProps` object. `SceneProps` is the main bundle of camera, light, rendering feature toggles, culling, God Rays, material parameters, and global scene render settings.
+
+### `EngineContext`
+
+`EngineContext` is a lightweight global bridge:
+
+```cpp
+struct EngineContext {
+  BaseDriver* driver;
+  Device* device;
+  DeviceContext* deviceContext;
+  JoltPhysicsSystem* physics;
+  ThreadPool* threadPool;
+  Config* config;
+};
+```
+
+`RefreshEngineContextFromGlobals()` pulls current globals (`g_pBaseDriver`, `T8Device`, `T8DeviceContext`, `g_threadPool`, `g_config`) into `EngineContext`. This is called after graphics API creation. It lets subsystems avoid passing the driver/device/thread pool through every call.
+
+## Application startup flow
+
+Runtime and editor entry points are similar:
+
+- Runtime: `T850/DayScene/App.cpp`
+- Editor: `T850/T8ditor/main.cpp`
+
+```mermaid
+sequenceDiagram
+  participant Main as main()
+  participant App as AppBase implementation
+  participant Framework as RootFramework implementation
+  participant Driver as BaseDriver backend
+
+  Main->>App: new App()/EditorApp()
+  Main->>Framework: new Win32Framework/LinuxFramework(app)
+  Main->>Framework: OnCreateApplication(desc)
+  Framework->>Framework: InitGlobalThreadPool()
+  Framework->>App: InitVars()
+  Framework->>Framework: ChangeAPI(desc.api)
+  Framework->>Driver: InitDriver()
+  Framework->>Framework: RefreshEngineContextFromGlobals()
+  Framework->>App: CreateAssets()
+  Framework->>Driver: BuildPipelineObjects()
+  Framework->>Framework: UpdateApplication()
+```
+
+Important details:
+
+- `main()` builds an `ApplicationDesc` from config/CLI.
+- `Win32Framework::OnCreateApplication()` initializes SDL, input/gamepads, thread pool, telemetry, navigation backend logging, then calls `ChangeAPI`.
+- `ChangeAPI()` creates or recreates the graphics driver/window and calls `AppBase::CreateAssets()`.
+- Runtime app may enter `UpdateApplication()` immediately; the editor is also driven by the framework loop.
+
+## Per-frame flow: runtime app
+
+`T850/DayScene/Application.cpp` owns the runtime frame. The major flow is:
+
+```mermaid
+flowchart TD
+  Frame["App::OnUpdate"] --> Timer["DtTimer.Update / DtSecs"]
+  Timer --> TelemetryStart["RuntimeTelemetry::BeginFrame"]
+  TelemetryStart --> SceneUpdate["DevLayer.Update(dt) or Scene.OnUpdate(dt) on Android"]
+  SceneUpdate --> Physics["Jolt physics update if initialized"]
+  Physics --> Input["App::OnInput"]
+  Input --> Draw["App::OnDraw"]
+  Draw --> TelemetryEnd["RuntimeTelemetry::EndFrame"]
+
+  Draw --> Clear["BaseDriver::Clear"]
+  Clear --> SceneDraw["DevLayer.Draw or Scene.OnDraw on Android"]
+  SceneDraw --> RuntimeGUI["Runtime ImGui/dev UI"]
+  RuntimeGUI --> Present["Driver present path"]
+```
+
+Notable runtime behavior:
+
+- Non-Android uses `DevLayer` to forward scene update/draw/input and add dev tooling.
+- Android calls the active scene directly in several paths to avoid desktop dev UI assumptions.
+- Physics update is outside individual scenes if `EngineContext.physics` is initialized.
+- Benchmark/offscreen paths can bypass the standard present loop and use `BaseDriver::FrameTargetMode::Offscreen`.
+
+## Per-frame flow: editor
+
+`T850/T8ditor/EditorApp.cpp` owns editor frames:
+
+```mermaid
+flowchart TD
+  Update["EditorApp::OnUpdate"] --> Timer["m_dtTimer.Update"]
+  Timer --> Hosted["Close/open hosted scene windows if requested"]
+  Hosted --> Cubemap["Apply pending editor cubemap"]
+  Cubemap --> LoadScene["LoadPendingScene"]
+  LoadScene --> Resize["CheckResize"]
+  Resize --> Timeline["UpdateEditorSplinePreview"]
+  Timeline --> Input["OnInput"]
+  Input --> Skinned["UpdateSkinnedAnimationAndRagdolls"]
+  Skinned --> Draw["OnDraw"]
+
+  Draw --> BeginFrame["BaseDriver::BeginFrame"]
+  BeginFrame --> Clear["BaseDriver::Clear"]
+  Clear --> SceneFrame["RenderEditorSceneFrame"]
+  SceneFrame --> ImGui["DrawEditorUI"]
+  ImGui --> Dumps["Frame dump if requested"]
+  Dumps --> Swap["SwapBuffers / EndFrame"]
+```
+
+The editor uses the same graphics backend abstraction, but layers editor-only systems on top:
+
+- ImGui docking/panels.
+- ImGuizmo transforms.
+- editor line renderer and grid.
+- editor render graph.
+- scene hierarchy/inspector.
+- `.t8scene` load/save.
+- Play Scene export/runtime hosting.
+- Mesh Editor, Ragdoll Editor, NavMesh Authoring.
+
+## Dev layer
+
+`DevLayer` is a runtime scene wrapper, not the editor. It is used by the runtime app to:
+
+- forward `Update`, `Draw`, and `ProcessInput` to the active `SceneBase`;
+- block scene input when needed;
+- support a pause toggle;
+- save scene state on Tab;
+- request frame dumps on F10;
+- draw culling debug resources.
+
+```mermaid
+flowchart LR
+  App["Runtime App"] --> DevLayer
+  DevLayer --> SceneBase
+  DevLayer --> CullingDebug["Culling debug frustum/sphere"]
+  SceneBase --> SceneProps
+  SceneProps --> Cameras
+  SceneProps --> Lights
+```
+
+## Scene properties and shared scene state
+
+`SceneBase::SceneProp` is the shared runtime scene state object. It carries:
+
+- camera lists and active camera;
+- light lists and active light camera;
+- render feature toggles such as shadow, SSAO, DOF, parallax, God Rays;
+- material/global lighting parameters;
+- culling settings and debug counters;
+- God Rays volume parameters;
+- camera culling state.
+
+Render systems and render graph passes read from `SceneProps`, so many editor/runtime features work by updating `SceneProps` before rendering.
+
+## Global graphics objects
+
+`BaseDriver.cpp` defines these global pointers:
+
+- `g_pBaseDriver`
+- `T8Device`
+- `T8DeviceContext`
+
+They are legacy/global access points used throughout Framework systems. `EngineContext` wraps the same pointers into a more structured object, but both paths still exist.
+
+Important rule: after an API switch or driver recreation, GPU resource caches and `EngineContext` must be refreshed. `Win32Framework::ChangeAPI()` clears mesh/material caches and calls `RefreshEngineContextFromGlobals()` after the new driver initializes.
+
+## API switching
+
+The Windows path supports runtime API switching through `Win32Framework::ChangeAPI()`.
+
+High-level flow:
+
+```mermaid
+flowchart TD
+  Request["ChangeAPI(api)"] --> IfInited{"Already initialized?"}
+  IfInited -->|yes| Flush["Flush GPU resources"]
+  Flush --> DestroyAssets["AppBase::DestroyAssets"]
+  DestroyAssets --> ClearCaches["Clear MeshAssetCache / MaterialAssetCache / ResourceManager"]
+  ClearCaches --> DestroyDriver["Destroy old driver"]
+  IfInited -->|no| Window
+  DestroyDriver --> Window["Destroy old SDL window/context"]
+  Window --> CreateWindow["Create SDL window with API flags"]
+  CreateWindow --> NewDriver["Create GL/D3D11/D3D12/Vulkan driver"]
+  NewDriver --> InitDriver["InitDriver"]
+  InitDriver --> Context["RefreshEngineContextFromGlobals"]
+  Context --> CreateAssets["AppBase::CreateAssets"]
+  CreateAssets --> PSO["BuildPipelineObjects"]
+```
+
+This is why GPU-owned resources should be created in `CreateAssets()` or later and destroyed in `DestroyAssets()`.
+
+## Platform summary
+
+| Platform | Framework | Graphics APIs | Notes |
+|---|---|---|---|
+| Windows | `Win32Framework` | D3D11, D3D12, OpenGL, Vulkan | SDL window, Win32 icon/mouse confinement, gamepad handling, API switching. |
+| Linux / Steam Deck | `LinuxFramework` | Vulkan only | SDL window, Steam Deck detection, Vulkan-only backend. |
+| Android | `AndroidFramework` | Vulkan only | Native activity window lifecycle, `ANativeWindow`, Android input/touch/back handling. |
+
+See [platform-event-loop.md](platform-event-loop.md) for details.
+
+## Extension points
+
+To add a new runtime scene:
+
+1. Implement `SceneBase`.
+2. Implement `InitVars`, `CreateAssets`, `DestroyAssets`, `OnUpdate`, `OnDraw`, `OnInput`, `OnLoadScene`, `OnDestoryScene`.
+3. Register or instantiate it from the runtime `App`.
+4. Ensure all graphics resources are recreated correctly after API switches.
+
+To add a new platform:
+
+1. Implement `RootFramework`.
+2. Provide lifecycle, input, window/surface, API creation, resize, and destruction behavior.
+3. Ensure `RefreshEngineContextFromGlobals()` is called after driver creation.
+4. Ensure `AppBase::CreateAssets()` / `DestroyAssets()` are called around driver lifetime changes.
+
+To add a new graphics backend:
+
+1. Implement `BaseDriver`, `Device`, `DeviceContext`, buffers, textures, shaders, render targets.
+2. Add creation path to the platform framework.
+3. Ensure shader/resource binding conventions match existing renderers.
+4. Implement frame lifecycle methods for explicit APIs.
+
+## Known limitations and gotchas
+
+- `OnDestoryScene` is misspelled in the `SceneBase` API and existing code; use the existing name unless doing a coordinated API rename.
+- `g_pBaseDriver`, `T8Device`, and `T8DeviceContext` are still global; `EngineContext` is a structured wrapper, not a total replacement.
+- API switches destroy and recreate GPU resources. Any cache that owns GPU handles must be cleared or rebuilt.
+- Android and Steam Deck force Vulkan.
+- Android bypasses some desktop dev-layer paths.
+- Many scene examples still have very large monolithic `.cpp` files; documentation should explain the runtime flow even when code organization is legacy.
+
+## Debugging checklist
+
+- If rendering fails after an API switch, verify `CreateAssets()` recreated all GPU resources.
+- If a subsystem sees null graphics pointers, check `RefreshEngineContextFromGlobals()`.
+- If a scene does not receive input, check dev-layer input blocking, ImGui capture, app pause state, and platform event mapping.
+- If a hidden mesh is expected to drive NavMesh, verify it has explicit `navigation.include=true`.
+- If Android/Steam Deck behaves differently, check whether the desktop dev-layer path is bypassed.
+
+## Related documents
+
+- [Platform Event Loop and Window Management](platform-event-loop.md)
+- [Geometry Loading](../geometry/loading-geometry.md)
+- [Render Graph](../rendering/render-graph.md)
+- [Geometry Rendering Flow](../rendering/geometry-rendering-flow.md)
+- [Editor Overview](../editor/editor-overview.md)
+- [Scene Format and Runtime](../scenes/scene-format-and-runtime.md)

--- a/documentation/architecture/main-architecture.md
+++ b/documentation/architecture/main-architecture.md
@@ -2,6 +2,15 @@
 
 This document describes the top-level architecture of T850: the Framework layer, scene applications, editor application, dev layer, and shared runtime context. It focuses on ownership and lifecycle rather than subsystem internals.
 
+Related documents:
+
+- [Dependency map](../dependency-map.md)
+- [Platform event loop](platform-event-loop.md)
+- [Resource locator and cache paths](resource-locator.md)
+- [Input, camera, and controls](../input/camera-and-controls.md)
+- [FrameworkImGui runtime UI](../editor/imgui-system.md)
+- [Scene format and runtime](../scenes/scene-format-and-runtime.md)
+
 ## Purpose
 
 T850 is organized around a reusable **Framework** plus executable **applications/scenes**:

--- a/documentation/architecture/platform-event-loop.md
+++ b/documentation/architecture/platform-event-loop.md
@@ -1,0 +1,353 @@
+# Platform Event Loop and Window Management
+
+This document describes how T850 runs on Windows, Linux/Steam Deck, and Android: event loops, window/surface ownership, graphics API creation, resize handling, and frame lifecycle.
+
+For the high-level application/scene architecture, see [main-architecture.md](main-architecture.md).
+
+## Purpose
+
+The Framework hides platform differences behind `RootFramework`. Each platform implementation must:
+
+- create and destroy native windows/surfaces;
+- select or force a graphics API;
+- create the correct `BaseDriver` backend;
+- feed input into `AppBase::IManager`;
+- run the application update loop;
+- handle resize/surface loss/pause/resume;
+- call app lifecycle methods at the right time.
+
+## Platform implementations
+
+| Platform | File | Class | Window/surface |
+|---|---|---|---|
+| Windows | `T850/Framework/src/core/windows/Win32Framework.cpp` | `t850::Win32Framework` | `SDL_Window*`, optional `SDL_GLContext`, HWND for icon/mouse confinement |
+| Linux / Steam Deck | `T850/Framework/src/core/LinuxFramework.cpp` | `t850::LinuxFramework` | `SDL_Window*` with `SDL_WINDOW_VULKAN` |
+| Android | `T850/Framework/src/core/android/AndroidFramework.cpp` | `t850::AndroidFramework` | `ANativeWindow*` from native activity glue |
+
+## Window and API ownership
+
+```mermaid
+flowchart TD
+  Root["RootFramework"] --> Window["Platform window/surface"]
+  Root --> Driver["BaseDriver backend"]
+  Driver --> Device["Device"]
+  Driver --> Context["DeviceContext"]
+  Driver --> Swapchain["Swapchain / backbuffer"]
+  Window --> Driver
+  Driver --> EngineContext["EngineContext"]
+```
+
+`RootFramework` owns the driver pointer. The driver owns API-specific objects such as device, swapchain, render passes, descriptor heaps, or GL context integration. `EngineContext` is refreshed after the driver is initialized.
+
+## Windows lifecycle
+
+`Win32Framework` is the most flexible platform implementation. It supports D3D11, D3D12, OpenGL, and Vulkan.
+
+### Creation flow
+
+```mermaid
+sequenceDiagram
+  participant Main as main()
+  participant FW as Win32Framework
+  participant App as AppBase
+  participant SDL as SDL
+  participant Driver as BaseDriver
+
+  Main->>FW: OnCreateApplication(desc)
+  FW->>FW: InitGlobalThreadPool()
+  FW->>FW: RuntimeTelemetry::InitializeFromConfig()
+  FW->>SDL: SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD)
+  FW->>App: InitVars()
+  FW->>FW: InitializeGamepads()
+  FW->>FW: ChangeAPI(desc.api)
+  FW->>SDL: SDL_CreateWindow(...)
+  FW->>Driver: new D3D11/D3D12/GL/Vulkan driver
+  FW->>Driver: InitDriver()
+  FW->>FW: RefreshEngineContextFromGlobals()
+  FW->>App: CreateAssets()
+  FW->>Driver: BuildPipelineObjects()
+```
+
+### Update loop
+
+`Win32Framework::UpdateApplication()` is simple:
+
+```mermaid
+flowchart TD
+  Loop["while m_alive"] --> Input["ProcessInput"]
+  Input --> Update["AppBase::OnUpdate"]
+  Update --> Loop
+  Loop -->|exit| ReleaseMouse["ReleaseMouseMode"]
+```
+
+The app itself usually calls draw from inside `OnUpdate()`. Runtime `App::OnUpdate()` calls `OnDraw()` after update/input. Editor `EditorApp::OnUpdate()` also calls `OnDraw()` at the end.
+
+### Input processing
+
+`Win32Framework::ProcessInput()` polls SDL events and writes into `AppBase::IManager`.
+
+Input sources:
+
+- keyboard down/up events;
+- text input;
+- mouse motion/buttons/wheel;
+- window resize/pixel-size changes;
+- gamepad add/remove and axis/button polling.
+
+Escape closes the application unless `AppBase::IsModalActive()` returns true.
+
+### Mouse modes
+
+`Win32Framework` supports:
+
+- relative mouse mode when `AppBase::WantsRelativeMouseMode()` is true;
+- cursor hide/show;
+- cursor confinement for modal UI;
+- mouse delta reset on window state changes.
+
+This matters for editor hosted windows, fullscreen, gameplay camera control, and ImGui modals.
+
+### API switching
+
+`Win32Framework::ChangeAPI()` handles:
+
+1. Flush old GPU work.
+2. Destroy app assets.
+3. Clear mesh/material/resource caches.
+4. Destroy old driver.
+5. Destroy old SDL window/context.
+6. Create new SDL window with API-specific flags.
+7. Create backend driver.
+8. Initialize driver.
+9. Refresh `EngineContext`.
+10. Recreate app assets.
+11. Build pipeline objects.
+
+```mermaid
+flowchart LR
+  D3D11 --> ChangeAPI
+  D3D12 --> ChangeAPI
+  GL --> ChangeAPI
+  Vulkan --> ChangeAPI
+  ChangeAPI --> DestroyOld["Destroy old API resources"]
+  DestroyOld --> CreateNew["Create new window + driver"]
+  CreateNew --> RecreateAssets["AppBase::CreateAssets"]
+```
+
+## Linux / Steam Deck lifecycle
+
+`LinuxFramework` is Vulkan-only.
+
+Important behavior:
+
+- forces `ApplicationDesc.api = GraphicsApi::VULKAN`;
+- initializes SDL video/gamepad;
+- detects Steam Deck-like hardware through DMI strings;
+- creates an SDL Vulkan window;
+- creates `VulkanDriver`;
+- refreshes `EngineContext`;
+- calls `AppBase::CreateAssets()`;
+- runs an update loop similar to Windows.
+
+```mermaid
+flowchart TD
+  Create["LinuxFramework::OnCreateApplication"] --> ForceVK["Force Vulkan"]
+  ForceVK --> SDL["SDL_Init"]
+  SDL --> AppVars["AppBase::InitVars"]
+  AppVars --> ChangeAPI["ChangeAPI(VULKAN)"]
+  ChangeAPI --> Window["SDL Vulkan window"]
+  Window --> Driver["VulkanDriver"]
+  Driver --> Context["RefreshEngineContextFromGlobals"]
+  Context --> Assets["AppBase::CreateAssets"]
+  Assets --> Loop["UpdateApplication loop"]
+```
+
+`LinuxFramework::ProcessInput()` uses SDL key/mouse/gamepad/window events and feeds `InputManager`.
+
+Resize handling:
+
+- `SDL_EVENT_WINDOW_RESIZED`
+- `SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED`
+- calls `BaseDriver::ResizeSwapchain`.
+
+## Android lifecycle
+
+`AndroidFramework` is also Vulkan-only.
+
+Important behavior:
+
+- uses `android_native_app_glue`;
+- stores `android_app*`;
+- receives `ANativeWindow*` from app commands;
+- creates/destroys/suspends/resumes Vulkan runtime as native window changes;
+- forwards Android input events to `AppBase::HandleAndroidInputEvent` first;
+- maps touch input to mouse-like input in `InputManager`;
+- maps Android back key to Escape/close behavior.
+
+### Android creation and surface flow
+
+```mermaid
+sequenceDiagram
+  participant Glue as android_native_app_glue
+  participant FW as AndroidFramework
+  participant App as AppBase
+  participant Driver as VulkanDriver
+
+  Glue->>FW: OnCreateApplication(desc)
+  FW->>App: InitVars()
+  Glue->>FW: APP_CMD_INIT_WINDOW
+  FW->>FW: OnNativeWindowCreated(ANativeWindow)
+  FW->>Driver: CreateVulkanRuntime()
+  Driver->>Driver: InitDriver()
+  FW->>App: CreateAssets()
+  FW->>Driver: BuildPipelineObjects()
+  FW->>FW: UpdateApplication loop
+```
+
+### Android pause/resume
+
+```mermaid
+flowchart TD
+  Pause["APP_CMD_PAUSE / LOST_FOCUS"] --> Interrupt["OnInterruptApplication"]
+  Interrupt --> AppPause["AppBase::OnPause"]
+  Interrupt --> ClearTouch["ClearTouchState"]
+
+  Resume["APP_CMD_RESUME / GAINED_FOCUS"] --> ResumeApp["OnResumeApplication"]
+  ResumeApp --> AppResume["AppBase::OnResume"]
+
+  Term["APP_CMD_TERM_WINDOW"] --> Suspend["SuspendVulkanWindow"]
+  Init["APP_CMD_INIT_WINDOW"] --> ResumeSurface["ResumeVulkanWindow or CreateVulkanRuntime"]
+```
+
+### Android input
+
+Android input uses:
+
+- `AInputEvent` motion events for touch;
+- one-finger touch mapped to mouse position/button;
+- two-finger pinch mapped to scroll delta;
+- back key mapped to Escape/close;
+- app-specific input gets first chance through `AppBase::HandleAndroidInputEvent`.
+
+## BaseDriver frame lifecycle
+
+`BaseDriver` defines common frame methods:
+
+- `BeginFrame(FrameTargetMode)`
+- `EndFrame()`
+- `CompleteFrame(FrameCompletionMode)`
+- `Clear()`
+- `SwapBuffers()`
+- `ResizeSwapchain()`
+- `WaitForGPU()`
+- `FlushGPUResources()`
+
+Explicit APIs override these:
+
+- D3D12: `T850/Framework/src/video/d3d12/D3D12Driver.cpp`
+- Vulkan: `T850/Framework/src/video/vulkan/VulkanDriver.cpp`
+
+Default/simple APIs can rely on `SwapBuffers()`.
+
+## Frame ownership by executable
+
+### Runtime application
+
+Runtime `App::OnUpdate()` and `App::OnDraw()` control most frame logic.
+
+```mermaid
+flowchart TD
+  FrameworkLoop["RootFramework::UpdateApplication"] --> AppUpdate["App::OnUpdate"]
+  AppUpdate --> SceneUpdate["DevLayer.Update / Scene.OnUpdate"]
+  SceneUpdate --> Physics["Physics update"]
+  Physics --> AppInput["App::OnInput"]
+  AppInput --> AppDraw["App::OnDraw"]
+  AppDraw --> DriverClear["Driver::Clear"]
+  DriverClear --> SceneDraw["DevLayer.Draw / Scene.OnDraw"]
+  SceneDraw --> RuntimeGui["Runtime GUI"]
+  RuntimeGui --> Present["Present/Swap"]
+```
+
+### Editor application
+
+`EditorApp::OnUpdate()` owns editor timing, input, scene loading, and drawing.
+
+```mermaid
+flowchart TD
+  FrameworkLoop["RootFramework::UpdateApplication"] --> EditorUpdate["EditorApp::OnUpdate"]
+  EditorUpdate --> LoadPending["LoadPendingScene"]
+  LoadPending --> Resize["CheckResize"]
+  Resize --> EditorInput["EditorApp::OnInput"]
+  EditorInput --> EditorDraw["EditorApp::OnDraw"]
+  EditorDraw --> Begin["Driver::BeginFrame"]
+  Begin --> RenderScene["RenderEditorSceneFrame"]
+  RenderScene --> UI["DrawEditorUI"]
+  UI --> Dumps["Frame dump"]
+  Dumps --> Swap["SwapBuffers + EndFrame"]
+```
+
+## Resize handling
+
+Platform resize enters through window events and ends at the driver.
+
+```mermaid
+flowchart LR
+  WindowResize["SDL resize / pixel-size event"] --> Framework["RootFramework::ProcessInput"]
+  Framework --> Desc["Update ApplicationDesc width/height"]
+  Desc --> ResetInput["Reset input deltas/baseline"]
+  ResetInput --> Driver["BaseDriver::ResizeSwapchain"]
+  Driver --> Backbuffers["Swapchain/backbuffer/depth recreation"]
+```
+
+The editor also has its own `CheckResize()` and hosted viewport/render-target management for editor windows and embedded scenes.
+
+## API/platform constraints
+
+| Platform | API behavior |
+|---|---|
+| Windows | Can select D3D11, D3D12, OpenGL, Vulkan. Runtime scenes also expose API switching hotkeys in some scenes. |
+| Linux/Steam Deck | Vulkan-only. Non-Vulkan requests are forced to Vulkan. |
+| Android | Vulkan-only. Native window controls surface creation/suspend/resume. |
+
+## Troubleshooting
+
+### App starts but graphics pointers are null
+
+Check:
+
+- Did platform framework call `ChangeAPI()`?
+- Did driver `InitDriver()` set `T8Device` and `T8DeviceContext`?
+- Did framework call `RefreshEngineContextFromGlobals()`?
+
+### Resources disappear after API switch
+
+Expected if they were GPU resources. They must be recreated in `AppBase::CreateAssets()` and released in `DestroyAssets()`.
+
+### Input sticks after alt-tab/resize/modal
+
+Check platform reset paths:
+
+- `Win32Framework::ResetInputAfterWindowStateChange`
+- Linux resize handling
+- Android `ClearTouchState`
+
+### Android renders black after resume
+
+Check:
+
+- `OnNativeWindowCreated`
+- `ResumeVulkanWindow`
+- `CreateVulkanRuntime`
+- `AppBase::OnAndroidNativeWindowChanged`
+
+### Steam Deck uses wrong API
+
+It should not. `LinuxFramework::ChangeAPI()` forces Vulkan.
+
+## Related documents
+
+- [Main Architecture](main-architecture.md)
+- [Shader Management](../rendering/shader-management.md)
+- [Render Graph](../rendering/render-graph.md)
+- [Editor Overview](../editor/editor-overview.md)
+- [Scene Format and Runtime](../scenes/scene-format-and-runtime.md)

--- a/documentation/architecture/platform-event-loop.md
+++ b/documentation/architecture/platform-event-loop.md
@@ -2,7 +2,7 @@
 
 This document describes how T850 runs on Windows, Linux/Steam Deck, and Android: event loops, window/surface ownership, graphics API creation, resize handling, and frame lifecycle.
 
-For the high-level application/scene architecture, see [main-architecture.md](main-architecture.md).
+For the high-level application/scene architecture, see [main-architecture.md](main-architecture.md). For input and camera routing details, see [Input, camera, and controls](../input/camera-and-controls.md). For runtime/editor ImGui backend details, see [FrameworkImGui runtime UI](../editor/imgui-system.md). For cross-subsystem ownership, see [dependency-map.md](../dependency-map.md).
 
 ## Purpose
 

--- a/documentation/architecture/resource-locator.md
+++ b/documentation/architecture/resource-locator.md
@@ -1,0 +1,389 @@
+# Resource Locator and Cache Paths
+
+Status: Stage 14 draft.
+
+This document explains how T850 resolves asset paths, reads files on desktop and Android, chooses writable cache locations, and keeps generated cache files portable across editor, runtime scenes, and packaged builds.
+
+Related documents:
+
+- [Main architecture](main-architecture.md)
+- [Platform event loop](platform-event-loop.md)
+- [Loading geometry](../geometry/loading-geometry.md)
+- [Shader management](../rendering/shader-management.md)
+- [Textures, samplers, and IBL](../rendering/textures-and-ibl.md)
+- [Jolt physics](../physics/jolt-physics.md)
+- [NavMesh and Detour](../navigation/navmesh-detour.md)
+- [Scene format and runtime](../scenes/scene-format-and-runtime.md)
+- [Debug and diagnostics](../debug/diagnostics.md)
+
+## Purpose and responsibilities
+
+`ResourceLocator` is the central path abstraction for engine assets and generated runtime/editor caches.
+
+It is responsible for:
+
+1. Normalizing authored resource paths into engine-style relative names.
+2. Reading bytes/text from desktop files or Android packaged assets.
+3. Providing writable cache paths that work when assets are not directly writable.
+4. Supporting recursive fallback lookup for moved scene meshes.
+5. Keeping generated cache producers under consistent roots.
+
+```mermaid
+flowchart LR
+  Request["Scene / render / loader request"] --> Normalize["ResourceLocator::NormalizePath"]
+  Normalize --> ReadOrWrite{"Read or write?"}
+  ReadOrWrite -->|read| Desktop["desktop disk candidates"]
+  ReadOrWrite -->|read| Android["Android AAssetManager"]
+  ReadOrWrite -->|write/cache| Cache["ResolveCachePath"]
+  Desktop --> Result["Exists / ReadBinary / ReadText / ResolveFilePath"]
+  Android --> Result
+  Cache --> CacheFile["generated cache or writable JSON"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `Framework/include/utils/ResourceLocator.h` | Public singleton API for normalization, reads, lists, recursive lookup, file-path resolution, cache-path resolution, and Android asset-manager binding. |
+| `Framework/src/utils/ResourceLocator.cpp` | Desktop candidate search, Android packaged-asset read/list/fallback logic, cache path resolution, and text/binary helpers. |
+| `Framework/include/utils/AndroidAssets.h` / `Framework/src/utils/AndroidAssets.cpp` | Android wrapper functions that forward asset-manager setup and reads to `ResourceLocator`. |
+| `DayScene/AndroidEntry.cpp` | Installs the Android `AAssetManager`, sets base/cache paths to app data storage, and changes the working directory on Android. |
+| `Framework/src/utils/ResourceManager.cpp` | In-memory mesh database loader/reuser; dispatches `.gltf`/`.glb` to glTF and other paths to legacy `.x`. |
+| `Framework/src/scene/EditorSceneFile.cpp` | `.t8scene` text read/write and recursive mesh fallback resolution. |
+| `Framework/src/utils/gltf/GLTFLoader.cpp` | Reads `.gltf`/`.glb` and external glTF buffers through `ResourceLocator::ReadBinary`. |
+| `Framework/src/utils/gltf/GLTFImage.cpp` | Reads external glTF images through `ReadBinary` and registers decoded texture bytes. |
+| `Framework/src/video/BaseDriver.cpp` | Texture load path prepends `Textures/`, checks `Exists`, and falls back to checker texture when missing. |
+| `Framework/src/utils/ShaderDiskCache.cpp` | Compiled shader artifact cache under `Shaders/.t8shadercache`. |
+| `Framework/src/scene/MeshAssetCache.cpp` | Mesh preprocess/culling metadata cache under source-local `.t8cache` directories. |
+| `Framework/src/physics/JoltPhysicsSystem.cpp` | Cooked Jolt triangle mesh cache under source-local `.t8cache` directories. |
+| `Framework/src/navigation/NavigationSystem.cpp` | Generated and baked `.t8nav` cache/asset load-save paths. |
+| `Framework/src/scene/IBLResources.cpp` | Generated IBL cache under `Textures/GeneratedIBLCache`. |
+
+## Singleton lifetime and configured roots
+
+`ResourceLocator::Instance()` owns one process-wide locator.
+
+On construction:
+
+- `m_basePath` defaults to `std::filesystem::current_path()`.
+- `m_cachePath` defaults to the same value as `m_basePath`.
+
+Callers can change them with:
+
+| API | Meaning |
+|---|---|
+| `SetBasePath(path)` | Adds a preferred root for resolving relative readable assets. |
+| `GetBasePath()` | Returns the configured readable root. |
+| `SetCachePath(path)` | Sets the preferred root for relative writable/cache files. |
+| `GetCachePath()` | Returns the configured cache root. |
+
+Android startup is the only platform-specific setup currently performed by the app:
+
+1. `AndroidEntry.cpp` calls `SetAndroidAssetManager(state->activity->assetManager)`.
+2. It chooses `externalDataPath` or `internalDataPath`.
+3. It calls `SetBasePath(dataPath)` and `SetCachePath(dataPath)`.
+4. It attempts `chdir(dataPath)` and logs the Android working directory.
+
+That means packaged APK assets are read through `AAssetManager`, while generated files and caches go to app data storage.
+
+## Path normalization rules
+
+`ResourceLocator::NormalizePath(path)` performs engine-resource normalization:
+
+1. Convert backslashes to forward slashes.
+2. Remove leading slashes.
+3. Remove leading `./` segments.
+4. Strip a top-level `Assets/` prefix case-insensitively.
+
+Examples:
+
+| Input | Normalized output |
+|---|---|
+| `Assets\Models\Robot.glb` | `Models/Robot.glb` |
+| `/Textures/sky.dds` | `Textures/sky.dds` |
+| `./Scenes/day.json` | `Scenes/day.json` |
+
+Important: `NormalizePath` does not lower-case the whole path. It preserves authored case after stripping `Assets/`. Case-insensitive behavior is limited to Android packaged-asset fallback and specific subsystem keys such as `MeshAssetCache::Normalize()`.
+
+## Desktop read lookup
+
+For non-absolute paths, desktop disk lookup tries a fixed candidate list. Given `originalPath` and `normalizedPath`, `DiskCandidates()` tries:
+
+1. the original relative path,
+2. the normalized relative path when it differs,
+3. `basePath / normalizedPath`,
+4. `current_working_directory / normalizedPath`,
+5. `current_working_directory / Assets / normalizedPath`,
+6. `current_working_directory / T850 / Assets / normalizedPath`.
+
+If the original request is absolute, the absolute path is the only disk candidate.
+
+This makes the same authored path work from several launch locations:
+
+```text
+Models/robot.glb
+Assets/Models/robot.glb
+<cwd>/Models/robot.glb
+<cwd>/Assets/Models/robot.glb
+<cwd>/T850/Assets/Models/robot.glb
+```
+
+## Android packaged-asset lookup
+
+Android assets inside the APK are not regular filesystem files. Callers must use `Exists`, `ReadBinary`, `ReadText`, or `List`; `ResolveFilePath` is only meaningful for directly addressable filesystem paths.
+
+Android behavior:
+
+- `Exists()` checks packaged assets first, then disk candidates.
+- `ReadBinary()` tries disk candidates first, then packaged assets.
+- `ReadText()` calls `ReadBinary()` and converts the bytes to a string.
+- `List()` merges Android packaged entries and disk entries, then sorts and de-duplicates them.
+
+`ResolveAndroidAssetPathCaseInsensitive()` gives packaged builds a case-insensitive fallback:
+
+1. Try to match the filename inside the requested parent directory.
+2. If that fails, walk path segments from the root and match each segment case-insensitively.
+
+This helps when desktop development succeeds on a case-insensitive filesystem but packaged Android asset casing differs.
+
+## Public API behavior
+
+| API | Behavior |
+|---|---|
+| `Exists(path)` | Normalizes the path, checks Android packaged assets on Android, then checks desktop disk candidates for a file or directory. |
+| `ReadBinary(path, out)` | Clears `out`, normalizes the path, reads the first readable disk candidate, then falls back to Android packaged assets on Android. |
+| `ReadText(path, out)` | Uses `ReadBinary`; clears `out` on failure. |
+| `WriteText(path, text)` | Writes absolute paths directly. For relative paths, writes to an existing resolved file when found; otherwise writes under `ResolveCachePath`. |
+| `List(directory, recursive)` | Lists files from Android assets and/or desktop disk, returns engine resource paths, sorts and de-duplicates results. |
+| `ResolveFilePath(path)` | Returns the first regular desktop filesystem candidate; if nothing exists, returns the original requested path. |
+| `ResolveCachePath(path)` | Returns absolute paths unchanged; otherwise normalizes and appends to `m_cachePath`, or returns the normalized relative path if no cache root exists. |
+| `FindFileByNameRecursive(requestedPath, outPath, searchDirectories)` | Searches by filename under caller directories, requested parent, requested first top-level directory, `Models` for glTF/GLB, then root. |
+
+## ResolveFilePath versus ResolveCachePath
+
+Use the APIs for different purposes:
+
+```mermaid
+flowchart TD
+  NeedFile["Need readable existing asset?"] --> ResolveFile["ResolveFilePath or ReadBinary/ReadText"]
+  NeedWrite["Need generated/writable file?"] --> ResolveCache["ResolveCachePath"]
+  ResolveFile --> DesktopOnly["desktop filesystem path"]
+  ResolveFile --> AndroidNote["not an APK asset path"]
+  ResolveCache --> CacheRoot["cachePath / normalized relative path"]
+```
+
+Use `ReadBinary` or `ReadText` when the data may live in an Android APK asset. Use `ResolveFilePath` only when a subsystem truly needs a `std::filesystem::path` to a disk file.
+
+Use `ResolveCachePath` for generated data because packaged assets are read-only on Android and may be read-only in installed desktop builds.
+
+## Scene and mesh fallback behavior
+
+`.t8scene` files are loaded through `LoadEditorSceneFile()` using `ResourceLocator::ReadText()`.
+
+After parsing, `EditorSceneFile.cpp` tries to repair missing mesh references:
+
+1. Normalize object mesh paths with `NormalizeSceneResourcePath()`.
+2. If the normalized glTF/GLB path exists, store that normalized path.
+3. Otherwise search recursively by filename.
+
+The fallback directories are:
+
+- the scene file's parent directory,
+- the mesh path's parent directory,
+- the first top-level directory in the mesh path,
+- `Models`.
+
+`FindFileByNameRecursive()` also adds the requested parent, the first top-level directory, `Models` for `.gltf`/`.glb`, and root. It matches filenames case-insensitively and returns the first normalized resource path found.
+
+This is a recovery path for moved scene meshes. It should not be used as a substitute for saving correct relative resource paths.
+
+## ResourceManager path role
+
+`ResourceManager::Load(filename)` is not a general path resolver. It is an in-memory `xF::XDataBase` reuse layer plus format dispatcher:
+
+```mermaid
+flowchart LR
+  Request["ResourceManager::Load(filename)"] --> Existing["m_resources exact-name reuse"]
+  Existing -->|miss| Ext["extension lower-case"]
+  Ext -->|.gltf/.glb| GLTF["gltf::LoadGLTF + ConvertToXDatabase"]
+  Ext -->|other| XFile["XDataBase::LoadXFile"]
+  GLTF --> XDB["xF::XDataBase"]
+  XFile --> XDB
+```
+
+The actual file bytes are read deeper in the glTF loader, `XDataBase`, texture loader, shader source loader, or other subsystem through `ResourceLocator`.
+
+## Read path users
+
+| Subsystem | ResourceLocator dependency |
+|---|---|
+| Config/runtime JSON | `ConfigRuntime.cpp` reads config text through `ReadText`. |
+| Render graph | `RenderGraph.cpp` reads render graph JSON through `ReadText`. |
+| Scene descriptors | `SceneDescriptor.cpp` reads and writes descriptor JSON through `ReadText`/`WriteText`. |
+| `.t8scene` | `EditorSceneFile.cpp` reads scene JSON through `ReadText` and writes JSON through `WriteText`. |
+| Shader sources | `Utils.cpp::file2string()` reads shader/source text through `ReadText`. |
+| Vulkan SPIR-V | `VulkanShader.cpp` reads binary shader artifacts through `ReadBinary`. |
+| glTF buffers | `GLTFLoader.cpp` resolves external buffers relative to the `.gltf` and reads them through `ReadBinary`. |
+| glTF images | `GLTFImage.cpp` resolves external images relative to the `.gltf` and reads them through `ReadBinary`. |
+| Texture loading | `Texture::LoadTexture()` checks `Textures/<name>` with `Exists`; lower-level CIL file reads also use `ReadBinary`. |
+| Q3 BSP collision | `Q3BspCollision.cpp` reads collision text through `ReadText`. |
+| Ragdoll authoring | `PhysicsAuthoring.cpp` reads authoring JSON through `ReadText` and chooses writable paths through locator-aware helpers. |
+
+## Cache-producing subsystems
+
+Generated caches should be rooted through `ResolveCachePath()` unless the user explicitly provides an absolute output path.
+
+```mermaid
+flowchart TD
+  CachePath["ResourceLocator::ResolveCachePath"] --> Shader["Shaders/.t8shadercache"]
+  CachePath --> Mesh["<source parent>/.t8cache/*.t8mesh"]
+  CachePath --> Jolt["<source parent>/.t8cache/*.t8jolt"]
+  CachePath --> Nav["Navigation/.t8cache/*.t8nav"]
+  CachePath --> IBL["Textures/GeneratedIBLCache/*.t8ibl"]
+  CachePath --> Json["Skeleton/Ragdoll/runtime JSON edits"]
+```
+
+| Cache | Path rule | Key/invalidation inputs |
+|---|---|---|
+| Shader disk cache | `ResolveCachePath("Shaders/.t8shadercache") / <api> / <sha1>` | cache format/version, API, driver signature, shader key bits, shader names, shader source contents. Driver metadata changes clear the API directory. |
+| Mesh preprocess cache | `<source parent>/.t8cache/<stem>_v<version>_<hash>.t8mesh`, resolved under cache root for relative sources | cache version, clustering settings, source size, source write ticks or byte hash, normalized source path; header validates source signature, settings, and metadata ranges. |
+| Jolt cooked mesh cache | `<source parent>/.t8cache/<stem>_joltmesh_v<version>_<hash>.t8jolt`, resolved under cache root for relative sources | cache version, Jolt version, platform tag, cook settings, normalized source path, vertices, indices; header validates version/Jolt/platform/counts. |
+| Generated NavMesh cache | `Navigation/.t8cache/navmesh_<key>.t8nav` under cache root | cache version, Recast/T850 build settings, query extents, auto-link settings, off-mesh validation key, vertices, indices, off-mesh links, modifiers, area costs. |
+| Baked NavMesh asset | caller path; relative save paths are resolved through `ResolveCachePath`, load paths through `ResolveFilePath` | baked files use expected key `0` and are treated as explicit assets rather than generated key-addressed cache entries. |
+| IBL generated cache | `Textures/GeneratedIBLCache/<kind>_v<version>_<hash>.t8ibl` under cache root | cache version, IBL kind, source bytes or source path/file metadata, dimensions, mip/face/sample settings, generated sizes. |
+| Runtime/editor JSON writes | absolute path, existing resolved file path, or cache path fallback | depends on owning subsystem; examples include runtime ImGui settings, skeleton edits, ragdoll edits, and descriptor writes. |
+
+## Shader cache path
+
+`ShaderDiskCache.cpp` uses:
+
+```text
+Shaders/.t8shadercache/
+  metadata.json
+  d3d11/<sha1>/...
+  d3d12/<sha1>/...
+  opengl/<sha1>/...
+  vulkan/<sha1>/...
+```
+
+The root is always `ResourceLocator::Instance().ResolveCachePath("Shaders/.t8shadercache")`.
+
+`metadata.json` stores per-API driver signatures. If a driver signature changes, the API-specific directory is removed before new artifacts are written. Individual shader directories include a `manifest.json` with cache format, cache version, API, SHA-1, shader key, shader source names, and driver signature.
+
+## Mesh preprocess cache path
+
+`MeshAssetCache` has two cache layers:
+
+- in-memory `MeshAsset` entries keyed by a lower-case, forward-slash source path;
+- disk preprocess metadata keyed by source signature and preprocess settings.
+
+The disk path is:
+
+```text
+<source parent>/.t8cache/<stem>_v2_<hash>.t8mesh
+```
+
+For relative sources, the path is passed through `ResolveCachePath()`. For absolute sources, the `.t8cache` directory is placed next to the absolute source.
+
+The source signature uses desktop file size/write time when the source is a real file. If a source is not a filesystem file but `ReadBinary()` succeeds, it hashes the bytes; this matters for Android packaged assets.
+
+## Jolt cooked mesh cache path
+
+`JoltPhysicsSystem` stores cooked triangle mesh shapes as:
+
+```text
+<source parent>/.t8cache/<stem>_joltmesh_v<version>_<hash>.t8jolt
+```
+
+The hash includes:
+
+- T850 cooked-mesh cache version,
+- Jolt version,
+- platform tag,
+- cook settings such as max triangles per leaf, build quality, active-edge threshold, and per-triangle user data,
+- normalized source path,
+- full vertex and index data.
+
+The file header repeats version, hash, Jolt version, platform tag, vertex count, triangle count, and cook settings. A mismatch causes the cache to be ignored and rebuilt when disk cache is enabled.
+
+## NavMesh cache and baked assets
+
+Generated NavMesh cache files use:
+
+```text
+Navigation/.t8cache/navmesh_<16-hex-key>.t8nav
+```
+
+The key is computed from build settings plus source geometry and navigation metadata. `BuildCached()` loads the generated cache only when a nonzero key is provided and the geometry has no explicit off-mesh links. If explicit links are present, it rebuilds; the computed key still includes links and the result can be saved for later.
+
+Baked NavMesh assets are different:
+
+- `LoadBaked(path)` uses `ResolveFilePath(path)`.
+- `SaveBaked(path)` writes an absolute path directly or resolves a relative path through `ResolveCachePath(path)`.
+- baked files are serialized with expected cache key `0`.
+
+This distinction lets editor-authored `.t8nav` files behave like named assets while generated caches remain content-addressed runtime files.
+
+## IBL generated cache path
+
+`IBLResources.cpp` writes generated image-based lighting data under:
+
+```text
+Textures/GeneratedIBLCache/
+```
+
+The root is resolved through `ResolveCachePath()`. The cache key includes the IBL output kind, source image bytes when readable, source path/file metadata as fallback, generated dimensions, mip/face count, and sample counts.
+
+When loading a float cache, IBL first tries the resolved path and then falls back to `Textures/GeneratedIBLCache/<filename>` through `ReadBinary()`. That allows prepackaged generated cache assets to be read from `Assets/Textures/GeneratedIBLCache` on platforms where writing is unavailable or undesirable.
+
+## Writable authoring paths
+
+`WriteText()` is safe for portable relative writes because unresolved relative paths fall back to `ResolveCachePath()`.
+
+Some authoring paths have custom behavior:
+
+- `PhysicsAuthoring::ResolveRagdollEditWritePath()` writes existing relative ragdoll files in place when found on desktop, tries likely `Assets` locations when parents exist, and uses cache path on Android.
+- Skeleton edit helpers in runtime scenes use `ResolveCachePath("SkeletonEdits/<key>.json")`.
+- Runtime Android GUI settings use `ResolveCachePath("android_gui_settings.txt")`.
+
+Use the same pattern for new editor/runtime generated JSON: prefer authored asset locations only when the file is intentionally part of source-controlled assets; otherwise use `ResolveCachePath()`.
+
+## Extension rules
+
+When adding a new asset reader:
+
+1. Store relative engine resource paths, not absolute local paths, in `.t8scene` or descriptor JSON.
+2. Normalize paths with `ResourceLocator::NormalizePath()` or a schema-specific equivalent that strips embedded `Assets/` prefixes.
+3. Use `ReadBinary()`/`ReadText()` for data that may be packaged in an APK.
+4. Use `ResolveFilePath()` only when a library requires a filesystem path and APK assets are not expected.
+
+When adding a new generated cache:
+
+1. Use `ResolveCachePath()` for the root.
+2. Include a cache format/version number.
+3. Include all settings that change generated output.
+4. Include source identity and source content/signature, not only source filename.
+5. Include platform or third-party library versions when serialized data is not portable.
+6. Write to a temporary file and rename when practical.
+7. Log cache hits, stale cache ignores, and cache write failures with the final resolved path.
+
+## Known limitations and gotchas
+
+- `NormalizePath()` preserves case. Do not rely on it to canonicalize desktop paths.
+- `ResolveFilePath()` does not expose Android APK assets as files.
+- Absolute paths bypass `basePath` and `cachePath`; avoid saving them into portable scene files.
+- Recursive fallback matches by filename, so duplicate filenames under different folders can resolve to the first listed match.
+- `ResourceManager::Load()` reuses resources by the request string it sees, while `MeshAssetCache` lower-cases its source key. Keep path normalization consistent before calling both.
+- Texture loading still has legacy assumptions such as prepending `Textures/` before checking existence.
+- Generated caches are safe to delete; they should rebuild if the owning subsystem's key/header validation is complete.
+
+## Debugging checklist
+
+1. Normalize the failing path and check whether it accidentally includes `Assets/`, a leading slash, or mixed separators.
+2. On desktop, verify the file exists under one of the disk candidates: direct relative path, `basePath`, `cwd`, `cwd/Assets`, or `cwd/T850/Assets`.
+3. On Android, use `Exists()`/`ReadBinary()` rather than `ResolveFilePath()` for packaged assets.
+4. Check Android logcat for the working directory and data path selected in `AndroidEntry.cpp`.
+5. If a `.t8scene` mesh is missing, check for `[SceneFile] Resolved missing mesh` log output and duplicate filenames under `Models`.
+6. If a cache does not refresh, confirm the cache version/key includes the setting or source data you changed.
+7. If a cache cannot be written, inspect `GetCachePath()` and parent directory creation errors in subsystem logs.
+8. Delete the generated cache directory only after confirming the cache is derived data: `Shaders/.t8shadercache`, source `.t8cache`, `Navigation/.t8cache`, or `Textures/GeneratedIBLCache`.

--- a/documentation/debug/diagnostics.md
+++ b/documentation/debug/diagnostics.md
@@ -1,0 +1,336 @@
+# Debug and Diagnostics
+
+Status: Stage 13 draft.
+
+This document explains T850's diagnostic stack: loading progress, runtime telemetry, frame dumps and replay snapshots, render tracing, profiler scopes, and how these systems are used by runtime scenes, editor, render graph, shaders, physics, and navigation.
+
+Related documents:
+
+- [Main architecture](../architecture/main-architecture.md)
+- [Platform event loop](../architecture/platform-event-loop.md)
+- [Resource locator and cache paths](../architecture/resource-locator.md)
+- [FrameworkImGui runtime UI](../editor/imgui-system.md)
+- [Dependency map](../dependency-map.md)
+- [Render graph](../rendering/render-graph.md)
+- [Geometry rendering flow](../rendering/geometry-rendering-flow.md)
+- [Scene format and runtime](../scenes/scene-format-and-runtime.md)
+
+## Purpose and responsibilities
+
+Diagnostics help answer three questions:
+
+1. What is loading or stalling?
+2. What happened in a frame?
+3. Why do two backends or two runs differ?
+
+```mermaid
+flowchart LR
+  Loading["LoadingProgress"] --> LoadingUI["loading frame / console text"]
+  Frame["App frame"] --> Telemetry["RuntimeTelemetry"]
+  Frame --> Profiler["Profiler"]
+  Frame --> FrameDump["FrameDumper"]
+  GPU["Backend state"] --> RenderTrace["RenderTracer"]
+  FrameDump --> Dumps["RT dumps + snapshot.json"]
+  RenderTrace --> Dumps
+  Telemetry --> TelemetryJson["perf_telemetry_*.json"]
+  Profiler --> Log["timing report in log"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `Framework/include/debug/LoadingProgress.h` | Header-only loading progress state, scoped steps, snapshots, and frame callback. |
+| `Framework/include/debug/RuntimeTelemetry.h` / `Framework/src/debug/RuntimeTelemetry.cpp` | Runtime frame sampling, scope timers, counters, and telemetry JSON output. |
+| `Framework/include/debug/FrameDumper.h` / `Framework/src/debug/FrameDumper.cpp` | Render-target dump, snapshot capture, snapshot replay, frame-dump triggers. |
+| `Framework/src/debug/FrameDumperIO.cpp` | Glaze JSON snapshot load/save plus legacy text snapshot parser. |
+| `Framework/include/debug/RenderTrace.h` / `Framework/src/debug/RenderTrace.cpp` | Optional compile-time render event/resource tracer, guarded by `T850_RENDER_TRACE`. |
+| `Framework/include/debug/Profiler.h` / `Framework/src/debug/Profiler.cpp` | CPU/GPU scope profiler and draw-call counting. |
+| `DayScene/Application.cpp` | Runtime frame lifecycle, render tracer init, telemetry frame boundaries, profiler frame boundaries. |
+| `T8ditor/EditorApp.cpp` | Loading progress console/render frame, editor frame dumps, hosted window diagnostics. |
+| `FrameworkImGui/src/ImGuiSystem.cpp` | Installs `LoadingProgress` frame callback and renders loading frames. |
+
+## LoadingProgress
+
+`LoadingProgress` is a small global progress state used by load/build paths that can take visible time.
+
+It stores:
+
+- phase,
+- item,
+- detail,
+- completed weight,
+- total weight,
+- percent,
+- active flag.
+
+Important APIs:
+
+| API | Meaning |
+|---|---|
+| `Reset(totalWeight, phase, item, detail)` | Starts a progress session. |
+| `ScopedStep` | RAII step that updates current phase/item and advances by weight on destruction. |
+| `SetCurrent()` | Updates phase/item/detail. |
+| `SetDetail()` | Updates detail string. |
+| `Advance(weight)` | Advances completed work. |
+| `Complete()` | Marks total complete and forces a frame request. |
+| `GetSnapshot()` | Returns a thread-safe progress snapshot. |
+| `SetFrameCallback()` | Installs a callback for rendering/loading-frame pumping. |
+
+`LoadingProgress` throttles frame callback requests to roughly 33 ms unless forced. `FrameworkImGui::ImGuiSystem` installs a callback that renders a loading frame while long tasks run, and T8ditor can format snapshots for the console/loading UI.
+
+Common call sites include:
+
+- model loading,
+- glTF conversion,
+- texture creation,
+- shader compilation,
+- render graph loading,
+- scene loading,
+- editor startup.
+
+## RuntimeTelemetry
+
+`RuntimeTelemetry` is a lightweight frame sampler for CPU scopes and numeric counters.
+
+Enablement comes from `Config`:
+
+- `runtimeTelemetry`
+- `runtimeTelemetryFrequencyFrames`
+- `runtimeTelemetryOutputPath`
+
+Important APIs:
+
+| API | Meaning |
+|---|---|
+| `InitializeFromConfig(config)` | Enables/disables telemetry and chooses sample frequency/output path. |
+| `BeginFrame(frameIndex, deltaSeconds)` | Clears frame state and activates sampling for selected frames. |
+| `EndFrame()` | Stores the current frame sample when active. |
+| `ScopedTimer` / `T8_TELEMETRY_SCOPE(name)` | Records elapsed milliseconds for a named scope. |
+| `AddCounter(name, value)` | Accumulates a numeric counter for the active frame. |
+| `SetCounter(name, value)` | Sets/replaces a numeric counter for the active frame. |
+| `Shutdown()` | Flushes collected samples to a timestamped JSON file. |
+
+Output:
+
+- default path: `logs/perf_telemetry.json`,
+- actual file is timestamped,
+- JSON contains sampled frames, scopes, and counters.
+
+Telemetry is used throughout render, physics, navigation, animation, benchmark, projection/path queries, mesh drawing, and loading-sensitive paths.
+
+## FrameDumper and replay snapshots
+
+`FrameDumper` captures render output and enough scene state to replay a frame.
+
+Inputs:
+
+- `FrameDumperConfig`,
+- active cameras,
+- `SceneProps`,
+- list of render target dump entries,
+- optional omni cameras/light position,
+- optional skinned mesh snapshot.
+
+Triggers:
+
+- explicit request, such as editor/runtime spacebar debug flow,
+- frame number,
+- elapsed seconds,
+- replay warmup completion.
+
+Output directory format:
+
+```text
+dumps_<api>_f<frame>_<timestamp>/
+```
+
+Files written:
+
+- backbuffer screenshot,
+- named render target attachments,
+- `snapshot.json`,
+- optional `trace.json` when `T850_RENDER_TRACE` is enabled.
+
+Snapshot contents include:
+
+- camera and light camera state,
+- scene props,
+- matrices,
+- lights,
+- optional omni state,
+- optional skinned mesh state including bone matrices and bone texture data.
+
+Replay flow:
+
+1. Load a `snapshot.json` or legacy text snapshot.
+2. Apply camera, light, scene props, matrices, optional omni and skinned data.
+3. Warm up for a few frames.
+4. Trigger a dump.
+
+This is useful for cross-API image comparisons and reproducing a frame without manually recreating UI/runtime state.
+
+## RenderTrace
+
+`RenderTrace` is compiled only when `T850_RENDER_TRACE` is defined. When disabled, trace macros become no-ops.
+
+Its goal is mechanical cross-backend diffing, especially D3D12 vs Vulkan.
+
+It records:
+
+- textures and views,
+- render targets,
+- shaders and vertex input layouts,
+- PSOs/pipelines,
+- samplers,
+- buffers and buffer update versions,
+- render state,
+- render target push/pop/clear,
+- shader/PSO/resource binds,
+- draw-indexed events,
+- denormalized per-draw state snapshots.
+
+The tracer distinguishes:
+
+- request events, when engine code calls `Texture::Set`, CB/VB/IB bind, etc.;
+- commit events, when a backend actually makes GPU-visible bindings.
+
+This matters because Vulkan delays descriptor binding until draw time.
+
+Runtime initialization happens through `EnsureRenderTracer()` in the app draw path. `FrameDumper::DumpFrame()` saves trace data beside render target dumps when tracing is enabled.
+
+## Profiler
+
+`Profiler` measures named CPU/GPU scopes and draw-call counts.
+
+Enablement:
+
+- runtime `--profile`,
+- Android profile launch extra,
+- direct initialization after driver creation.
+
+Key APIs:
+
+| API | Meaning |
+|---|---|
+| `Init(driver, maxScopes)` | Creates API-specific GPU timestamp backend. |
+| `BeginFrame()` / `EndFrame()` | Frame profiler boundary. |
+| `BeginScope()` / `EndScope()` | CPU + GPU scoped timing. |
+| `BeginCPUScope()` / `EndCPUScope()` | CPU-only scoped timing. |
+| `AddDrawCall(vertexCount)` | Counts draw work from backend draw calls. |
+| `Report()` | Logs timing breakdown. |
+| `Reset()` | Clears accumulated results. |
+
+Backends:
+
+- D3D12 timestamp query heap + readback buffer.
+- D3D11 timestamp/disjoint queries.
+- OpenGL timestamp queries.
+- Vulkan query pool/readback allocation with deferred reset support.
+
+Macros:
+
+- `T8_PROFILE_SCOPE(g_profiler, "name")`
+- `T8_PROFILE_CPU_SCOPE(g_profiler, "name")`
+
+## Runtime frame integration
+
+Typical runtime frame:
+
+```mermaid
+sequenceDiagram
+  participant App
+  participant Telemetry as RuntimeTelemetry
+  participant Profiler
+  participant Scene
+  participant Driver
+  participant Dumper as FrameDumper
+  participant Trace as RenderTracer
+
+  App->>Telemetry: BeginFrame(frame, dt)
+  App->>Scene: OnUpdate(dt)
+  App->>Telemetry: scoped timers/counters
+  App->>Driver: BeginFrame
+  App->>Profiler: BeginFrame
+  App->>Trace: EnsureRenderTracer(driver)
+  App->>Scene: OnDraw()
+  Driver->>Trace: resource/bind/draw events
+  App->>Dumper: ShouldDump(dt)
+  Dumper->>Driver: SaveScreenshot / SaveRTToFile
+  Dumper->>Trace: Save(trace.json)
+  App->>Profiler: EndFrame
+  App->>Telemetry: EndFrame
+```
+
+## Editor integration
+
+T8ditor uses diagnostics for:
+
+- startup loading progress,
+- render target/frame dumps,
+- console progress text,
+- editor render graph RT dump entries,
+- hosted window state logging,
+- NavMesh wire dump logs,
+- physics/navigation debug overlays.
+
+Because editor hosted windows can freeze the main editor viewport, frame dumps may capture either the active editor frame or the frozen frame target depending on open hosted windows.
+
+## Common workflows
+
+### Investigating a black frame
+
+1. Trigger a frame dump.
+2. Inspect backbuffer and render target outputs.
+3. If trace is enabled, compare `trace.json` against a known-good backend.
+4. Check shader key, PSO, RT, texture, and CB bindings in the draw snapshot.
+5. Cross-check [Render graph](../rendering/render-graph.md), [Shader management](../rendering/shader-management.md), and [Geometry rendering flow](../rendering/geometry-rendering-flow.md).
+
+### Investigating a load stall
+
+1. Check `LoadingProgress::GetSnapshot()` output in UI/console.
+2. Find the phase/item/detail.
+3. Search call sites for the phase string.
+4. Check resource lookup, cache loading, shader compilation, or mesh conversion depending on phase.
+
+### Investigating performance
+
+1. Enable profiler for GPU/CPU timings.
+2. Enable runtime telemetry for sampled counters/scopes.
+3. Use benchmark output where available for aggregate frame timings.
+4. Correlate telemetry scope names with render graph pass names and physics/navigation counters.
+
+## Extension points
+
+When adding a new diagnostic:
+
+1. Prefer `T8_TELEMETRY_SCOPE` for low-overhead scoped timing.
+2. Add counters with stable names; use dot-separated prefixes such as `render.mesh.*`.
+3. Use `LoadingProgress::ScopedStep` for long load/build operations.
+4. Add `FrameDumper` RT entries when a new render target is important for debugging.
+5. Add `RenderTrace` resource/event hooks only inside `T850_RENDER_TRACE` guards.
+6. Add profiler scopes around GPU-relevant passes if timing granularity matters.
+
+## Known limitations and gotchas
+
+- `LoadingProgress` is global and assumes one active progress flow.
+- Runtime telemetry samples only selected frames based on `frequencyFrames`; missing frames may be intentional.
+- Telemetry writes on shutdown, so hard process termination can lose output.
+- Frame dumps write API-specific image/trace output and can be expensive.
+- Replay snapshots are not full scene serialization; they restore render/camera/light/props state for reproducibility, not arbitrary gameplay state.
+- RenderTrace only exists in trace-enabled builds.
+- RenderTrace schema intentionally writes many sentinel/default fields for mechanical diffability.
+- GPU profiler results are asynchronous and may represent earlier frames depending on backend.
+- Some diagnostics are runtime-only or editor-only depending on call sites.
+
+## Debugging checklist
+
+1. Confirm the feature is compiled/enabled: `T850_RENDER_TRACE`, `--profile`, runtime telemetry config, dump flags.
+2. For loading UI, verify `LoadingProgress::SetFrameCallback()` is installed and the progress flow called `Reset()`.
+3. For telemetry, verify `RuntimeTelemetry::IsEnabled()` and sample frequency.
+4. For missing telemetry output, ensure normal shutdown calls `RuntimeTelemetry::Shutdown()`.
+5. For frame dumps, check `FrameDumperConfig`, dump trigger, `keepRunning`, and RT dump entry list.
+6. For replay, verify `snapshot.json` parsed and warmup completed.
+7. For render trace, ensure `g_renderTracer` is initialized and `FrameDumper` saved trace output.
+8. For profiler, check driver API support and that `BeginFrame()` / `EndFrame()` bracket the frame.
+9. For cross-API mismatches, compare render target outputs first, then shader/PSO/resource/draw snapshots.

--- a/documentation/dependency-map.md
+++ b/documentation/dependency-map.md
@@ -1,0 +1,393 @@
+# Dependency Map
+
+Status: Stage 11 draft.
+
+This document cross-links the subsystem documentation and shows the major class/data dependencies between architecture, assets, rendering, animation, physics, navigation, editor authoring, and scene runtime.
+
+## Related documents
+
+- [Main architecture](architecture/main-architecture.md)
+- [Platform event loop](architecture/platform-event-loop.md)
+- [Resource locator and cache paths](architecture/resource-locator.md)
+- [Input, camera, and controls](input/camera-and-controls.md)
+- [FrameworkImGui runtime UI](editor/imgui-system.md)
+- [Debug and diagnostics](debug/diagnostics.md)
+- [Loading geometry](geometry/loading-geometry.md)
+- [Shader management](rendering/shader-management.md)
+- [Render graph](rendering/render-graph.md)
+- [Geometry rendering flow](rendering/geometry-rendering-flow.md)
+- [Textures, samplers, and IBL](rendering/textures-and-ibl.md)
+- [Animation system](animation/animation-system.md)
+- [Jolt physics](physics/jolt-physics.md)
+- [NavMesh and Detour](navigation/navmesh-detour.md)
+- [Editor overview](editor/editor-overview.md)
+- [Scene format and runtime](scenes/scene-format-and-runtime.md)
+- [SceneSetup descriptors](scenes/scene-setup-descriptors.md)
+- [Review and gaps](review-and-gaps.md)
+
+## Documentation dependency table
+
+| If you change... | Read first | Then read |
+|---|---|---|
+| Platform/window/API lifecycle | [Platform event loop](architecture/platform-event-loop.md) | [Main architecture](architecture/main-architecture.md), [Debug and diagnostics](debug/diagnostics.md), [Shader management](rendering/shader-management.md) |
+| Resource paths, Android packaged assets, or generated caches | [Resource locator and cache paths](architecture/resource-locator.md) | [Loading geometry](geometry/loading-geometry.md), [Shader management](rendering/shader-management.md), [Jolt physics](physics/jolt-physics.md), [NavMesh and Detour](navigation/navmesh-detour.md), [Scene format and runtime](scenes/scene-format-and-runtime.md) |
+| Input, controllers, camera profiles, or hosted viewport input | [Input, camera, and controls](input/camera-and-controls.md) | [Platform event loop](architecture/platform-event-loop.md), [Editor overview](editor/editor-overview.md), [Scene format and runtime](scenes/scene-format-and-runtime.md), [Jolt physics](physics/jolt-physics.md) |
+| Runtime/editor ImGui, docking, platform windows, or hosted scene panels | [FrameworkImGui runtime UI](editor/imgui-system.md) | [Input, camera, and controls](input/camera-and-controls.md), [Editor overview](editor/editor-overview.md), [Platform event loop](architecture/platform-event-loop.md), [Debug and diagnostics](debug/diagnostics.md) |
+| Mesh import or asset format conversion | [Loading geometry](geometry/loading-geometry.md) | [Resource locator and cache paths](architecture/resource-locator.md), [Geometry rendering flow](rendering/geometry-rendering-flow.md), [Animation system](animation/animation-system.md), [Jolt physics](physics/jolt-physics.md), [NavMesh and Detour](navigation/navmesh-detour.md) |
+| Shader feature bits or passes | [Shader management](rendering/shader-management.md) | [Resource locator and cache paths](architecture/resource-locator.md), [Render graph](rendering/render-graph.md), [Geometry rendering flow](rendering/geometry-rendering-flow.md) |
+| Texture loading, sampler state, IBL, or cubemap profiles | [Textures, samplers, and IBL](rendering/textures-and-ibl.md) | [Resource locator and cache paths](architecture/resource-locator.md), [Shader management](rendering/shader-management.md), [Render graph](rendering/render-graph.md), [Scene format and runtime](scenes/scene-format-and-runtime.md) |
+| Render pass order or render targets | [Render graph](rendering/render-graph.md) | [Textures, samplers, and IBL](rendering/textures-and-ibl.md), [Shader management](rendering/shader-management.md), [Geometry rendering flow](rendering/geometry-rendering-flow.md), [Editor overview](editor/editor-overview.md) |
+| Draw-call behavior | [Geometry rendering flow](rendering/geometry-rendering-flow.md) | [Textures, samplers, and IBL](rendering/textures-and-ibl.md), [Loading geometry](geometry/loading-geometry.md), [Shader management](rendering/shader-management.md), [Render graph](rendering/render-graph.md) |
+| Skeletal animation | [Animation system](animation/animation-system.md) | [Geometry rendering flow](rendering/geometry-rendering-flow.md), [Jolt physics](physics/jolt-physics.md) |
+| Ragdoll or character physics | [Jolt physics](physics/jolt-physics.md) | [Animation system](animation/animation-system.md), [Scene format and runtime](scenes/scene-format-and-runtime.md), [Editor overview](editor/editor-overview.md) |
+| NavMesh authoring/runtime pathing | [NavMesh and Detour](navigation/navmesh-detour.md) | [Jolt physics](physics/jolt-physics.md), [Scene format and runtime](scenes/scene-format-and-runtime.md), [Editor overview](editor/editor-overview.md) |
+| Editor panels or authoring workflow | [Editor overview](editor/editor-overview.md) | [Scene format and runtime](scenes/scene-format-and-runtime.md), subsystem doc for the authored feature |
+| `.t8scene` schema or runtime loading | [Scene format and runtime](scenes/scene-format-and-runtime.md) | [SceneSetup descriptors](scenes/scene-setup-descriptors.md), [Editor overview](editor/editor-overview.md), [Render graph](rendering/render-graph.md), [Jolt physics](physics/jolt-physics.md), [NavMesh and Detour](navigation/navmesh-detour.md) |
+| Runtime control descriptors, `SceneProps` mappings, or profiles | [SceneSetup descriptors](scenes/scene-setup-descriptors.md) | [Scene format and runtime](scenes/scene-format-and-runtime.md), [FrameworkImGui runtime UI](editor/imgui-system.md), [Textures, samplers, and IBL](rendering/textures-and-ibl.md) |
+| Runtime diagnostics, frame dumps, telemetry, or profiling | [Debug and diagnostics](debug/diagnostics.md) | [Platform event loop](architecture/platform-event-loop.md), affected subsystem doc |
+
+## High-level class dependencies
+
+```mermaid
+classDiagram
+  class RootFramework {
+    +pVideoDriver
+    +UpdateApplication()
+  }
+  class AppBase {
+    +CreateAssets()
+    +OnUpdate()
+    +OnDraw()
+    +OnInput()
+    +InputManager IManager
+  }
+  class InputManager
+  class ImGuiSystem
+  class DevGuiContext
+  class CameraController
+  class SceneBase {
+    +SceneProp
+    +OnLoadScene()
+    +OnUpdate()
+    +OnDraw()
+  }
+  class EditorApp
+  class EngineContext {
+    +driver
+    +device
+    +deviceContext
+    +physics
+    +threadPool
+    +config
+  }
+  class BaseDriver {
+    +CreateShader()
+    +CreateRT()
+    +PushRT()
+    +PopRT()
+  }
+  class RenderGraph {
+    +Load()
+    +CreateRenderTargets()
+    +Execute()
+  }
+  class PrimitiveManager {
+    +CreateMesh()
+  }
+  class RenderMesh
+  class RenderSkinnedMesh
+  class Texture
+  class IBLResources
+  class EnvironmentMapSet
+  class ResourceLocator {
+    +ReadBinary()
+    +ReadText()
+    +ResolveCachePath()
+  }
+  class ShaderDiskCache
+  class MeshAssetCache
+  class JoltPhysicsSystem
+  class NavMesh
+  class EditorSceneFile
+  class SceneDescriptor
+  class SceneSetup
+
+  RootFramework --> AppBase
+  AppBase <|-- EditorApp
+  AppBase --> InputManager
+  AppBase --> ImGuiSystem
+  AppBase --> SceneBase
+  AppBase --> EngineContext
+  EngineContext --> BaseDriver
+  EngineContext --> JoltPhysicsSystem
+  SceneBase --> RenderGraph
+  EditorApp --> RenderGraph
+  RenderGraph --> ResourceLocator
+  SceneBase --> PrimitiveManager
+  EditorApp --> PrimitiveManager
+  PrimitiveManager --> RenderMesh
+  RenderMesh <|-- RenderSkinnedMesh
+  RenderMesh --> Texture
+  RenderMesh --> MeshAssetCache
+  RenderGraph --> EnvironmentMapSet
+  EnvironmentMapSet --> Texture
+  IBLResources --> EnvironmentMapSet
+  IBLResources --> Texture
+  IBLResources --> ResourceLocator
+  MeshAssetCache --> ResourceLocator
+  ShaderDiskCache --> ResourceLocator
+  SceneBase --> NavMesh
+  SceneBase --> CameraController
+  SceneBase --> DevGuiContext
+  EditorApp --> CameraController
+  EditorApp --> ImGuiSystem
+  EditorApp --> DevGuiContext
+  NavMesh --> ResourceLocator
+  JoltPhysicsSystem --> ResourceLocator
+  EditorApp --> EditorSceneFile
+  SceneBase --> EditorSceneFile
+  EditorSceneFile --> ResourceLocator
+  SceneBase --> SceneSetup
+  SceneSetup --> SceneDescriptor
+  SceneSetup --> ResourceLocator
+```
+
+## Asset-to-draw flow
+
+This is the core path for static and skinned mesh rendering.
+
+```mermaid
+flowchart LR
+  File[".glb/.gltf/.x"] --> ResourceManager["ResourceManager::Load"]
+  ResourceManager --> XDB["XDataBase"]
+  XDB --> RenderMeshLoad["RenderMesh::Load"]
+  RenderMeshLoad --> PrimitiveManager["PrimitiveManager::CreateMesh"]
+  PrimitiveManager --> StaticOrSkin{"skin/animation data?"}
+  StaticOrSkin -->|no| RenderMesh["RenderMesh"]
+  StaticOrSkin -->|yes| RenderSkinnedMesh["RenderSkinnedMesh"]
+  RenderMesh --> MeshAsset["MeshAssetCache + MeshPool"]
+  RenderSkinnedMesh --> MeshAsset
+  RenderMesh --> MaterialAsset["MaterialAssetCache"]
+  RenderSkinnedMesh --> MaterialAsset
+  MaterialAsset --> ShaderKey["ShaderKey"]
+  ShaderKey --> Shader["BaseDriver::CreateShader/GetShader"]
+  MeshAsset --> Draw["DeviceContext::DrawIndexed"]
+  Shader --> Draw
+```
+
+Key documents:
+
+- [Loading geometry](geometry/loading-geometry.md)
+- [Resource locator and cache paths](architecture/resource-locator.md)
+- [Shader management](rendering/shader-management.md)
+- [Geometry rendering flow](rendering/geometry-rendering-flow.md)
+
+## Resource and cache lookup flow
+
+```mermaid
+flowchart TD
+  AuthoredPath["Authored path in scene/config/shader/mesh"] --> Normalize["ResourceLocator::NormalizePath"]
+  Normalize --> Read["ReadBinary / ReadText / Exists"]
+  Normalize --> Resolve["ResolveFilePath"]
+  Normalize --> Cache["ResolveCachePath"]
+  Read --> Desktop["desktop candidates: cwd, base, Assets, T850/Assets"]
+  Read --> Android["Android AAssetManager packaged assets"]
+  Resolve --> DiskOnly["filesystem path for disk-backed users"]
+  Cache --> ShaderCache["Shaders/.t8shadercache"]
+  Cache --> MeshCache["source .t8cache: .t8mesh / .t8jolt"]
+  Cache --> NavCache["Navigation/.t8cache/*.t8nav"]
+  Cache --> IBLCache["Textures/GeneratedIBLCache/*.t8ibl"]
+```
+
+Key documents:
+
+- [Resource locator and cache paths](architecture/resource-locator.md)
+- [Loading geometry](geometry/loading-geometry.md)
+- [Shader management](rendering/shader-management.md)
+- [Jolt physics](physics/jolt-physics.md)
+- [NavMesh and Detour](navigation/navmesh-detour.md)
+
+## Input and camera control flow
+
+```mermaid
+flowchart LR
+  Platform["Win32 / Linux / Android events"] --> Input["InputManager"]
+  Input --> RuntimeApp["DayScene App"]
+  Input --> EditorApp["T8ditor EditorApp"]
+  RuntimeApp --> SceneInput["SceneTemplate / Quake3Mock / SandboxScene"]
+  SceneInput --> CameraInput["CameraInputState"]
+  CameraInput --> CameraController["CameraController"]
+  CameraController --> Profile["Orbit / Free Fly / Colliding Fly / FPS profiles"]
+  Profile --> Camera["Camera"]
+  EditorApp --> EditorCamera["EditorCamera orbit mode"]
+  EditorApp --> Hosted["Hosted Play/Mesh/Ragdoll viewports"]
+```
+
+Key documents:
+
+- [Input, camera, and controls](input/camera-and-controls.md)
+- [Platform event loop](architecture/platform-event-loop.md)
+- [Editor overview](editor/editor-overview.md)
+- [Scene format and runtime](scenes/scene-format-and-runtime.md)
+
+## Runtime UI and hosted panel flow
+
+```mermaid
+flowchart TD
+  App["DayScene App / T8ditor EditorImGui"] --> ImGuiSystem["ImGuiSystem"]
+  ImGuiSystem --> Platform["SDL3 or Android backend"]
+  ImGuiSystem --> Renderer["D3D11 / D3D12 / GL / Vulkan renderer backend"]
+  ImGuiSystem --> Frame["NewFrame / Render / platform windows"]
+  App --> DevGui["DevGuiContext"]
+  DevGui --> SceneGui["SceneBase::DrawDevGui"]
+  T8ditor["T8ditor hosted windows"] --> Hosted["HostedViewportPanel"]
+  Hosted --> DevGui
+  ImGuiSystem --> Loading["LoadingProgress renderer"]
+```
+
+Key documents:
+
+- [FrameworkImGui runtime UI](editor/imgui-system.md)
+- [Input, camera, and controls](input/camera-and-controls.md)
+- [Editor overview](editor/editor-overview.md)
+- [Debug and diagnostics](debug/diagnostics.md)
+
+## Texture and IBL resource flow
+
+```mermaid
+flowchart TD
+  Paths["SceneDescriptor environment_* fields / material texture paths"] --> ResourceLocator["ResourceLocator"]
+  ResourceLocator --> TextureLoad["Texture::LoadTexture / cil_load"]
+  TextureLoad --> BackendTexture["API texture resource + sampler"]
+  BackendTexture --> DriverSlots["BaseDriver::Textures"]
+  DriverSlots --> MaterialSlots["RenderMesh material slots"]
+  DriverSlots --> EnvSet["EnvironmentMapSet"]
+  EnvSet --> IBL["LoadEnvironmentIBLResources"]
+  IBL --> Cache["Textures/GeneratedIBLCache"]
+  IBL --> EnvSlots["slots 10-15 diffuse/specular/BRDF/Charlie/sheen"]
+  EnvSlots --> RenderGraph["RenderGraph bind_environment_map"]
+  RenderGraph --> Draw["mesh / quad draw"]
+```
+
+Key documents:
+
+- [Textures, samplers, and IBL](rendering/textures-and-ibl.md)
+- [Resource locator and cache paths](architecture/resource-locator.md)
+- [Render graph](rendering/render-graph.md)
+- [Geometry rendering flow](rendering/geometry-rendering-flow.md)
+
+## Frame/render flow
+
+```mermaid
+flowchart TD
+  Platform["RootFramework platform loop"] --> AppUpdate["AppBase::OnUpdate"]
+  AppUpdate --> SceneUpdate["Scene or Editor update"]
+  SceneUpdate --> Physics["JoltPhysicsSystem::Update"]
+  SceneUpdate --> Animation["RenderSkinnedMesh::UpdateAnimationAndBones"]
+  AppUpdate --> AppDraw["AppBase::OnDraw"]
+  AppDraw --> BeginFrame["BaseDriver::BeginFrame"]
+  BeginFrame --> RenderGraph["RenderGraph::Execute"]
+  RenderGraph --> MeshDraw["RenderMesh / RenderSkinnedMesh draws"]
+  MeshDraw --> ShaderSet["ShaderBase::Set"]
+  ShaderSet --> PSO["D3D12/Vulkan PSO or GL/D3D11 shader state"]
+  PSO --> DrawIndexed["DeviceContext::DrawIndexed"]
+  DrawIndexed --> Overlays["Editor/debug overlays"]
+  Overlays --> Present["SwapBuffers / EndFrame"]
+```
+
+Key documents:
+
+- [Platform event loop](architecture/platform-event-loop.md)
+- [Render graph](rendering/render-graph.md)
+- [Geometry rendering flow](rendering/geometry-rendering-flow.md)
+
+## Editor-to-runtime scene flow
+
+```mermaid
+flowchart LR
+  EditorWorld["EditorWorld"] --> Snapshot["BuildEditorSceneSnapshot"]
+  Snapshot --> SceneFile["EditorSceneFile / .t8scene"]
+  SceneFile --> Save["SaveEditorSceneFile"]
+  SceneFile --> PlayScene["Play Scene temp export"]
+  PlayScene --> SceneTemplate["SceneTemplate"]
+  SceneTemplate --> RenderGraph["RenderGraph"]
+  SceneTemplate --> Physics["JoltPhysicsSystem"]
+  SceneTemplate --> Navigation["NavMesh"]
+  SceneTemplate --> Ragdoll["RenderSkinnedMesh + ragdoll"]
+  SceneDescriptor["SceneDescriptor JSON"] --> SceneSetup["SceneSetup"]
+  SceneSetup --> SceneProps["SceneProps controls"]
+  SceneSetup --> SceneTemplate
+```
+
+Key documents:
+
+- [Editor overview](editor/editor-overview.md)
+- [Scene format and runtime](scenes/scene-format-and-runtime.md)
+- [SceneSetup descriptors](scenes/scene-setup-descriptors.md)
+- [Jolt physics](physics/jolt-physics.md)
+- [NavMesh and Detour](navigation/navmesh-detour.md)
+
+## Animation-physics-ragdoll flow
+
+```mermaid
+flowchart TD
+  GLTF["glTF skin/animation"] --> AnimData["xSkeleton + xAnimationInfo"]
+  AnimData --> Controller["AnimationController"]
+  Controller --> BoneMatrices["final bone matrices"]
+  BoneMatrices --> BoneTexture["bone texture t24"]
+  BoneTexture --> SkinnedDraw["RenderSkinnedMesh draw"]
+  Controller --> RagdollPose["BuildRagdollPoseFromAnimation"]
+  RagdollPose --> JoltRagdoll["Jolt kinematic ragdoll"]
+  JoltRagdoll --> Dynamic["Switch to dynamic physics"]
+  Dynamic --> RagdollState["GetRagdollState"]
+  RagdollState --> SkeletonPose["BuildSkeletonPoseFromRagdollState"]
+  SkeletonPose --> Controller
+```
+
+Key documents:
+
+- [Animation system](animation/animation-system.md)
+- [Jolt physics](physics/jolt-physics.md)
+- [Geometry rendering flow](rendering/geometry-rendering-flow.md)
+
+## Scene-driven navigation flow
+
+```mermaid
+flowchart TD
+  SceneFile[".t8scene navigation_mesh"] --> SceneTemplate["SceneTemplate::EnsureNavMeshBuilt"]
+  SceneTemplate --> Sources["NavSourceInstance from meshes"]
+  Sources --> Geometry["NavMeshGeometry"]
+  SceneFile --> Volumes["Nav volumes and authored links"]
+  Volumes --> Geometry
+  Physics["Jolt static triangle meshes"] --> Validator["ValidateNavOffMeshLinkWithPhysics"]
+  Validator --> Geometry
+  Geometry --> Recast["Recast build"]
+  Recast --> Detour["Detour navmesh/query"]
+  Detour --> Agents["ProjectPoint / FindPath / nav agents"]
+  Detour --> Debug["NavMeshDebugRenderer"]
+  Detour --> Baked[".t8nav cache/baked asset"]
+```
+
+Key documents:
+
+- [NavMesh and Detour](navigation/navmesh-detour.md)
+- [Jolt physics](physics/jolt-physics.md)
+- [Scene format and runtime](scenes/scene-format-and-runtime.md)
+- [Editor overview](editor/editor-overview.md)
+
+## Cross-subsystem change checklist
+
+Use this checklist before touching code that crosses subsystems:
+
+1. If a data field is saved, update `.t8scene` schema, editor snapshot save/load, runtime load, and docs.
+2. If a material or vertex attribute changes, update glTF conversion, `ShaderKey`, shaders, reflection/input layout, and draw binding.
+3. If a render pass changes, update render graph JSON, shader pass defines, PSO expectations, editor rendering controls, and runtime scenes.
+4. If animation pose data changes, update `AnimationController`, skinned draw, ragdoll binding, snapshots, and debug visualization.
+5. If physics or NavMesh relies on render geometry, verify hidden/skinned/object filtering and cache keys.
+6. If editor tools mutate state, add undo/redo coverage and Play Scene export coverage.
+7. If cache content changes, bump or extend the relevant cache key/version and document the invalidation behavior.
+8. If a path must work on Android, use `ResourceLocator::ReadBinary`/`ReadText` instead of assuming a resolved filesystem path exists.
+9. If input routing changes, verify keyboard/mouse/gamepad state, ImGui capture gates, hosted viewport coordinate conversion, and Android virtual controls.
+10. If ImGui UI changes, verify backend init/shutdown, docking IDs, platform-window behavior, Android native-window rebinding, and hosted scene panel IDs.
+11. If texture or IBL behavior changes, verify material slot mapping, sampler params, render-graph environment slots, Android generated-cache fallback, and scene/profile cubemap overrides.
+12. If runtime descriptor controls change, update `SceneDescriptor`, `SceneSetup`, scene/tool mapping tables, profile override handling, save-state behavior, and docs together.

--- a/documentation/doc-conventions.md
+++ b/documentation/doc-conventions.md
@@ -76,9 +76,10 @@ Example:
 ```md
 ## Related documents
 
-- [Geometry loading](../geometry/loading-geometry.md)
-- [Shader management](shader-management.md)
-- [Render graph](render-graph.md)
+- [Dependency map](dependency-map.md)
+- [Geometry loading](geometry/loading-geometry.md)
+- [Shader management](rendering/shader-management.md)
+- [Render graph](rendering/render-graph.md)
 ```
 
 ## Agent workflow for future stages
@@ -91,4 +92,3 @@ Each agent should report:
 - Classes/functions documented.
 - Gaps or uncertainties.
 - Follow-up links needed.
-

--- a/documentation/doc-conventions.md
+++ b/documentation/doc-conventions.md
@@ -1,0 +1,94 @@
+# Documentation Conventions
+
+This file defines how the `documentation/` tree should be written so every stage is consistent.
+
+## File organization
+
+- Use one Markdown file per major subsystem or flow.
+- Keep cross-subsystem topics linked instead of duplicating long explanations.
+- Use relative links between files.
+- Keep diagrams close to the text they explain.
+- Prefer code/file references over vague subsystem names.
+
+## Standard document structure
+
+Each subsystem document should follow this structure unless there is a good reason to deviate:
+
+```md
+# Subsystem Name
+
+## Purpose
+## Key files and classes
+## Runtime ownership
+## Initialization flow
+## Per-frame flow
+## Data model
+## Important APIs
+## Editor integration
+## Runtime scene integration
+## Diagrams
+## Extension points
+## Known limitations
+## Debugging checklist
+## Related documents
+```
+
+## Diagram conventions
+
+Use Mermaid for diagrams.
+
+Recommended diagram types:
+
+- `flowchart TD` for build/load/update pipelines.
+- `flowchart LR` for render/input/data paths.
+- `sequenceDiagram` for frame lifecycle or async flows.
+- `classDiagram` only when class dependency matters more than data flow.
+
+Keep node names short, but add surrounding prose that names the exact files and classes.
+
+## Naming conventions
+
+- Use code formatting for class and function names: `RenderMesh`, `PrimitiveInst`, `SceneTemplate`.
+- Use inline paths for files: `T850/Framework/src/scene/RenderMesh.cpp`.
+- Use `.t8scene` for authored editor scenes.
+- Use “Framework” for core reusable engine systems.
+- Use “T8ditor” for the editor executable and editor-only code.
+- Use “SceneTemplate” for the runtime scene that loads `.t8scene`.
+
+## Required detail level
+
+Each document should make it possible to answer:
+
+- What owns this data?
+- Who creates it?
+- Who destroys it?
+- What thread/frame phase runs it?
+- How does it reach the GPU/physics/navigation/runtime system?
+- What is editor-only versus runtime?
+- What breaks when this subsystem is misconfigured?
+
+## Cross-linking conventions
+
+Add a “Related documents” section to every document.
+
+Example:
+
+```md
+## Related documents
+
+- [Geometry loading](../geometry/loading-geometry.md)
+- [Shader management](shader-management.md)
+- [Render graph](render-graph.md)
+```
+
+## Agent workflow for future stages
+
+For each stage, narrow the agent context to the relevant files. The expected output is the Markdown document plus links from `README.md` and, when needed, `glossary.md`.
+
+Each agent should report:
+
+- Files inspected.
+- Classes/functions documented.
+- Gaps or uncertainties.
+- Follow-up links needed.
+

--- a/documentation/editor/editor-overview.md
+++ b/documentation/editor/editor-overview.md
@@ -1,8 +1,517 @@
 # Editor Overview
 
-Status: planned.
+Status: Stage 9 draft.
 
-This document will cover T8ditor, panels, hierarchy, inspector, gizmos, Play Scene, Mesh Editor, Ragdoll Editor, NavMesh Authoring, and undo/redo.
+This document explains T850's editor, T8ditor: app lifecycle, editor-world data model, scene save/load, panels, hierarchy/inspector/rendering/timeline controls, viewport and gizmo behavior, Play Scene, Mesh Editor, Ragdoll Editor, NavMesh authoring, undo/redo, hosted windows, render-graph integration, limitations, and debugging workflows.
 
-See [stage-plan.md](../stage-plan.md#stage-9--editor).
+Related documents:
 
+- [Main architecture](../architecture/main-architecture.md)
+- [Input, camera, and controls](../input/camera-and-controls.md)
+- [FrameworkImGui runtime UI](imgui-system.md)
+- [Dependency map](../dependency-map.md)
+- [Render graph](../rendering/render-graph.md)
+- [Textures, samplers, and IBL](../rendering/textures-and-ibl.md)
+- [Geometry rendering flow](../rendering/geometry-rendering-flow.md)
+- [Jolt physics](../physics/jolt-physics.md)
+- [NavMesh and Detour](../navigation/navmesh-detour.md)
+- [Scene format and runtime](../scenes/scene-format-and-runtime.md)
+- [SceneSetup descriptors](../scenes/scene-setup-descriptors.md)
+
+## Purpose and responsibilities
+
+T8ditor is the authoring shell for `.t8scene` files. It is an `AppBase` application that shares the Framework renderer, physics, navigation, mesh loading, render graph, and scene serialization systems with runtime scenes.
+
+The editor is responsible for:
+
+1. Importing and previewing meshes.
+2. Editing object transforms, visibility, grouping, cameras, lights, splines, physics, ragdolls, navigation, God Rays, render settings, and profiles.
+3. Saving/loading `.t8scene`.
+4. Running Play Scene through an embedded `SceneTemplate`.
+5. Hosting embedded Mesh Edit and Ragdoll Edit windows.
+6. Maintaining undo/redo and selection state.
+7. Drawing editor-only overlays: grid, gizmos, wireframes, camera/light gizmos, physics, NavMesh, splines.
+
+```mermaid
+flowchart TD
+  EditorApp["EditorApp AppBase"] --> World["EditorWorld shared data model"]
+  EditorApp --> Renderer["Framework renderer + T8ditor_RenderGraph"]
+  EditorApp --> UI["EditorImGui panels"]
+  EditorApp --> Tools["EditorCamera/Grid/Gizmo/Mesh/LineRenderer"]
+  EditorApp --> Physics["JoltPhysicsSystem + debug"]
+  EditorApp --> Nav["NavMesh + debug"]
+  EditorApp --> Hosted["Play Scene / Mesh Edit / Ragdoll Edit"]
+  World --> SceneFile[".t8scene save/load"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `T8ditor/EditorApp.h` | Main editor app class, state fields, and method declarations. |
+| `T8ditor/EditorApp.cpp` | Main editor lifecycle, scene import/save/load, selection, render/UI loop, panels, NavMesh, profiles, undo state. |
+| `T8ditor/EditorWorld.h`, `T8ditor/EditorWorld.cpp` | Shared editor data model replacing scattered file-scope globals. |
+| `T8ditor/EditorScene.h`, `T8ditor/EditorScene.cpp` | Thin save/load wrapper around Framework `.t8scene` serialization and Windows file dialogs. |
+| `Framework/src/scene/EditorSceneFile.cpp` | Actual Glaze JSON `.t8scene` load/save implementation and mesh fallback resolution. |
+| `T8ditor/EditorImGui.h`, `T8ditor/EditorImGui.cpp` | ImGui lifecycle, menu/toolbar/context menu, panel visibility, base hierarchy/inspector/console/RT-debug helpers. |
+| `T8ditor/EditorCamera.*` | Orbit/pan/zoom editor camera and framing helpers. |
+| `T8ditor/EditorGrid.*` | XZ grid and axis lines. |
+| `T8ditor/EditorGizmo.*` | Editor line-gizmo meshes for translate/rotate/scale. |
+| `T8ditor/EditorMesh.*` | Editor wireframe/picking mesh loader for `.x`, `.gltf`, `.glb`, and generated triangle meshes. |
+| `T8ditor/EditorSceneGizmos.*` | Camera/light/gizmo overlay geometry. |
+| `T8ditor/EditorSceneSerialization.*` | Editor-to-scene conversion helpers for NavMesh, physics cook settings, links, volumes, etc. |
+| `T8ditor/UndoRedo.h` | Command-pattern undo stack plus transform/group-transform commands. |
+| `T8ditor/HostedViewportPanel.*` | Shared native ImGui viewport/window and render-target wrapper for hosted windows. |
+| `T8ditor/PlayScenePanel.cpp` | Hosted Play Scene runtime window. |
+| `T8ditor/MeshEditorPanel.cpp` | Hosted Mesh Edit window. |
+| `T8ditor/RagdollEditorPanel.cpp` | Hosted Ragdoll Edit window. |
+
+## EditorApp lifecycle
+
+`EditorApp` derives from `AppBase` and overrides:
+
+- `InitVars()`
+- `CreateAssets()`
+- `LoadAssets()`
+- `DestroyAssets()`
+- `OnUpdate()`
+- `OnDraw()`
+- `OnInput()`
+- pause/resume/reset.
+
+```mermaid
+sequenceDiagram
+  participant Framework
+  participant Editor as EditorApp
+  participant ImGui
+  participant Driver
+
+  Framework->>Editor: InitVars()
+  Framework->>Editor: CreateAssets()
+  Editor->>Editor: create camera, grid, gizmo, scene props
+  Editor->>Editor: initialize physics, primitive manager, render graph
+  Editor->>ImGui: ImGuiInit(platform windows enabled)
+  loop frame
+    Framework->>Editor: OnUpdate()
+    Editor->>Editor: LoadPendingScene / CheckResize / OnInput
+    Editor->>Editor: Update animation/ragdolls
+    Editor->>Editor: OnDraw()
+    Editor->>Driver: BeginFrame / Clear
+    Editor->>Editor: RenderEditorSceneFrame
+    Editor->>Editor: DrawEditorUI
+    Editor->>Driver: SwapBuffers / EndFrame
+  end
+  Framework->>Editor: DestroyAssets()
+```
+
+### `CreateAssets()`
+
+The editor initialization path creates:
+
+- editor camera and camera controller,
+- line renderers, grid, gizmo,
+- `SceneProps`, default camera, light camera, directional light,
+- scene setup from `Scenes/Quake3Mock.json`,
+- Gaussian kernels and SSAO resources,
+- Jolt physics runtime and debug renderer,
+- primitive manager and quad instances,
+- editor NavMesh debug renderer and initial state,
+- skybox and environment cubemap,
+- `Scenes/T8ditor_RenderGraph.json` render graph and render targets,
+- dummy white texture for deferred shadow slot,
+- frame dumper,
+- optional startup mesh/scene,
+- ImGui with platform windows enabled.
+
+### `OnUpdate()`
+
+`OnUpdate()`:
+
+1. Applies frame throttling.
+2. Updates editor delta time.
+3. Closes requested hosted windows.
+4. Applies pending cubemap changes.
+5. Loads pending scene after safe frame boundary.
+6. Checks main-window resize and recreates swapchain/render targets when needed.
+7. Updates spline preview.
+8. Processes input.
+9. Updates skinned animation and object ragdolls when not in Mesh Edit or Play Scene.
+10. Calls `OnDraw()`.
+
+### `OnDraw()`
+
+`OnDraw()`:
+
+- begins the driver frame,
+- clears the backbuffer,
+- optionally captures/draws a frozen editor frame when hosted windows are open,
+- renders the editor scene frame if assets are ready,
+- renders ImGui/editor UI,
+- handles frame dumps,
+- swaps buffers and ends the frame.
+
+The frozen-frame path prevents the main editor viewport from mutating while hosted windows own user focus/rendering.
+
+## EditorWorld data model
+
+`EditorWorld` is the shared authoring data model. It is accessed via `GetEditorWorld()`, and many editor files use reference aliases to the same state.
+
+It owns:
+
+- scene objects,
+- cameras,
+- lights,
+- light cameras,
+- camera animations,
+- splines,
+- God Rays volume,
+- physics entities,
+- game entities,
+- groups,
+- mixed selection state,
+- undo stack,
+- loaded scene file data,
+- unloaded scene object fallbacks,
+- scene collision path,
+- profiles,
+- Quake3 collision world.
+
+Selection type values:
+
+| Type | Meaning |
+|---|---|
+| `0` | mesh/object |
+| `1` | camera |
+| `2` | light |
+| `3` | physics entity |
+| `4` | NavMesh |
+| `5` | spline |
+| `6` | light camera |
+| `7` | spline point |
+| `8` | God Rays volume |
+
+`multiSelect` is legacy mesh-only selection. `multiEntitySelect` stores typed `SelectionRef` values for mixed mesh/physics/etc. selection.
+
+## Scene save/load
+
+T8ditor saves and loads `.t8scene` through:
+
+- `EditorApp::BuildEditorSceneSnapshot()`
+- `EditorApp::SaveEditorSceneSnapshot()`
+- `EditorApp::RefreshVirtualEditorScene()`
+- `EditorScene.cpp` wrappers
+- `Framework/src/scene/EditorSceneFile.cpp`.
+
+`BuildEditorSceneSnapshot()` gathers:
+
+- editor camera and view toggles,
+- optional ImGui layout when "Allow Custom Layout" is enabled,
+- scene objects, transforms, visibility, mobile visibility, wire/orientation flags,
+- physics/navigation/ragdoll metadata,
+- unloaded scene objects that failed to load,
+- game entities,
+- splines,
+- light cameras,
+- camera animations,
+- God Rays volume,
+- physics entities,
+- NavMesh descriptor,
+- cameras and lights,
+- collision resource path,
+- profiles.
+
+Transient editor objects are excluded.
+
+`EditorSceneFile.cpp` uses Glaze JSON. Unknown keys are ignored on load. Mesh paths are normalized, and missing glTF mesh paths can be resolved by recursive fallback search using the scene directory, mesh directory, first resource directory, and `Models`.
+
+## ImGui, menu, toolbar, and panels
+
+`EditorImGui` owns:
+
+- ImGui initialization/shutdown,
+- frame begin/render,
+- menu bar,
+- toolbar,
+- context menu,
+- panel visibility flags,
+- log capture,
+- layout capture/apply/save,
+- ImGuizmo setup and manipulation,
+- base hierarchy/inspector/console/RT-debug helper functions.
+
+Panel visibility includes:
+
+- Hierarchy,
+- Inspector/Properties,
+- Console,
+- Look & Lighting,
+- Timeline,
+- NavMesh Authoring,
+- Wireframe,
+- Skybox,
+- RT Debug.
+
+The main `DrawEditorUI()` function:
+
+1. Starts a new ImGui frame.
+2. Captures a before-state for automatic ImGui undo.
+3. Routes to Mesh Edit or Play Scene if those hosted windows are open.
+4. Draws menu bar and toolbar.
+5. Handles menu actions such as import, save, load, exit, reset layout.
+6. Draws hierarchy/properties/nav/timeline/rendering/console/RT debug panels.
+7. Draws hosted Ragdoll, Mesh, and Play windows.
+8. Commits an undo state if ImGui edits changed the scene.
+9. Calls `ImGuiRender()`.
+
+## Hierarchy and Inspector
+
+The hierarchy panel is the main scene tree. It includes:
+
+- scene root,
+- game entities,
+- mesh objects,
+- cameras,
+- lights,
+- physics entities,
+- ragdoll child bodies,
+- NavMesh authoring children,
+- splines and spline points,
+- light cameras,
+- God Rays volume.
+
+Selecting from the hierarchy updates `g_selectionType`, `g_selectedIdx`, `g_multiSelect`, and `g_multiEntitySelect`.
+
+The Properties/Inspector path edits the selected entity's fields. Depending on selection type, this can edit:
+
+- mesh transform/visibility/freeze/wire/orientation/navigation/physics/ragdoll,
+- camera settings,
+- light settings,
+- physics body/player/character settings,
+- NavMesh volume or link settings,
+- spline settings and points,
+- light camera settings,
+- God Rays volume.
+
+## Viewport, selection, and gizmos
+
+The main editor viewport uses:
+
+- `EditorCamera` for orbit/pan/zoom/free-fly state,
+- `EditorGrid` for XZ reference grid,
+- `EditorGizmo` and ImGuizmo for selected transforms,
+- `EditorSceneGizmos` for camera/light gizmos,
+- `EditorLineRenderer` for wire/debug overlays,
+- `HandleMousePick()` and ray tests for selection.
+
+Keyboard shortcuts include:
+
+- `Q/W/E/R`: select/translate/rotate/scale gizmo mode.
+- `Ctrl+Z`: undo.
+- `Ctrl+Shift+Z` or `Ctrl+Y`: redo.
+- `Z` without Ctrl: frame selected entity.
+- `Delete`: delete selected entity.
+- `Space`: dump frame when frame dumper is active.
+
+Object transforms edited through ImGuizmo are captured as undo commands. Group transforms use `GroupTransformCommand`.
+
+## Rendering integration
+
+The editor uses the same Framework render path as scenes:
+
+- `T8ditor_RenderGraph.json`,
+- `RenderGraph::Execute()` for deferred rendering on D3D11/D3D12/Vulkan,
+- forward fallback for OpenGL,
+- `SceneProps` for lighting/render controls,
+- `RenderMesh` / `RenderSkinnedMesh` primitives through `PrimitiveManager`,
+- overlay drawing after deferred output.
+
+`RenderEditorSceneFrame()`:
+
+1. Selects active camera: scene camera, light camera, or editor orbit camera.
+2. Syncs editor lights to `SceneProps`.
+3. Applies God Rays volume to scene properties.
+4. Syncs object transforms.
+5. Uploads skinned bone textures.
+6. Copies visible mesh instances into a contiguous array for `RenderGraph::Execute()`.
+7. Binds environment and dummy shadow resources.
+8. Draws RT debug override if selected.
+9. Draws wireframe, skeleton, physics, NavMesh, spline, camera, and light overlays.
+
+The Look & Lighting panel maps controls from `Scenes/Quake3Mock.json` into editor `SceneProps`, including exposure, bloom, light scales, lightmaps, tone mapping, shadow/SSAO/DOF/parallax/God Rays, debug RTs, cubemap, Gaussian kernels, material multipliers, and render graph pass toggles.
+
+## Timeline
+
+`DrawEditorTimelinePanel()` drives authored time-based editor playback.
+
+It:
+
+- selects a spline track,
+- estimates spline duration,
+- can play/loop/scrub time,
+- updates a `SplineAgent`,
+- writes the spline's `agent_offset`,
+- applies camera animations at the current time,
+- applies spline agent position to attached cameras.
+
+It intentionally moves authored cameras but never switches the active view camera.
+
+## Play Scene hosted runtime
+
+Play Scene hosts a real `SceneTemplate` in an ImGui platform window/viewport.
+
+Flow:
+
+1. If authored NavMesh is dirty, regenerate it.
+2. Export a temporary `.t8scene` under the OS temp directory.
+3. Snapshot current editor state.
+4. Create/open a hosted window.
+5. Initialize a `SceneTemplate` with its own `EngineContext` and `m_playScenePhysics`.
+6. Render SceneTemplate to a hosted render target.
+7. Route input into SceneTemplate when the viewport is active.
+8. Restore editor state and delete temp file on close.
+
+`WantsRelativeMouseMode()` returns true only when Play Scene is open, loaded, GUI hidden, and not closing.
+
+## Mesh Editor hosted window
+
+Mesh Edit is a hosted window that embeds a `RagdollEditor` scene for a selected mesh.
+
+It uses:
+
+- `HostedSceneWindowController m_meshEditorWindow`,
+- `HostedRenderViewport m_meshEditorViewport`,
+- a separate GBuffer target,
+- an embedded `RagdollEditor` scene,
+- profile/cubemap controls,
+- its own orbit camera state and GUI visibility toggle.
+
+The embedded scene uses `UseExternalMesh(obj.litInst, meshPath)`, sharing the selected mesh primitive while rendering into isolated hosted viewport targets. This is a sensitive render-state boundary: embedded editor windows should share API resources only as intended and avoid leaking render state back into the main editor.
+
+## Ragdoll Editor hosted window
+
+Ragdoll Edit is a hosted window for skinned meshes.
+
+It provides:
+
+- a hosted viewport and GBuffer/output render targets,
+- orbit camera for ragdoll editing,
+- body/joint/bone selection,
+- move/rotate/edit tools,
+- physics/skeleton debug toggles,
+- simulation speed and fixed-delta controls,
+- load/save/reset ragdoll edits,
+- undo snapshots for ragdoll authoring,
+- integration with `RagdollEditorTool` and `RagdollEditorGui`.
+
+Opening the Ragdoll Editor requires a skinned mesh. It loads or generates ragdoll authoring, recreates runtime kinematic ragdoll bodies, and marks the object for ragdoll debug drawing.
+
+## NavMesh authoring
+
+The editor owns a complete NavMesh authoring state:
+
+- `m_editorNavMesh`,
+- build settings,
+- source stats,
+- status,
+- runtime mode,
+- baked asset path,
+- volumes,
+- authored links,
+- source-triangle classification,
+- selected triangles/volumes/links/nodes,
+- brush selection.
+
+Workflow:
+
+1. Create or regenerate NavMesh from scene objects.
+2. Preview source classification.
+3. Select or brush source triangles.
+4. Create include/exclude/area/link include/link exclude volumes from selections.
+5. Add/edit authored links and pick endpoints from nodes.
+6. Bake `.t8nav` asset when desired.
+7. Save scene.
+
+Play Scene refuses stale NavMesh export unless regeneration succeeds.
+
+## Undo/redo
+
+The undo system uses the Command Pattern.
+
+Core types:
+
+- `UndoCommand`
+- `TransformCommand`
+- `GroupTransformCommand`
+- `UndoStack`
+- `EditorSceneStateCommand`
+
+`UndoStack` supports:
+
+- `Execute()` for commands that should apply immediately,
+- `Push()` for commands already applied by UI/gizmo,
+- `Undo()`,
+- `Redo()`,
+- `Clear()`.
+
+T8ditor uses two granularities:
+
+1. Small transform commands for direct object/group gizmo drags.
+2. Whole-scene snapshot commands for ImGui/editor actions.
+
+`EditorApp::CaptureEditorUndoState()` stores the scene snapshot, groups, selection, active group, active camera, selected NavMesh volume/link, and selected spline point. `ApplyEditorUndoState()` reconstructs render primitives, physics entities, nav state, groups, selection, and profiles.
+
+Every editor action should be undoable. If a new UI edit mutates editor state, it should either push a command directly or be included in the automatic before/after scene-state capture around `DrawEditorUI()`.
+
+## Hosted windows and render targets
+
+Hosted windows use:
+
+- `HostedSceneWindowController` for ImGui platform viewport/native handle/docking/window open state.
+- `HostedRenderViewport` for render target creation, image rect, input-local coordinate conversion, resize checks, and ImGui texture drawing.
+
+Hosted windows track:
+
+- open/loaded/openRequested/closeRequested,
+- GUI visible state,
+- viewport input active state,
+- native handle and ImGui viewport id,
+- dockspace/dock class,
+- viewport and image rectangles.
+
+Input routing temporarily maps global editor mouse coordinates into hosted viewport local coordinates before calling the embedded scene's input handler.
+
+## Extension points
+
+When adding editor features:
+
+1. Add durable data to `EditorWorld` or scene schema, not scattered file-scope state.
+2. Add save/load conversion in `BuildEditorSceneSnapshot()` and `.t8scene` schema helpers.
+3. Add UI in the relevant panel or a new panel file.
+4. Add undo support via `UndoStack` or scene-state capture.
+5. If it draws in the viewport, add overlay/debug rendering in `RenderEditorSceneFrame()`.
+6. If it has a hosted runtime, use `HostedSceneWindowController` and `HostedRenderViewport`.
+7. Keep render-state isolation explicit for hosted Mesh/Ragdoll/Play windows.
+
+## Known limitations and gotchas
+
+- `EditorApp.cpp` remains very large; many panels and helpers are still in one file.
+- `RenderQueue`-style extraction is not used by editor scene rendering; it still copies visible `PrimitiveInst` values for render graph execution.
+- Mesh Edit shares the selected mesh primitive with the hosted scene; this is an intentional but sensitive isolation boundary.
+- Timeline moves authored cameras but does not switch the active viewport camera.
+- NavMesh volumes and links are authoring helpers, not normal gameplay objects.
+- Scene snapshots skip transient objects but preserve unloaded scene objects.
+- Hosted windows can freeze the main editor viewport and route input differently.
+- Some editor state is still global/static or referenced through aliases into `EditorWorld`.
+
+## Debugging checklist
+
+1. If editor startup fails, check `CreateAssets()` sections: camera, helpers, scene props, physics, render graph, ImGui.
+2. If save/load fails, inspect `EditorSceneFile.cpp` parse/write logs and mesh fallback resolution.
+3. If undo fails, verify the action pushes a command or changes are captured by `DrawEditorUI()` before/after state.
+4. If selection breaks, check `g_selectionType`, `g_selectedIdx`, `multiSelect`, and `multiEntitySelect`.
+5. If gizmos do not draw, check `EditorGizmo::Create()`, ImGuizmo frame setup, and selection/frozen flags.
+6. If viewport rendering is wrong, check `RenderEditorSceneFrame()`, active camera selection, deferred readiness, and render graph pass toggles.
+7. If hosted windows misroute input, inspect `HostedRenderViewport::Contains/LocalX/LocalY` and GUI visibility state.
+8. If Mesh Edit or Ragdoll Edit corrupts main rendering, audit shared `PrimitiveInst`/render-state/resource use and make sure hosted windows restore driver state.
+9. If Play Scene differs from editor, inspect the temporary exported `.t8scene` and restoration path.
+10. If NavMesh authoring is stale, check `m_editorNavMeshDirty`, classification readiness, and Play Scene regeneration logs.

--- a/documentation/editor/editor-overview.md
+++ b/documentation/editor/editor-overview.md
@@ -1,0 +1,8 @@
+# Editor Overview
+
+Status: planned.
+
+This document will cover T8ditor, panels, hierarchy, inspector, gizmos, Play Scene, Mesh Editor, Ragdoll Editor, NavMesh Authoring, and undo/redo.
+
+See [stage-plan.md](../stage-plan.md#stage-9--editor).
+

--- a/documentation/editor/imgui-system.md
+++ b/documentation/editor/imgui-system.md
@@ -1,0 +1,423 @@
+# FrameworkImGui Runtime UI Layer
+
+Status: Stage 16 draft.
+
+This document explains the reusable FrameworkImGui layer used by runtime scenes and wrapped by T8ditor: platform/backend initialization, frame lifecycle, docking and platform windows, Android native-window rebinding, loading-screen rendering, `DevGuiContext`, and hosted viewport integration.
+
+Related documents:
+
+- [Main architecture](../architecture/main-architecture.md)
+- [Platform event loop](../architecture/platform-event-loop.md)
+- [Input, camera, and controls](../input/camera-and-controls.md)
+- [Debug and diagnostics](../debug/diagnostics.md)
+- [Editor overview](editor-overview.md)
+- [Scene format and runtime](../scenes/scene-format-and-runtime.md)
+- [SceneSetup descriptors](../scenes/scene-setup-descriptors.md)
+
+## Purpose and responsibilities
+
+FrameworkImGui is the shared UI bridge between T850 platform/render backends and Dear ImGui.
+
+It is responsible for:
+
+1. Creating and destroying the Dear ImGui context.
+2. Initializing the correct platform backend: SDL3 on desktop/Linux, Android backend on Android.
+3. Initializing the correct renderer backend: D3D11, D3D12, OpenGL, or Vulkan.
+4. Driving `NewFrame()`, draw-data build, draw-data render, and optional platform windows.
+5. Routing manual gamepad navigation into ImGui.
+6. Rendering loading-progress frames while long asset loads run.
+7. Providing `DevGuiContext` wrappers for scene controls, embedded panels, hosted editor viewports, and descriptor-driven widgets.
+
+```mermaid
+flowchart LR
+  App["DayScene App / T8ditor wrapper"] --> ImGuiSystem["ImGuiSystem"]
+  ImGuiSystem --> Platform["SDL3 or Android platform backend"]
+  ImGuiSystem --> Renderer["D3D11 / D3D12 / OpenGL / Vulkan backend"]
+  ImGuiSystem --> DevGui["DevGuiContext"]
+  DevGui --> SceneGui["SceneBase::DrawDevGui"]
+  ImGuiSystem --> Loading["LoadingProgress frame callback"]
+  ImGuiSystem --> DrawData["ImGui draw data"]
+  DrawData --> Driver["BaseDriver backend frame"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `FrameworkImGui/include/imgui/ImGuiSystem.h` | Public UI-system wrapper: init/shutdown, frame lifecycle, draw data, loading frame renderer, capture queries, wheel/gamepad input, Android event/native-window APIs. |
+| `FrameworkImGui/src/ImGuiSystem.cpp` | Platform/backend initialization, renderer dispatch, dockspace/platform windows, SDL event watcher, Android native-window rebind, loading screen, gamepad navigation. |
+| `FrameworkImGui/include/imgui/DevGuiContext.h` | Shared scene/dev GUI facade around ImGui panels, sections, descriptor widgets, hosted viewport docking IDs, embedded panels, and navigation focus. |
+| `FrameworkImGui/src/DevGuiContext.cpp` | `DevGuiContext` implementation: scoped labels, panel begin/end, slider/checkbox/combo/button helpers, frame stats overlay, navigation focus. |
+| `DayScene/Application.cpp` | Runtime ImGui owner: layout seeding, init, loading-frame install, runtime GUI drawing, Android pre-present overlay rendering, input dispatch. |
+| `T8ditor/EditorImGui.cpp` | T8ditor-specific wrapper around `ImGuiSystem`: editor layout path, style, appearance dialog, log capture, texture IDs, editor platform-window usage. |
+| `T8ditor/HostedViewportPanel.*` | Hosted viewport/window helpers used by Play Scene, Mesh Edit, and Ragdoll Edit. |
+| `T8ditor/PlayScenePanel.cpp` and `T8ditor/MeshEditorPanel.cpp` | Hosted runtime scene panels that use `DevGuiContext` with viewport/dock/window-class IDs. |
+
+## Runtime ownership
+
+`ImGuiSystem` is owned by the executable/application layer:
+
+- runtime `DayScene::App` owns `m_imgui`;
+- T8ditor owns a static `s_imguiSystem` through `EditorImGui.cpp`;
+- scenes do not own ImGui directly, they receive a `DevGuiContext&` in `DrawDevGui()`.
+
+The normal runtime order is:
+
+```mermaid
+sequenceDiagram
+  participant App as AppBase implementation
+  participant UI as ImGuiSystem
+  participant Scene as SceneBase
+  participant Driver as BaseDriver
+
+  App->>UI: Init(framework, ini, docking, platformWindows)
+  App->>UI: NewFrame(createDockspace)
+  App->>Scene: DrawDevGui(DevGuiContext)
+  App->>UI: BuildDrawData / Render
+  UI->>Driver: backend-specific RenderDrawData
+  App->>UI: Shutdown()
+```
+
+## ImGuiSystem initialization
+
+`ImGuiSystem::Init()` requires a valid `RootFramework` and `RootFramework::pVideoDriver`. It extracts the platform window from the framework and the API from the active driver.
+
+Root extraction:
+
+| Platform | Window source |
+|---|---|
+| Windows | `Win32Framework::m_pWindow` (`SDL_Window*`) |
+| Linux | `LinuxFramework::m_pWindow` (`SDL_Window*`) |
+| Android | `AndroidFramework::GetNativeWindow()` (`ANativeWindow*`) |
+
+Initial setup:
+
+1. `IMGUI_CHECKVERSION()`.
+2. `ImGui::CreateContext()`.
+3. Enable keyboard and gamepad navigation.
+4. Enable docking when requested.
+5. Enable platform viewports when requested and not Android.
+6. Assign `io.IniFilename`.
+7. Apply dark style and rounded defaults.
+8. When platform windows are enabled, set window rounding to 0 and force opaque window backgrounds.
+
+## Platform backend setup
+
+Platform backend selection:
+
+| Platform/API | Backend init |
+|---|---|
+| Android | `ImGui_ImplAndroid_Init(m_androidWindow)` |
+| Windows + OpenGL | `ImGui_ImplSDL3_InitForOpenGL(m_sdlWindow, nullptr)` |
+| Windows + Vulkan | `ImGui_ImplSDL3_InitForVulkan(m_sdlWindow)` |
+| Windows + D3D11/D3D12 | `ImGui_ImplSDL3_InitForD3D(m_sdlWindow)` |
+| Linux | `ImGui_ImplSDL3_InitForVulkan(m_sdlWindow)` |
+| Other desktop fallback | `ImGui_ImplSDL3_InitForOpenGL(m_sdlWindow, nullptr)` |
+
+Desktop builds set SDL gamepad mode to manual:
+
+```cpp
+ImGui_ImplSDL3_SetGamepadMode(ImGui_ImplSDL3_GamepadMode_Manual);
+```
+
+This is intentional because T850 feeds gamepad navigation from `InputManager`/`GamepadInputState`, not from ImGui's automatic SDL polling.
+
+Desktop initialization also registers an SDL event watcher after renderer init. The watcher:
+
+- forwards events to `ImGui_ImplSDL3_ProcessEvent()`;
+- accumulates mouse wheel into `m_wheelAccum`;
+- records window events for short trace logging.
+
+## Renderer backend setup
+
+Renderer backend selection:
+
+| API | Backend init and special notes |
+|---|---|
+| D3D11 | Uses `ID3D11Device` and `ID3D11DeviceContext` from global `T8Device`/`T8DeviceContext`, then calls `ImGui_ImplDX11_Init`. |
+| D3D12 | Enabled only when `imgui_impl_dx12.h` is available. Uses `D3D12Driver`, native device, command queue, backbuffer count, RTV/DSV formats, and the driver's visible CBV/SRV/UAV heap. |
+| OpenGL | Desktop only. Calls `ImGui_ImplOpenGL3_Init("#version 300 es")`. |
+| Vulkan | Uses `VulkanDriver` instance/device/queue family/queue, descriptor pool size 64, backbuffer count, and the backbuffer render pass. |
+
+D3D12 uses custom descriptor allocation callbacks that allocate CPU/GPU descriptors from `D3D12Heap::CBV_SRV_UAV_VISIBLE`. The free callback is intentionally empty because descriptors come from the driver's heap allocator path.
+
+Vulkan rendering calls `VulkanDriver::EnsureBackbufferRenderPass()` before rendering draw data and uses the current `VulkanDeviceContext` command buffer.
+
+## NewFrame and rendering lifecycle
+
+`NewFrame(createDockspace)` performs:
+
+1. Android native-window validation/rebind when needed.
+2. Renderer backend `NewFrame()`.
+3. Platform backend `NewFrame()`.
+4. Desktop mouse synchronization from SDL global/window mouse state.
+5. Manual gamepad navigation submission.
+6. `ImGui::NewFrame()`.
+7. Optional main dockspace creation through `DockSpaceOverViewport`.
+
+Desktop gamepad behavior:
+
+- Windows submits full gamepad navigation through `SubmitGamepadGuiNavigation()`.
+- Linux submits directional gamepad navigation through `SubmitGamepadGuiDirectionalNavigation()`.
+- Windows also uses `MouseDrawCursor` when gamepad GUI is visible and touch cursor is active.
+
+`Render()` performs:
+
+1. `BuildDrawData()` -> `ImGui::Render()`.
+2. `RenderDrawData()` -> API backend draw-data submission.
+3. Desktop platform-window updates when viewports are enabled.
+
+OpenGL preserves/restores the current SDL GL window/context around platform-window rendering. Vulkan defers platform-window resize handling during a left-mouse drag if any platform viewport has `PlatformRequestResize`; this avoids resize churn during drag operations.
+
+## BuildDrawData and RenderDrawData
+
+`BuildDrawData()` is intentionally small: it calls `ImGui::Render()`.
+
+`RenderDrawData()` dispatches by active API:
+
+- D3D11 -> `ImGui_ImplDX11_RenderDrawData`.
+- D3D12 -> binds the D3D12 SRV heap and calls `ImGui_ImplDX12_RenderDrawData` with the current command list.
+- OpenGL -> `ImGui_ImplOpenGL3_RenderDrawData`.
+- Vulkan -> clears pending texture slots, ensures the backbuffer render pass, gets the current command buffer, then calls `ImGui_ImplVulkan_RenderDrawData`.
+
+On Android, runtime code normally calls `BuildDrawData()` in `DrawRuntimeGui()`, then installs a Vulkan pre-present overlay callback that calls `RenderDrawData()` at the correct point in the frame.
+
+## Capture queries and wheel input
+
+`ImGuiSystem` exposes:
+
+| API | Meaning |
+|---|---|
+| `WantsKeyboard()` | Returns `ImGui::GetIO().WantCaptureKeyboard`. |
+| `WantsTextInput()` | Returns `ImGui::GetIO().WantTextInput`. |
+| `WantsMouse()` | Returns `ImGui::GetIO().WantCaptureMouse`. |
+| `ConsumeWheelDelta()` | Returns accumulated SDL wheel delta and resets it. |
+| `AddWheelDelta(delta)` | Adds wheel amount from the SDL event watcher. |
+
+Editor and runtime input code use these capture flags to avoid applying shortcuts, mouse look, camera movement, or text-sensitive actions while ImGui is interacting with controls.
+
+## Android native-window binding and input
+
+Android is special because the `ANativeWindow` can be destroyed and recreated while the app object and ImGui wrapper survive.
+
+`SetAndroidNativeWindow(window)`:
+
+1. If not initialized yet, stores the incoming window and returns whether it is non-null.
+2. If already initialized with the same live window, returns true.
+3. If a platform backend is active for an old window, shuts it down.
+4. Initializes `ImGui_ImplAndroid` for the new window.
+5. Logs `Android native window rebound`.
+
+`NewFrame()` calls `SetAndroidNativeWindow(currentWindow)` every frame before backend new-frame calls. `DayScene::App::OnAndroidNativeWindowChanged()` also calls `m_imgui.SetAndroidNativeWindow(window)` when the Android framework reports a surface change.
+
+`HandleAndroidInputEvent(event)` forwards to `ImGui_ImplAndroid_HandleInputEvent()`. It also patches stylus/eraser motion by manually adding touch-screen source, mouse position, and left-button events for down/up/move cases.
+
+## Loading-progress frame renderer
+
+`InstallLoadingProgressRenderer()` registers a `LoadingProgress` frame callback that calls `RenderLoadingFrame()`. `ClearLoadingProgressRenderer()` removes the callback.
+
+`RenderLoadingFrame()`:
+
+1. Guards against reentrancy with `m_loadingFrameActive`.
+2. Processes desktop input while loading.
+3. Clears the backbuffer.
+4. Starts an ImGui frame without a dockspace.
+5. Reads `LoadingProgress::GetSnapshot()`.
+6. Draws a full-screen loading UI with title, phase, progress bar, percentage, item, and detail.
+7. Renders ImGui.
+8. Presents through `BaseDriver::CompleteFrame(Present)`.
+
+Runtime `App::CreateAssets()` installs this renderer before scene/font/primitive loading and clears it when loading is complete.
+
+## Runtime DayScene UI flow
+
+`DayScene/Application.cpp` uses `ImGuiSystem` directly.
+
+Initialization:
+
+- skips runtime ImGui for regular benchmark mode, except benchmark matrix;
+- seeds `imgui_runtime_layout.ini` from `Layouts/imgui_runtime_layout.ini` when missing;
+- calls `m_imgui.Init(pFramework, kRuntimeImGuiLayoutFile, true)`;
+- installs the loading-progress renderer on success.
+
+Frame drawing:
+
+```mermaid
+flowchart TD
+  DrawRuntimeGui["App::DrawRuntimeGui"] --> Gamepad["SetGamepadNavigationInput"]
+  Gamepad --> NewFrame["m_imgui.NewFrame(m_imguiVisible)"]
+  NewFrame --> Overlay["DevGuiContext::DrawFrameStatsOverlay"]
+  NewFrame --> Panel["Scene Controls panel"]
+  Panel --> SceneGui["m_actualScene->DrawDevGui(gui)"]
+  Panel --> DebugRT["desktop debug RT windows"]
+  NewFrame --> AndroidControls["Android virtual controls when applicable"]
+  AndroidControls --> RenderPath{"Platform"}
+  RenderPath -->|desktop| Render["m_imgui.Render()"]
+  RenderPath -->|Android| PrePresent["BuildDrawData + Vulkan pre-present callback RenderDrawData"]
+```
+
+On desktop, the runtime GUI also uses `DevGuiContext::SetNavigationFocusPanel()` to restrict gamepad nav focus to the currently selected panel. After rendering, it resets navigation focus to `nullptr`.
+
+On Android, runtime GUI has extra controls:
+
+- pause/resume scene,
+- close GUI,
+- undock panel,
+- GUI scale slider,
+- left triple-tap/right-side panel mode behavior handled by app code,
+- special physics panel routing.
+
+## DevGuiContext
+
+`DevGuiContext` is the shared facade for scene/runtime debug panels. It lets runtime scenes draw the same controls in:
+
+- standalone runtime windows,
+- T8ditor hosted Play Scene panels,
+- Mesh Edit panels,
+- embedded/collapsible contexts,
+- Android-specific panels.
+
+Important APIs:
+
+| API | Meaning |
+|---|---|
+| `BeginPanel(title, open, flags)` / `EndPanel()` | Opens a normal ImGui window, or a collapsible embedded section when embedded mode is enabled. |
+| `SetIdSuffix(suffix)` | Adds a stable hidden label suffix so hosted scene panels do not collide with main runtime panels. |
+| `SetViewportId(viewportId)` | Pins the next panel to a specific ImGui platform viewport. |
+| `SetDockId(dockId)` | Applies a first-use dock target for hosted panels. |
+| `SetWindowClassId(classId)` | Applies a window class and disables unclassed docking. |
+| `SetEmbedPanels(embed)` | Uses collapsible headers instead of separate ImGui windows. |
+| `Slider`, `Checkbox`, `Combo`, `Button` | Descriptor-aware wrappers used by scene controls. |
+| `DrawFrameStatsOverlay(text)` | Draws a small transparent frame-stats overlay. |
+| `SetNavigationFocusPanel(title)` / `PanelAllowsNavigationFocus(title)` | Limits gamepad/keyboard navigation to one visible panel title. |
+
+Label handling:
+
+- `MakeImGuiLabel(name, label)` creates `visible##name` labels for descriptor controls.
+- `MakePanelLabel(title, suffix)` creates `visible##suffix/original` panel labels for hosted windows.
+- `VisiblePanelTitle()` strips hidden `##` IDs before navigation-focus comparison.
+
+On Android, `Combo()` supports touch scrolling inside combo popups and avoids auto-closing while a touch drag is in progress.
+
+## Runtime scene DevGui call sites
+
+Scene classes expose debug/runtime controls through `SceneBase::DrawDevGui(DevGuiContext&)`.
+
+Major current call sites:
+
+- `SceneTemplate::DrawDevGui()`,
+- `Quake3Mock::DrawDevGui()`,
+- `SandboxScene::DrawDevGui()`,
+- `RagdollEditor::DrawDevGui()`,
+- Android physics panel wrappers in `Application.cpp`.
+
+Scene code should prefer `DevGuiContext` wrappers for descriptor-style controls. Direct ImGui calls are still used for custom/debug views, but `DevGuiContext` gives hosted windows, embedded panels, and gamepad navigation focus consistent behavior.
+
+## T8ditor relationship
+
+T8ditor does not use `DayScene::App::m_imgui`; it wraps the same `ImGuiSystem` through `T8ditor/EditorImGui.cpp`.
+
+T8ditor-specific additions:
+
+- `BuildGlobalLayoutPath()` stores the global editor layout under SDL pref path `T850/T8ditor/imgui_layout.ini` when available.
+- Legacy relative `imgui_layout.ini` is migrated into that global path.
+- `ImGuiInit(fw, true)` enables docking and platform windows.
+- `ApplyArtistEditorStyle()` applies editor-specific theme/font scaling.
+- `ImGuiRender()` calls `s_imguiSystem.Render()` and saves the global layout when dirty.
+- `ImGuiTextureID()` converts backend texture objects to ImGui texture IDs for D3D11, D3D12, Vulkan, and OpenGL.
+- Vulkan texture descriptors are cached through `ImGui_ImplVulkan_AddTexture()`.
+- Log capture feeds the editor console ring buffer.
+
+This means FrameworkImGui owns the backend lifecycle, while T8ditor owns editor layout policy, editor appearance, editor panels, texture-ID conversion, and scene-specific layout behavior.
+
+## Hosted viewport integration
+
+T8ditor hosted windows use ImGui docking/platform-window features plus `DevGuiContext`.
+
+`HostedSceneWindowController` stores:
+
+- open/loaded/close state,
+- GUI visibility,
+- native/window handle logging state,
+- ImGui viewport ID,
+- dockspace ID,
+- dock class ID,
+- viewport/image rects.
+
+`HostedRenderViewport` stores the render target and its ImGui image rect. It can draw a backend texture into an ImGui image, track input-active state, and convert global mouse coordinates to local viewport coordinates.
+
+Hosted scene controls:
+
+| Hosted window | Integration |
+|---|---|
+| Play Scene | Creates `PlaySceneDockSpace`, `PlaySceneDockClass`, pins scene controls to the play-scene viewport/dock/class, calls `m_playScene->DrawDevGui(gui)`. |
+| Mesh Edit | Creates `MeshEditDockSpace`, `MeshEditDockClass`, pins scene controls to the mesh-edit viewport/dock/class, calls `m_meshEditorScene->DrawDevGui(gui)`. |
+| Ragdoll Edit | Uses hosted viewport/image input for custom ragdoll tool UI; it is mostly editor-specific panel code rather than a hosted runtime `DrawDevGui()` scene panel. |
+
+When adding hosted windows, use unique `SetIdSuffix()` values and window class IDs to avoid ImGui ID collisions and accidental docking into unrelated editor panels.
+
+## Shutdown and reload hazards
+
+`ImGuiSystem::Shutdown()`:
+
+1. Clears the loading-progress frame callback.
+2. Saves ini settings when an ini path exists.
+3. Shuts down the active renderer backend.
+4. Shuts down the platform backend.
+5. Removes the SDL event watcher on desktop.
+6. Destroys the ImGui context.
+7. Clears framework/window/gamepad/transient state.
+
+Important hazards:
+
+- Do not call `NewFrame()` or `Render()` after driver destruction; `ImGuiSystem` expects the current `BaseDriver` and backend objects to exist.
+- On API switch/reload, shut down ImGui before destroying backend resources and reinitialize after the new driver exists.
+- D3D12 ImGui rendering needs the visible SRV heap bound before draw-data submission.
+- Vulkan ImGui rendering needs a valid current command buffer and backbuffer render pass.
+- Android surface loss requires native-window rebinding; stale `ANativeWindow*` values must not be used.
+- Desktop platform windows require the SDL event watcher and backend platform-window update/render calls.
+- The loading-progress callback must be cleared before shutdown to avoid callbacks into a destroyed UI system.
+
+## Extension rules
+
+When adding a runtime UI panel:
+
+1. Prefer `SceneBase::DrawDevGui(DevGuiContext&)` for scene-owned controls.
+2. Use `DevGuiContext` descriptor wrappers for sliders, checkboxes, selectors, and buttons when metadata already exists.
+3. Use stable `name` values in descriptors so ImGui IDs do not depend on localized/visible labels.
+4. Respect `PanelAllowsNavigationFocus()` when drawing extra standalone panels that should cooperate with gamepad navigation.
+
+When adding backend/platform support:
+
+1. Add platform init and shutdown branches together.
+2. Add renderer init, new-frame, shutdown, and render-draw-data branches together.
+3. Verify docking and platform windows are either supported or explicitly disabled.
+4. Verify texture-ID conversion for T8ditor if editor image previews must work.
+5. Verify loading-frame rendering during long startup.
+
+When adding hosted editor panels:
+
+1. Use a unique dockspace ID, dock class ID, and `DevGuiContext::SetIdSuffix()`.
+2. Pin panels to the hosted ImGui viewport with `SetViewportId()`.
+3. Use `SetDockId()` and `SetWindowClassId()` to keep panel docking local to the hosted window.
+4. Keep render-target image rect/input state in `HostedRenderViewport`.
+
+## Known limitations and gotchas
+
+- Runtime `ImGuiSystem` and T8ditor's `EditorImGui` wrapper share backend code but have different layout/style policies.
+- Android does not enable platform viewports; hosted native editor windows are desktop-only.
+- D3D12 backend support depends on `imgui_impl_dx12.h` being available at compile time.
+- `DevGuiContext` does not prevent direct ImGui calls; mixed direct/wrapper code must still avoid ID collisions.
+- T8ditor Vulkan texture descriptor caching must be cleared on ImGui shutdown/API reload.
+- Platform-window behavior is sensitive to mouse/resize events; the system has trace logging for short windows after SDL window events.
+
+## Debugging checklist
+
+1. If ImGui fails to initialize, check that `RootFramework::pVideoDriver` and the platform window/native window are valid.
+2. If controls do not receive keyboard/gamepad navigation, check `SetGamepadNavigationInput()`, `SetNavigationFocusPanel()`, and `PanelAllowsNavigationFocus()`.
+3. If mouse coordinates are wrong in editor platform windows, check whether platform windows are enabled and whether mouse sync is using global or window coordinates.
+4. If Android UI disappears after rotation/surface loss, check `SetAndroidNativeWindow()` rebinding logs.
+5. If Vulkan UI does not render, confirm the command buffer exists and `EnsureBackbufferRenderPass()` is called.
+6. If D3D12 UI draws incorrectly, verify the ImGui SRV heap is bound before `ImGui_ImplDX12_RenderDrawData()`.
+7. If hosted Play/Mesh scene panels dock into the wrong window, check `SetViewportId()`, `SetDockId()`, `SetWindowClassId()`, and `SetIdSuffix()`.
+8. If loading progress keeps rendering after shutdown, verify `ClearLoadingProgressRenderer()` ran.

--- a/documentation/geometry/loading-geometry.md
+++ b/documentation/geometry/loading-geometry.md
@@ -1,0 +1,8 @@
+# Loading Geometry
+
+Status: planned.
+
+This document will cover glTF/GLB, `.x`, `XDataBase`, mesh conversion, vertex/index buffers, materials, and skinned/static detection.
+
+See [stage-plan.md](../stage-plan.md#stage-2--loading-geometry).
+

--- a/documentation/geometry/loading-geometry.md
+++ b/documentation/geometry/loading-geometry.md
@@ -1,8 +1,456 @@
 # Loading Geometry
 
-Status: planned.
+Status: Stage 2 draft.
 
-This document will cover glTF/GLB, `.x`, `XDataBase`, mesh conversion, vertex/index buffers, materials, and skinned/static detection.
+This document explains how T850 loads mesh assets, converts them into the engine's internal geometry format, creates material/shader metadata, uploads vertex/index data, and decides whether a mesh is rendered by `RenderMesh` or `RenderSkinnedMesh`.
 
-See [stage-plan.md](../stage-plan.md#stage-2--loading-geometry).
+Related documents:
+
+- [Main architecture](../architecture/main-architecture.md)
+- [Shader management](../rendering/shader-management.md)
+- [Geometry rendering flow](../rendering/geometry-rendering-flow.md)
+- [Animation system](../animation/animation-system.md)
+- [Scene format and runtime](../scenes/scene-format-and-runtime.md)
+
+## Purpose and responsibilities
+
+Geometry loading has three major responsibilities:
+
+1. Convert source asset formats into a shared engine data model.
+2. Build render-ready CPU metadata: interleaved vertices, subsets, shader keys, material records, bounds, culling clusters, and skin/animation data.
+3. Upload or reference GPU resources through shared mesh/material caches so runtime draw code can bind VB/IB/material/shader state efficiently.
+
+The current path is intentionally format-normalized: both modern glTF/GLB and legacy `.x` files feed into `xF::XDataBase`. Runtime renderers then consume `XDataBase` instead of knowing which file format was loaded.
+
+```mermaid
+flowchart LR
+  Scene["Scene / Editor request"] --> PM["PrimitiveManager::CreateMesh"]
+  PM --> Probe["RenderMesh::Load probe"]
+  Probe --> RM["ResourceManager::Load"]
+  RM -->|.gltf/.glb| GLTF["gltf::LoadGLTF + ConvertToXDatabase"]
+  RM -->|legacy| XLOAD["XDataBase::LoadXFile"]
+  GLTF --> XDB["xF::XDataBase"]
+  XLOAD --> XDB
+  XDB --> Detect["skin/animation detection"]
+  Detect -->|static| Static["RenderMesh::Create"]
+  Detect -->|skinned or animated| Skinned["RenderSkinnedMesh::Create"]
+  Static --> Cache["MeshAssetCache / MaterialAssetCache / MeshPool"]
+  Skinned --> Cache
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `Framework/src/utils/ResourceManager.cpp` | File extension dispatch and resource reuse. `.gltf`/`.glb` use the glTF loader; all other mesh paths use `XDataBase::LoadXFile`. |
+| `Framework/src/utils/gltf/GLTFLoader.cpp` | Parses `.gltf` JSON or `.glb`, resolves buffers, validates glTF 2.x documents and supported extensions. |
+| `Framework/src/utils/gltf/GLTFMesh.cpp` | Converts glTF scene nodes/primitives into `xMeshGeometry` and `xFinalGeometry`; handles transforms, attributes, indices, tangents, Draco, skins, and animations. |
+| `Framework/src/utils/gltf/GLTFMaterial.cpp` | Maps glTF PBR material data into `xMaterial::EffectInstance` defaults consumed later by `RenderMesh`. |
+| `Framework/src/utils/XDataBase.cpp` and `Framework/include/utils/XDataBase.h` | Legacy `.x` parser plus internal intermediate mesh database. |
+| `Framework/include/utils/xDefs.h` | Defines `xMeshGeometry`, `xFinalGeometry`, `xMaterial`, skeleton, animation, and subset structs. |
+| `Framework/src/scene/PrimitiveManager.cpp` | Creates mesh primitives and selects `RenderMesh` versus `RenderSkinnedMesh`. |
+| `Framework/src/scene/RenderMesh.cpp` | Static mesh runtime creation: shader-key gathering, texture loads, material cache acquisition, VB/IB pool allocation, culling metadata, wireframe buffers. |
+| `Framework/src/scene/RenderSkinnedMesh.cpp` | Skinned mesh creation: animation controller, bone texture upload, skinned shader/wireframe/skeleton setup. |
+| `Framework/include/scene/MeshAsset.h` | Shared mesh metadata: submeshes, vertex/index counts, bounds, culling clusters, pool allocations. |
+| `Framework/src/scene/MeshAssetCache.cpp` | Path-keyed mesh cache and mesh preprocess cache for culling metadata. |
+| `Framework/src/scene/MeshPool.cpp` | Shared vertex/index GPU buffer pools. |
+| `Framework/include/scene/MaterialAsset.h` and `Framework/src/scene/MaterialAssetCache.cpp` | Deduplicated material parameter/texture records. |
+| `T8ditor/EditorMesh.cpp` | Editor wireframe/picking import path. Uses the same glTF or `.x` conversion into `XDataBase`, then builds editor line geometry. |
+
+## Runtime ownership and lifetime
+
+```mermaid
+classDiagram
+  class ResourceManager {
+    +Load(filename) XDataBase*
+    +Release()
+  }
+  class XDataBase {
+    +XMeshDataBase
+    +MeshInfo
+    +LoadXFile()
+  }
+  class xMeshGeometry {
+    +Positions
+    +Normals
+    +Tangents
+    +TexCoordinates
+    +Triangles/Triangles32
+    +MaterialList
+    +SkinIndex
+    +Info
+  }
+  class xFinalGeometry {
+    +pData
+    +pDataDest
+    +Subsets
+    +VertexSize
+    +NumVertex
+  }
+  class RenderMesh {
+    +xFile
+    +Info
+    +m_asset
+    +Load()
+    +Create()
+  }
+  class RenderSkinnedMesh {
+    +m_animController
+    +UploadBoneTexture()
+  }
+  class MeshAssetCache {
+    +Acquire(path)
+    +Release(asset)
+    +UploadDirtyPools()
+  }
+  class MeshAsset {
+    +submeshes
+    +clusters
+    +rootAABB
+    +vertexAttribMask
+  }
+  class MaterialAssetCache {
+    +Acquire(proto)
+  }
+  ResourceManager --> XDataBase
+  XDataBase --> xMeshGeometry
+  XDataBase --> xFinalGeometry
+  RenderMesh --> XDataBase
+  RenderMesh --> MeshAsset
+  RenderSkinnedMesh --|> RenderMesh
+  MeshAssetCache --> MeshAsset
+  RenderMesh --> MaterialAssetCache
+```
+
+Important lifetime rules:
+
+- `ResourceManager` owns loaded `XDataBase` instances and reuses them by exact filename string.
+- `RenderMesh::Load()` stores a borrowed `xFile` pointer returned by `ResourceManager::Load()`.
+- `RenderMesh::Load()` also acquires a path-keyed `MeshAsset` from `MeshAssetCache`; `RenderMesh::Destroy()` releases it.
+- `MeshAsset` owns shared metadata only. GPU pool buffers live on `MeshAssetCache`, not on one `RenderMesh` instance.
+- `MaterialAssetCache::Acquire()` deduplicates immutable material parameter/texture records. `SubSetInfo` stores a borrowed `MaterialAsset*`.
+- `RenderMesh::Info` and `SubSetInfo` remain per-instance because they contain per-instance constant buffers and draw-time state.
+
+## Entry points
+
+### Runtime scene path
+
+Typical runtime scenes create meshes through the primitive manager:
+
+```mermaid
+sequenceDiagram
+  participant Scene
+  participant PrimitiveManager
+  participant Probe as RenderMesh probe
+  participant ResourceManager
+  participant XDB as XDataBase
+  participant Renderer as RenderMesh/RenderSkinnedMesh
+
+  Scene->>PrimitiveManager: CreateMesh(path)
+  PrimitiveManager->>Probe: Load(path)
+  Probe->>ResourceManager: Load(path)
+  ResourceManager-->>Probe: XDataBase*
+  PrimitiveManager->>PrimitiveManager: inspect skin/animation data
+  alt static mesh
+    PrimitiveManager->>Probe: Create()
+    Probe-->>Scene: primitive id
+  else skinned or animated mesh
+    PrimitiveManager->>Renderer: transfer xFile/m_asset/sourcePath
+    PrimitiveManager->>Renderer: Create()
+    Renderer-->>Scene: primitive id
+  end
+```
+
+`PrimitiveManager::CreateMesh()` first creates a temporary `RenderMesh` probe and calls `Load()`. It inspects the loaded `XDataBase` for:
+
+- `HAS_SKINWEIGHTS0` and `HAS_SKININDEXES0` on any `xMeshGeometry`.
+- animation info in `xMeshContainer::Animation`.
+
+If either condition is true, the primitive becomes `RenderSkinnedMesh`; otherwise the probe itself becomes the final static `RenderMesh`.
+
+### Editor mesh preview path
+
+`T8ditor/EditorMesh.cpp` loads files independently for editor wireframe display and picking:
+
+- `.gltf`/`.glb`: `gltf::LoadGLTF()` then `gltf::ConvertToXDatabase()`.
+- Other extensions: `XDataBase::LoadXFile()`.
+- It then walks `XMeshDataBase[*]->Geometry`, copies positions to a single position-only vertex buffer, and converts every triangle into three line segments for wireframe display.
+
+This path does not create runtime materials, mesh pools, or shader permutations. It is an editor inspection path that shares only the import/conversion stage.
+
+## Format loading
+
+### glTF / GLB
+
+`ResourceManager::Load()` chooses the glTF path when the filename extension is `gltf` or `glb`.
+
+`gltf::LoadGLTF()` performs:
+
+1. Read file bytes.
+2. Sniff JSON glTF versus binary GLB.
+3. Parse JSON into `gltf::Document`.
+4. Check required extensions against the supported extension list.
+5. Rebase GLB buffer views when binary buffer data is embedded.
+6. Resolve external, data URI, or GLB buffers.
+7. Validate glTF 2.x buffers, accessors, meshes, materials, textures, images, and animations.
+
+`gltf::ConvertToXDatabase()` then performs the engine-specific conversion:
+
+1. Pick the active glTF scene if provided; otherwise use scene 0; otherwise use every node with a mesh.
+2. Traverse nodes recursively and compute world matrices using the engine convention `world = local * parent`.
+3. Create a build job per mesh primitive instance.
+4. Decode Draco-compressed primitives up front when `KHR_draco_mesh_compression` is present.
+5. Build primitive geometry, optionally in parallel through `g_threadPool`.
+6. Build interleaved `xFinalGeometry` and material subsets.
+7. Convert glTF material data into one `xMaterial` per primitive.
+8. Build skins and animations when the document contains skins or animation clips.
+
+```mermaid
+flowchart TD
+  Doc["gltf::Document"] --> Nodes["GatherNodes: scene nodes -> mesh instances"]
+  Nodes --> Jobs["Primitive jobs"]
+  Jobs --> Draco{"KHR_draco_mesh_compression?"}
+  Draco -->|yes| Decode["DecodeDracoMesh"]
+  Draco -->|no| Build
+  Decode --> Build["BuildGeometry"]
+  Build --> Final["BuildFinalGeometry"]
+  Final --> Subsets["BuildSubsets"]
+  Subsets --> Materials["ConvertMaterial"]
+  Materials --> XGeom["xMeshContainer::Geometry"]
+  Subsets --> XFinal["XDataBase::MeshInfo"]
+  Doc --> SkinAnim["BuildSkinsAndAnimations"]
+  SkinAnim --> XDB["XDataBase skeleton/animation"]
+```
+
+#### glTF attributes
+
+`BuildGeometry()` reads these glTF attributes when present:
+
+| glTF attribute | Engine storage | Notes |
+|---|---|---|
+| `POSITION` | `xMeshGeometry::Positions` | Required. Transformed by node world matrix for static meshes. |
+| `NORMAL` | `Normals` | Generated as flat normals if missing. |
+| `TANGENT` | `Tangents` and generated `Binormals` | If missing and normals/UV0 exist, MikkTSpace tangents are generated; naive tangents are fallback. |
+| `TEXCOORD_0..3` | `TexCoordinates[0..3]` | Up to four UV channels. |
+| `COLOR_0` | `VertexColors` | Read into geometry, but later render layout support should be verified before relying on it. |
+| `JOINTS_0` | `SkinIndices` | Stored as four floats in a vec4 slot. |
+| `WEIGHTS_0` | `SkinWeights` | Stored as four floats in a vec4 slot. |
+
+The converter sets `xMeshGeometry::VertexAttributes` bits such as `HAS_POSITION`, `HAS_NORMAL`, `HAS_TANGENT`, `HAS_BINORMAL`, `HAS_TEXCOORD0`, `HAS_SKININDEXES0`, and `HAS_SKINWEIGHTS0`. These bits later become `ShaderKey` vertex attribute bits in `RenderMesh::GatherInfo()`.
+
+Skinned vertex positions remain in local/bind space. Static mesh vertices are transformed by the glTF node world matrix during conversion. This distinction matters: runtime skinning applies inverse-bind and bone transforms, so pre-baking skinned vertex positions by node world transform would double-transform the mesh.
+
+### Legacy `.x`
+
+Every non-glTF extension currently uses `XDataBase::LoadXFile()`.
+
+The `.x` path:
+
+1. Reads the asset through `ResourceLocator::ReadBinary()`.
+2. Parses the `.x` template stream into `XMeshDataBase`.
+3. Calls `XDataBase::CreateSubSets()`.
+4. Produces `xMeshGeometry` plus interleaved `xFinalGeometry` entries in `MeshInfo`.
+
+`CreateSubSets()` computes the interleaved vertex stride from `VertexAttributes`, copies attribute arrays into `xFinalGeometry::pData`, mirrors the same data into `pDataDest`, and creates one `xSubsetInfo` per material by counting `MaterialList.FaceIndices`.
+
+The legacy path is still important because it defines the renderer-facing data layout that glTF conversion mirrors.
+
+## `XDataBase` as the intermediate format
+
+`XDataBase` is the compatibility boundary between importers and renderers. Importers fill it; `RenderMesh` and `RenderSkinnedMesh` consume it.
+
+The important structures are:
+
+| Structure | Meaning |
+|---|---|
+| `xF::XDataBase` | Loaded mesh database. Main fields are `XMeshDataBase` and `MeshInfo`. |
+| `xF::xMeshContainer` | Container holding `Geometry`, `Skeleton`, `SkeletonAnimated`, and `Animation`. |
+| `xF::xMeshGeometry` | Source-style geometry arrays: positions, normals, tangents, UVs, skin weights/indices, triangles, materials, and per-geometry skin metadata. |
+| `xF::xFinalGeometry` | Renderer-friendly interleaved vertex data (`pData`/`pDataDest`), vertex stride, vertex count, and material subsets. |
+| `xF::xMaterialList` | Material array plus one face-material index per triangle. |
+| `xF::xSubsetInfo` | One subset per material; stores triangle count, vertex count, vertex start, triangle start, and vertex size. |
+
+```mermaid
+flowchart LR
+  Source["glTF/.x source"] --> XGeom["xMeshGeometry: attribute arrays + triangles"]
+  XGeom --> XFinal["xFinalGeometry: interleaved pData"]
+  XGeom --> Materials["xMaterialList: materials + face indices"]
+  Materials --> Subsets["xSubsetInfo: one draw subset per material"]
+  XFinal --> RenderMesh["RenderMesh::Create"]
+  Subsets --> RenderMesh
+```
+
+### Vertex layout
+
+The interleaved runtime vertex order is deterministic and driven by `VertexAttributes`:
+
+1. Position as `float4`.
+2. Normal as `float4`.
+3. Tangent as `float4`.
+4. Binormal as `float4`.
+5. UV0 as `float2`.
+6. UV1 as `float2`.
+7. UV2 as `float2`.
+8. UV3 as `float2`.
+9. Skin indices as `float4` for glTF/skinned geometry.
+10. Skin weights as `float4` for glTF/skinned geometry.
+
+`xFinalGeometry::VertexSize` is byte stride, not float count. Most of the renderer computes `floatsPerVertex = VertexSize / sizeof(float)`.
+
+## Index buffers
+
+glTF conversion preserves the narrowest index width that can represent the primitive:
+
+- If every triangle index fits in 16 bits, `xMeshGeometry::Triangles` is used and `Indices32Bit = false`.
+- If any index is above `65535`, `xMeshGeometry::Triangles32` is used and `Indices32Bit = true`.
+
+`RenderMesh::Create()` checks `pActual->Indices32Bit` per geometry and suballocates each material subset into either a 16-bit or 32-bit `IndexPool`.
+
+Winding can be changed by `CHANGE_TO_RH` / left-right-handed conversion code. When conversion flips Z to the engine coordinate convention, triangle winding is reversed so face orientation remains correct.
+
+## Materials and textures
+
+The glTF material converter intentionally maps glTF PBR material fields into the older `xMaterial::EffectInstance.pDefaults` mechanism, because `RenderMesh::Create()` already understands those string/float/dword defaults.
+
+Common mappings include:
+
+| glTF source | Engine effect default |
+|---|---|
+| `pbrMetallicRoughness.baseColorFactor` | `diffuseColor` |
+| `baseColorTexture` | `diffuseMap` |
+| `metallicFactor` | `pbrMetallic` |
+| `roughnessFactor` | `pbrRoughness` |
+| `metallicRoughnessTexture` | `metallicMap` |
+| `normalTexture` | `normalMap` plus `normalScale` |
+| `occlusionTexture` | `occlusionMap` plus `occlusionStrength` |
+| `emissiveTexture` / `emissiveFactor` | `emissiveMap` / `emissiveColor` |
+| `alphaMode` / `alphaCutoff` | `alphaMode` / `alphaCutoff` |
+| `doubleSided` | `doubleSided` |
+| `KHR_texture_transform` | per-slot UV transform defaults |
+| material extensions such as sheen, clearcoat, transmission, specular, ior | corresponding material defaults and texture slots where supported |
+
+`RenderMesh::GatherInfo()` converts material/attribute defaults into `ShaderKey` bits. For example, diffuse/specular/gloss/normal/height/metallic/emissive/occlusion/specular/transmission/lightmap maps set feature bits. It then pre-creates shader variants for forward, GBuffer, shadow map, and radial-depth passes, plus parallax variants when a height map is present.
+
+`RenderMesh::Create()` loads textures from material string defaults via `LoadTex()` and copies the fully-populated `SubSetInfo` material state into a `MaterialAsset` prototype. `MaterialAssetCache::Acquire()` deduplicates that prototype and stores a borrowed pointer on the subset.
+
+Texture path handling uses `RemovePath()` before loading, so material texture names are expected to resolve through the engine's normal asset/resource lookup paths rather than arbitrary external file paths.
+
+## Mesh cache, preprocess cache, and GPU upload
+
+`MeshAssetCache` is keyed by normalized source path. On the first acquisition of a path, `RenderMesh::Create()` populates the shared `MeshAsset`; later acquisitions reuse its submesh metadata and pool allocations.
+
+```mermaid
+flowchart TD
+  Load["RenderMesh::Load"] --> Acquire["MeshAssetCache::Acquire(path)"]
+  Acquire --> First{"first acquisition?"}
+  First -->|yes| Create["RenderMesh::Create builds metadata"]
+  First -->|no| Reuse["reuse populated MeshAsset"]
+  Create --> Gather["GatherInfo -> ShaderKey + subsets"]
+  Gather --> Pools["VertexPool/IndexPool suballocations"]
+  Pools --> Upload["MeshAssetCache::UploadDirtyPools"]
+  Create --> Mat["MaterialAssetCache::Acquire"]
+  Create --> Cull["bounds + culling clusters"]
+  Cull --> PPCache["optional preprocess cache"]
+  Reuse --> DrawInfo["copy pool allocs into per-instance MeshInfo/SubSetInfo"]
+```
+
+### Mesh pools
+
+`VertexPool` and `IndexPool` are shared buffer owners:
+
+- `VertexPool` is grouped by vertex format hash and vertex stride.
+- `IndexPool` is grouped by index width: 16-bit or 32-bit.
+- `Suballocate()` appends CPU staging data and returns an element offset.
+- `EnsureUploaded()` recreates the GPU buffer from staging data only when dirty.
+- `GetGPUBuffer()` logs an error and returns null if a dirty pool is accessed before `UploadDirtyPools()`.
+
+`RenderMesh::Create()` writes the pool ids, element offsets, and element counts into `Submesh::vbAlloc` / `Submesh::ibAlloc`, then mirrors those allocations into per-instance `MeshInfo::vbPoolAlloc` and `SubSetInfo::ibPoolAlloc`.
+
+### Culling metadata
+
+`MeshAsset` stores:
+
+- root AABB,
+- per-submesh AABB,
+- submesh index ranges,
+- optional `SubmeshCluster` ranges for finer culling.
+
+When `Config::cullingLoadMode == FullOnLoad`, `RenderMesh::Create()` can load a mesh preprocess cache from disk. If the cache is stale, invalid, or topology-mismatched, culling metadata is rebuilt and can be saved back through `MeshAssetCache::SavePreprocessCache()`.
+
+The preprocess cache is validated against:
+
+- source file size and write time,
+- cache version/header,
+- culling clustering settings,
+- vertex/index/submesh/cluster counts,
+- topology hash and range validity.
+
+## Static versus skinned meshes
+
+`PrimitiveManager::CreateMesh()` uses loaded data inspection to choose renderer type:
+
+```mermaid
+flowchart TD
+  XDB["XDataBase loaded"] --> Attr{"Any geometry has skin weights + indices?"}
+  Attr -->|yes| Skinned["RenderSkinnedMesh"]
+  Attr -->|no| Anim{"Animation info present?"}
+  Anim -->|yes| Skinned
+  Anim -->|no| Static["RenderMesh"]
+```
+
+Skinned rendering adds:
+
+- `AnimationController` initialization from `xMeshContainer::Animation`, `Skeleton`, and `SkeletonAnimated`.
+- skin-weight handoff from the first geometry with `xSkinInfo::SkinWeights`.
+- per-frame animation update when playing.
+- bone matrix upload through a float texture.
+- skinned shader key bits and skinned wireframe/skeleton debug buffers.
+
+The bone texture upload path clamps to the texture's bone capacity and logs errors when context, storage, or matrices are invalid.
+
+## Editor/runtime differences
+
+| Area | Runtime `RenderMesh` / `RenderSkinnedMesh` | T8ditor `EditorMesh` |
+|---|---|---|
+| Import | `ResourceManager` -> `XDataBase` | Direct glTF/`.x` -> temporary `XDataBase` |
+| Materials | Fully loaded, shader-keyed, deduplicated in `MaterialAssetCache` | Ignored for wireframe preview |
+| GPU data | Shared mesh pools, constant buffers, material textures, wireframe buffers | Single position buffer plus line-list index buffer |
+| Picking | Runtime render picking uses engine/editor scene data | Editor mesh preview keeps CPU pick vertices/indices |
+| Skins/animations | Can select `RenderSkinnedMesh` | Mesh preview treats imported geometry as static line geometry |
+
+## Extension points
+
+Use these entry points when extending geometry loading:
+
+- Add a new source format by dispatching in `ResourceManager::Load()` and converting into `XDataBase`.
+- Add a new glTF attribute in `GLTFMesh.cpp`, then update `xMeshGeometry`, `BuildFinalGeometry()`, `RenderMesh::GatherInfo()`, shader input layouts, and shader code.
+- Add a new material feature by mapping glTF data in `GLTFMaterial.cpp`, adding `SubSetInfo`/`MaterialParams` fields if needed, setting a `ShaderKey` bit in `GatherInfo()`, and updating shader permutations.
+- Add a new texture slot by extending `MatTexSlot`, `MaterialAsset`, `RenderMesh::Create()` material copy, shader binding, and material converter.
+- Improve culling by extending `SubmeshCluster` creation and the preprocess cache version/validation.
+
+## Known limitations and gotchas
+
+- `ResourceManager` reuses resources by exact filename string, so inconsistent relative paths can bypass reuse.
+- `XDataBase` remains the central intermediate even for glTF; new loaders should target it or deliberately replace the whole downstream path.
+- glTF vertex colors are imported into `xMeshGeometry`, but the runtime interleaved glTF layout path does not currently add a vertex-color slot in `BuildFinalGeometry()`. Treat vertex-color rendering as a gap unless verified in the shader/render path.
+- Legacy `.x` indices are 16-bit. glTF supports 32-bit indices through `Triangles32`.
+- `RenderMesh::GatherInfo()` pre-creates many shader variants during mesh creation; adding feature bits increases permutation pressure.
+- Texture names are normalized to basename-style lookup via `RemovePath()`. Embedded/external glTF image handling must produce names the engine can resolve.
+- Skinned geometry stays in local/bind space, while static glTF geometry is world-baked during conversion.
+- Mesh pool GPU buffers must be uploaded before draw-time access. A dirty pool logs an error and returns null.
+
+## Debugging checklist
+
+When a mesh does not appear or renders incorrectly:
+
+1. Check the log for `Failed to load`, `[glTF]`, `[RenderMesh]`, `[MeshAssetCache]`, `[MeshPool]`, and texture-not-found messages.
+2. Confirm the path resolves through `ResourceLocator` and uses the same normalized path everywhere.
+3. For glTF, verify `asset.version` is 2.x and required extensions are supported.
+4. Confirm the importer produced at least one `xMeshContainer::Geometry` entry and one `XDataBase::MeshInfo` entry.
+5. Check `xMeshGeometry::VertexAttributes` and `xFinalGeometry::VertexSize` match the expected shader input layout.
+6. For large meshes, verify `Indices32Bit` is set and draw code is using 32-bit index pools.
+7. For missing normal maps or wrong lighting, inspect material defaults and `ShaderKey` feature bits.
+8. For missing textures, check whether the engine is stripping paths and resolving the basename from the expected asset directory.
+9. For static/skinned mismatch, inspect `HAS_SKINWEIGHTS0`, `HAS_SKININDEXES0`, and `xMeshContainer::Animation`.
+10. For culling/pop-in, temporarily disable fine culling or rebuild the mesh preprocess cache.
 

--- a/documentation/geometry/loading-geometry.md
+++ b/documentation/geometry/loading-geometry.md
@@ -7,7 +7,10 @@ This document explains how T850 loads mesh assets, converts them into the engine
 Related documents:
 
 - [Main architecture](../architecture/main-architecture.md)
+- [Resource locator and cache paths](../architecture/resource-locator.md)
+- [Dependency map](../dependency-map.md)
 - [Shader management](../rendering/shader-management.md)
+- [Textures, samplers, and IBL](../rendering/textures-and-ibl.md)
 - [Geometry rendering flow](../rendering/geometry-rendering-flow.md)
 - [Animation system](../animation/animation-system.md)
 - [Scene format and runtime](../scenes/scene-format-and-runtime.md)
@@ -453,4 +456,3 @@ When a mesh does not appear or renders incorrectly:
 8. For missing textures, check whether the engine is stripping paths and resolving the basename from the expected asset directory.
 9. For static/skinned mismatch, inspect `HAS_SKINWEIGHTS0`, `HAS_SKININDEXES0`, and `xMeshContainer::Animation`.
 10. For culling/pop-in, temporarily disable fine culling or rebuild the mesh preprocess cache.
-

--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -14,6 +14,8 @@ This glossary captures engine terms used across the documentation.
 | Dev layer | Developer/debug UI and runtime tooling layer exposed by scenes and editor code. |
 | Primitive | Engine render object abstraction. Common path: `PrimitiveInst` references a `PrimitiveBase` implementation such as `RenderMesh`. |
 | RenderGraph | Data-driven render pipeline loaded from JSON, with passes, render targets, inputs, draw commands, and state changes. |
+| Render graph pass | One JSON-declared render step that can bind a render target, set state, bind inputs, and issue mesh or quad draws. |
+| Render graph edge | Runtime dependency record from a prior RT writer pass to a later pass that samples that RT attachment. |
 
 ## Rendering terms
 
@@ -22,13 +24,22 @@ This glossary captures engine terms used across the documentation.
 | `RenderMesh` | Static mesh renderer for loaded geometry. Owns mesh draw setup and material/shader binding. |
 | `RenderSkinnedMesh` | Skinned mesh renderer extending mesh rendering with animation/bone upload support. |
 | `PrimitiveInst` | Per-instance transform/texture/key wrapper used to draw primitive render objects. |
+| `PrimitiveBase` | Abstract render primitive interface implemented by mesh, skinned mesh, quad, and debug primitives. |
 | `MeshAsset` | Shared geometry/material asset data cached by path. |
 | `MaterialAsset` | Deduplicated material parameters and texture references. |
+| `MeshDrawStateTracker` | Pass-scoped state tracker that skips redundant shader-dependent texture, constant-buffer, topology, VB, and IB binds. |
+| `RenderQueue` | Future flat draw-list abstraction with sortable `DrawItem` entries; current mesh rendering still walks `RenderMesh::Draw`. |
+| `DrawIndexed` | Backend draw call using index count, start index, and base vertex to draw a submesh or cluster. |
 | `ShaderKey` | Bitfield describing shader permutation features and pass type. |
+| `PassType` | Six-bit render pass selector stored inside `ShaderKey`, used to compile pass-specific shader variants. |
+| Shader disk cache | API-specific compiled shader artifact cache stored under `Shaders/.t8shadercache`. |
+| SPIR-V reflection | Vulkan helper that parses SPIR-V modules for descriptor bindings and vertex input locations. |
 | PSO | Pipeline State Object, especially relevant for D3D12/Vulkan where shader/state/topology combine into a pipeline. |
+| PSO cache | D3D12/Vulkan runtime cache keyed by shader pointer plus render state, topology, and render target formats/render pass. |
 | VB | Vertex Buffer. |
 | IB | Index Buffer. |
 | RT | Render Target. |
+| Fullscreen quad | `RenderQuad` primitive used by render graph post-process, deferred, copy, and final-output passes. |
 | GBuffer | Deferred rendering target set containing surface properties, depth, etc. |
 | IBL | Image-based lighting resources. |
 
@@ -39,17 +50,26 @@ This glossary captures engine terms used across the documentation.
 | glTF / GLB | Modern mesh/scene asset format loaded by the glTF loader. |
 | `.x` | Legacy DirectX mesh format supported by the X loader. |
 | `XDataBase` | Internal mesh database format used as an intermediate after loading `.x` or converted glTF data. |
+| `xMeshGeometry` | Source-style geometry arrays inside `XDataBase`: attributes, triangle indices, material list, and optional skin metadata. |
+| `xFinalGeometry` | Interleaved render-ready vertex data and subset metadata generated from `xMeshGeometry`. |
 | Subset | Material/draw subset inside a mesh geometry. |
+| `Submesh` | Shared mesh-cache metadata for one drawable subset, including index range, material slot, bounds, and mesh-pool allocations. |
 | Mesh pool | Shared GPU buffer allocation path for mesh VB/IB data. |
+| Mesh preprocess cache | Disk cache for mesh bounds/culling cluster metadata keyed by source signature and clustering settings. |
 
 ## Animation terms
 
 | Term | Meaning |
 |---|---|
 | Skeleton | Bone hierarchy used by skinned meshes. |
+| `AnimationController` | Per-renderer runtime controller that owns mutable clip playback state, animated skeleton state, and final shader bone matrices. |
+| Skinning | Deforming mesh vertices by blending bone transforms using imported joint indices and weights. |
+| Bind pose | Rest pose used to compute inverse bind matrices and baseline skeleton transforms. |
+| Inverse bind matrix | Matrix that transforms from mesh/bind space into a bone's local bind-space reference; used before animated combined bone transform. |
 | Animation set / clip | Authored animation sequence. |
 | Bone texture | GPU texture path used to pass bone transforms to shaders for skinning. |
 | Snapshot pose | Captured pose data used for replay, ragdoll, or editor workflows. |
+| Keyframe mode | Animation inspection mode that snaps to discrete keyframes instead of interpolating continuously. |
 
 ## Physics terms
 
@@ -82,4 +102,3 @@ This glossary captures engine terms used across the documentation.
 | Gizmo | Viewport transform control using ImGuizmo/editor line rendering. |
 | Play Scene | Editor workflow that exports a temporary `.t8scene` and runs it through SceneTemplate. |
 | Mesh Editor | Editor-hosted mesh editing/inspection window. |
-

--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -7,11 +7,42 @@ This glossary captures engine terms used across the documentation.
 | Term | Meaning |
 |---|---|
 | Framework | Core engine library containing rendering, resources, physics, navigation, scene setup, utilities, and API backends. |
+| Dependency map | Cross-subsystem documentation map linking class dependencies and end-to-end runtime/editor flows. |
+| Review and gap pass | Final documentation audit listing validation results, missing subsystem docs, troubleshooting links, and cross-system limitations. |
 | Scene | Runtime application/demo built on the Framework. Examples include DayScene, Quake3Mock, SandboxScene, RagdollEditor, and SceneTemplate. |
 | T8ditor | The editor executable used to author `.t8scene` files. |
 | `.t8scene` | JSON scene-authoring file saved by T8ditor and loaded by SceneTemplate. |
+| `EditorSceneFile` | Framework schema struct for `.t8scene`, including objects, physics, navigation, ragdolls, cameras, lights, profiles, and editor state. |
+| `SceneDescriptor` | Runtime JSON descriptor for scene controls, cameras, lights, quality settings, UI metadata, and profiles. |
+| `SceneSetup` | Loader/applier that converts `SceneDescriptor` JSON into cameras, lights, filters, splines, and `SceneProps`. |
+| Runtime control descriptor | `SceneDescriptor` slider/checkbox/selector metadata consumed by runtime scenes and T8ditor rendering panels through name-based mapping tables. |
+| `QualityDesc` | `SceneDescriptor` block mapped by `SceneSetup::ApplyQualityAndSettings` into render-quality fields on `SceneProps`. |
+| `SceneSettingsDesc` | `SceneDescriptor` block mapped by `SceneSetup::ApplyQualityAndSettings` into exposure, lighting, material, and feature-toggle fields on `SceneProps`. |
 | SceneTemplate | Runtime scene intended to load and play editor-authored `.t8scene` content. |
+| Scene profile | `SandboxProfileDesc` override set selected by model/platform/GPU targets for render, camera, light, animation, and UI state. |
 | Dev layer | Developer/debug UI and runtime tooling layer exposed by scenes and editor code. |
+| LoadingProgress | Global loading progress state with snapshots, scoped weighted steps, and an optional frame callback for loading UI. |
+| RuntimeTelemetry | Runtime frame sampler for named scopes and counters, written to JSON on shutdown when enabled. |
+| FrameDumper | Diagnostic system that dumps backbuffer/render targets and writes/replays `snapshot.json` frame state. |
+| RenderTrace | Optional compile-time render instrumentation system that writes API resource/state/bind/draw events for cross-backend diffing. |
+| Profiler | CPU/GPU scope profiler with draw-call counting and API-specific timestamp backends. |
+| `ResourceLocator` | Process-wide path abstraction for normalizing resource paths, reading desktop or Android packaged assets, listing assets, resolving filesystem files, and choosing cache paths. |
+| Resource path | Portable engine-relative asset path, usually stored without a leading slash or top-level `Assets/` prefix, such as `Models/Robot.glb`. |
+| Base path | `ResourceLocator` readable root used as one candidate for resolving relative desktop assets. |
+| Cache path | `ResourceLocator` writable root used by generated caches and relative writes when the requested path is not an existing file. |
+| Android asset manager | Native `AAssetManager` pointer used by `ResourceLocator` to read packaged APK assets that are not regular filesystem files. |
+| `.t8cache` | Source-local generated cache directory used by mesh preprocess and Jolt cooked triangle mesh caches. |
+| `InputManager` | App-owned shared keyboard, mouse, text, touch-cursor, and gamepad state consumed by scenes, editor tools, and runtime UI. |
+| `GamepadInputState` | Normalized SDL gamepad state with connected/enabled flags, handheld metadata, axes, triggers, held buttons, and pressed-edge flags. |
+| `CameraController` | Runtime camera profile owner that attaches to a `Camera`, forwards `CameraInputState`, and updates the active profile. |
+| Camera profile | Runtime camera behavior mode such as Orbit, Free Fly, Colliding Fly, Grounded FPS, COD FPS, or Quake 3 FPS. |
+| `CameraInputState` | Scene/editor camera intent structure containing movement, jump/crouch/sprint, mouse look, orbit flags, deltas, and scroll. |
+| `EditorCamera` | T8ditor-specific orbit/pan/zoom camera used by the main editor viewport. |
+| Handheld overlay | ImGui gamepad navigation and controller help/footer UI drawn for handheld/controller workflows. |
+| `ImGuiSystem` | FrameworkImGui wrapper that owns Dear ImGui context setup, platform/renderer backend init, frame lifecycle, draw-data rendering, loading frames, and Android native-window rebinding. |
+| `DevGuiContext` | Shared scene/runtime debug UI facade used for panels, descriptor controls, embedded panels, hosted viewport docking, and gamepad navigation focus. |
+| Platform windows | Dear ImGui multi-viewport/native-window feature used by T8ditor hosted windows on desktop. |
+| Hosted scene panel | T8ditor Play Scene or Mesh Edit panel that pins a runtime scene's `DrawDevGui` output into a hosted ImGui viewport/dockspace. |
 | Primitive | Engine render object abstraction. Common path: `PrimitiveInst` references a `PrimitiveBase` implementation such as `RenderMesh`. |
 | RenderGraph | Data-driven render pipeline loaded from JSON, with passes, render targets, inputs, draw commands, and state changes. |
 | Render graph pass | One JSON-declared render step that can bind a render target, set state, bind inputs, and issue mesh or quad draws. |
@@ -42,6 +73,13 @@ This glossary captures engine terms used across the documentation.
 | Fullscreen quad | `RenderQuad` primitive used by render graph post-process, deferred, copy, and final-output passes. |
 | GBuffer | Deferred rendering target set containing surface properties, depth, etc. |
 | IBL | Image-based lighting resources. |
+| `Texture` | API-neutral base texture object containing source path, CIL flags, sampler params, dimensions, mip count, and backend bind/update functions. |
+| CIL | Common image loader used by `Texture::LoadTexture` for DDS/cubemap/compressed/half-float texture data. |
+| `EnvironmentMapSet` | Texture-index bundle for sky, diffuse/specular IBL, BRDF LUT, Charlie IBL/LUT, and sheen E LUT. |
+| `IBLResources` | Framework helpers that load explicit IBL assets, generate/cache filtered IBL cubemaps/LUTs, and update `SceneProps` IBL settings. |
+| `EnvironmentTextureSlot` | Reserved render texture slots 10-15 for diffuse/specular/BRDF/Charlie/sheen IBL resources. |
+| `MaterialTextureSlot` | Reserved render texture slots 16-25 for extended material maps such as sheen, clearcoat, occlusion, specular, transmission, and lightmap. |
+| Generated IBL cache | Derived `.t8ibl` float cache files stored under `Textures/GeneratedIBLCache`. |
 
 ## Geometry and asset terms
 
@@ -76,10 +114,16 @@ This glossary captures engine terms used across the documentation.
 | Term | Meaning |
 |---|---|
 | Jolt | Physics library integrated into the Framework. |
+| `JoltPhysicsSystem` | Framework wrapper around Jolt for lifecycle, body creation, casts, ragdolls, simulation update, and debug body queries. |
+| `PhysicsBodyHandle` | Runtime handle to a Jolt body slot stored on `PrimitiveInst` for authored physics bodies. |
+| `PhysicsRagdollHandle` | Runtime handle to a Jolt ragdoll slot containing multiple body handles and constraints. |
 | Static triangle mesh | Collision mesh generated from render geometry and used as static world collision. |
+| `.t8jolt` | Cached cooked Jolt triangle mesh shape stored under a source asset `.t8cache` directory. |
 | Character | Jolt character controller path. |
 | CharacterVirtual | Jolt virtual character controller path. |
+| Kinematic character controller | T850 movement controller that uses capsule/box sweeps against the physics world instead of directly wrapping Jolt CharacterVirtual. |
 | Ragdoll | Physics body/joint hierarchy bound to a skinned mesh skeleton. |
+| Ragdoll authoring asset | JSON file under `Models/RagdollEdits` storing edited ragdoll body, joint, frozen, and controlled-bone metadata. |
 | Cook | Process of building optimized physics collision data. |
 
 ## Navigation terms
@@ -89,9 +133,12 @@ This glossary captures engine terms used across the documentation.
 | Recast | Library used to build navigation meshes from source triangles. |
 | Detour | Library used to query built navigation meshes and paths. |
 | NavMesh | Recast/Detour navigation mesh used for pathfinding. |
+| `NavMeshGeometry` | Runtime build input containing source vertices/indices, off-mesh links, volume modifiers, area costs, and optional validators. |
+| `NavMeshBuildSettings` | Recast build and T850 traversal-link settings, including cell size, agent dimensions, query extents, and auto link options. |
 | Off-mesh link | Authored or generated traversal connection such as jump/drop/jump pad. |
 | Nav volume | Editor-authored helper volume used to include/exclude/area-mark/link-control NavMesh data. |
 | `.t8nav` | Baked NavMesh asset format using the engine’s serialized Detour data. |
+| `NavMeshDebugRenderer` | Line-renderer based debug view for navmesh geometry, nodes, graph edges, and off-mesh links. |
 
 ## Editor terms
 
@@ -102,3 +149,7 @@ This glossary captures engine terms used across the documentation.
 | Gizmo | Viewport transform control using ImGuizmo/editor line rendering. |
 | Play Scene | Editor workflow that exports a temporary `.t8scene` and runs it through SceneTemplate. |
 | Mesh Editor | Editor-hosted mesh editing/inspection window. |
+| Ragdoll Editor | Editor-hosted window for authoring and simulating ragdoll bodies, joints, controlled bones, and debug overlays. |
+| `EditorWorld` | Shared T8ditor authoring data model containing objects, cameras, lights, physics entities, selection, groups, undo, and loaded scene state. |
+| Hosted viewport | Editor-hosted render target and ImGui image/input rectangle used by Mesh Edit, Ragdoll Edit, and Play Scene windows. |
+| `UndoStack` | T8ditor command stack supporting undo/redo through transform commands and scene-state snapshots. |

--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -1,0 +1,85 @@
+# Glossary
+
+This glossary captures engine terms used across the documentation.
+
+## Core terms
+
+| Term | Meaning |
+|---|---|
+| Framework | Core engine library containing rendering, resources, physics, navigation, scene setup, utilities, and API backends. |
+| Scene | Runtime application/demo built on the Framework. Examples include DayScene, Quake3Mock, SandboxScene, RagdollEditor, and SceneTemplate. |
+| T8ditor | The editor executable used to author `.t8scene` files. |
+| `.t8scene` | JSON scene-authoring file saved by T8ditor and loaded by SceneTemplate. |
+| SceneTemplate | Runtime scene intended to load and play editor-authored `.t8scene` content. |
+| Dev layer | Developer/debug UI and runtime tooling layer exposed by scenes and editor code. |
+| Primitive | Engine render object abstraction. Common path: `PrimitiveInst` references a `PrimitiveBase` implementation such as `RenderMesh`. |
+| RenderGraph | Data-driven render pipeline loaded from JSON, with passes, render targets, inputs, draw commands, and state changes. |
+
+## Rendering terms
+
+| Term | Meaning |
+|---|---|
+| `RenderMesh` | Static mesh renderer for loaded geometry. Owns mesh draw setup and material/shader binding. |
+| `RenderSkinnedMesh` | Skinned mesh renderer extending mesh rendering with animation/bone upload support. |
+| `PrimitiveInst` | Per-instance transform/texture/key wrapper used to draw primitive render objects. |
+| `MeshAsset` | Shared geometry/material asset data cached by path. |
+| `MaterialAsset` | Deduplicated material parameters and texture references. |
+| `ShaderKey` | Bitfield describing shader permutation features and pass type. |
+| PSO | Pipeline State Object, especially relevant for D3D12/Vulkan where shader/state/topology combine into a pipeline. |
+| VB | Vertex Buffer. |
+| IB | Index Buffer. |
+| RT | Render Target. |
+| GBuffer | Deferred rendering target set containing surface properties, depth, etc. |
+| IBL | Image-based lighting resources. |
+
+## Geometry and asset terms
+
+| Term | Meaning |
+|---|---|
+| glTF / GLB | Modern mesh/scene asset format loaded by the glTF loader. |
+| `.x` | Legacy DirectX mesh format supported by the X loader. |
+| `XDataBase` | Internal mesh database format used as an intermediate after loading `.x` or converted glTF data. |
+| Subset | Material/draw subset inside a mesh geometry. |
+| Mesh pool | Shared GPU buffer allocation path for mesh VB/IB data. |
+
+## Animation terms
+
+| Term | Meaning |
+|---|---|
+| Skeleton | Bone hierarchy used by skinned meshes. |
+| Animation set / clip | Authored animation sequence. |
+| Bone texture | GPU texture path used to pass bone transforms to shaders for skinning. |
+| Snapshot pose | Captured pose data used for replay, ragdoll, or editor workflows. |
+
+## Physics terms
+
+| Term | Meaning |
+|---|---|
+| Jolt | Physics library integrated into the Framework. |
+| Static triangle mesh | Collision mesh generated from render geometry and used as static world collision. |
+| Character | Jolt character controller path. |
+| CharacterVirtual | Jolt virtual character controller path. |
+| Ragdoll | Physics body/joint hierarchy bound to a skinned mesh skeleton. |
+| Cook | Process of building optimized physics collision data. |
+
+## Navigation terms
+
+| Term | Meaning |
+|---|---|
+| Recast | Library used to build navigation meshes from source triangles. |
+| Detour | Library used to query built navigation meshes and paths. |
+| NavMesh | Recast/Detour navigation mesh used for pathfinding. |
+| Off-mesh link | Authored or generated traversal connection such as jump/drop/jump pad. |
+| Nav volume | Editor-authored helper volume used to include/exclude/area-mark/link-control NavMesh data. |
+| `.t8nav` | Baked NavMesh asset format using the engine’s serialized Detour data. |
+
+## Editor terms
+
+| Term | Meaning |
+|---|---|
+| Hierarchy | Editor panel listing scene objects, cameras, lights, navigation, splines, and volumes. |
+| Inspector / Properties | Editor panel for editing selected object data. |
+| Gizmo | Viewport transform control using ImGuizmo/editor line rendering. |
+| Play Scene | Editor workflow that exports a temporary `.t8scene` and runs it through SceneTemplate. |
+| Mesh Editor | Editor-hosted mesh editing/inspection window. |
+

--- a/documentation/input/camera-and-controls.md
+++ b/documentation/input/camera-and-controls.md
@@ -1,0 +1,506 @@
+# Camera and Controls
+
+Status: Stage 15 draft.
+
+This document explains T850's input state, platform input translation, gamepad and handheld paths, runtime camera profiles, editor camera routing, hosted window input behavior, and Android virtual controls.
+
+Related documents:
+
+- [Main architecture](../architecture/main-architecture.md)
+- [Platform event loop](../architecture/platform-event-loop.md)
+- [FrameworkImGui runtime UI](../editor/imgui-system.md)
+- [Dependency map](../dependency-map.md)
+- [Scene format and runtime](../scenes/scene-format-and-runtime.md)
+- [Editor overview](../editor/editor-overview.md)
+- [Jolt physics](../physics/jolt-physics.md)
+
+## Purpose and responsibilities
+
+Input and camera control are split into three layers:
+
+1. Platform code translates SDL or Android events into `AppBase::IManager`.
+2. Scene/editor code converts `InputManager` into intent such as `CameraInputState`, editor selection, UI navigation, or hosted scene input.
+3. `CameraController` applies the active camera profile to a `Camera`.
+
+```mermaid
+flowchart LR
+  Platform["Win32 / Linux / Android platform events"] --> Input["InputManager"]
+  Input --> App["AppBase / active scene / T8ditor"]
+  App --> CameraInput["CameraInputState"]
+  CameraInput --> Controller["CameraController"]
+  Controller --> Profile["active CameraProfile"]
+  Profile --> Camera["Camera"]
+  Input --> ImGui["ImGui / DevGuiContext"]
+  Input --> EditorTools["T8ditor selection, gizmos, hosted windows"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `Framework/include/utils/InputManager.h` | Shared keyboard, mouse, text, touch-cursor, and gamepad state. |
+| `Framework/src/utils/InputManager.cpp` | One-shot key/button helpers, gamepad activity detection, and press consumption. |
+| `Framework/src/core/windows/Win32Framework.cpp` | SDL3 keyboard/mouse/text/wheel/gamepad/touch events, Windows handheld detection, relative mouse mode. |
+| `Framework/src/core/LinuxFramework.cpp` | SDL3 keyboard/mouse/text/wheel/gamepad events, Steam Deck detection, Vulkan-only Linux loop. |
+| `Framework/src/core/android/AndroidFramework.cpp` | NativeActivity motion/key input, app-first Android event routing, touch-to-mouse fallback, pinch-to-scroll, back-key behavior. |
+| `Framework/include/utils/CameraProfiles.h` | `CameraProfileType`, `CameraInputState`, profile classes, and `CameraController`. |
+| `Framework/src/utils/CameraProfiles.cpp` | Runtime profile behavior, gamepad-to-camera mapping, collision fly, FPS controller updates. |
+| `Framework/include/physics/CharacterController.h` / `Framework/src/physics/CharacterController.cpp` | Kinematic FPS and Quake 3-style movement implementation used by camera profiles. |
+| `Framework/include/utils/HandheldControllerOverlay.h` | ImGui gamepad navigation submission and handheld footer/help overlay drawing. |
+| `DayScene/Application.cpp` | Runtime GUI visibility, relative mouse requests, handheld overlay drawing, Android input dispatch to scenes. |
+| `DayScene/SceneTemplate.cpp` | `CameraController` use, camera profile UI/F9 cycling, Android virtual controls, scene-state profile persistence. |
+| `DayScene/Quake3Mock.cpp` and `DayScene/SandboxScene.cpp` | Older scene variants with the same camera controller/input shape as SceneTemplate. |
+| `T8ditor/EditorCamera.*` | Editor orbit/pan/zoom camera for the main viewport. |
+| `T8ditor/EditorApp.cpp` | Editor input routing, orbit/free camera mode, hosted Play/Mesh scene input forwarding. |
+| `T8ditor/HostedViewportPanel.*` | Hosted viewport image rect and input-active tracking for Play Scene, Mesh Edit, and Ragdoll Edit windows. |
+
+## InputManager state model
+
+`InputManager` is owned by `AppBase` as `IManager`. Platform frameworks write into it once per frame; apps, scenes, editor tools, and ImGui integration read from it.
+
+Important fields:
+
+| Field | Meaning |
+|---|---|
+| `KeyStates[2][MAXKEYS]` | Current keyboard state plus one-shot latch state. |
+| `MouseButtonStates[2][MAXMOUSEBUTTONS]` | Current mouse button state plus one-shot latch state. SDL button 1 maps to index 0. |
+| `Gamepad` | Current normalized gamepad state and edge-triggered button presses. |
+| `xDelta`, `yDelta` | Mouse/look delta accumulated for the current frame. |
+| `mouseX`, `mouseY` | Window/client or viewport-local mouse coordinates, depending on caller routing. |
+| `scrollDelta` | Mouse wheel or pinch scroll amount for the current frame. |
+| `touchCursorVisible` | Set when touch events should make the cursor visible. |
+| `textInput` | UTF-8 text collected from SDL text input during the last frame. |
+
+Helper behavior:
+
+- `PressedKey(key)` and `PressedMouseButton(button)` read current state.
+- `PressedOnceKey(key)` and `PressedOnceMouseButton(button)` return true only once while held by setting the latch array.
+- Key/button release clears both current and one-shot latch state.
+- `HasGamepadInput()` returns true only when a connected/enabled gamepad has active sticks, triggers, buttons, shoulders, or d-pad input.
+- `ConsumeGamepadStartPress()` and `ConsumeGamepadEastPress()` clear the corresponding edge-trigger flag after use.
+
+The key enum is named `STDKEYS`. SDL3 ASCII keycodes map directly for values below 128; extended keys use `SDL3KeyToSTDKEY()`.
+
+## GamepadInputState
+
+`GamepadInputState` stores normalized state, not raw SDL values.
+
+| Group | Fields |
+|---|---|
+| Device | `connected`, `enabled`, `handheldDevice`, `name`, `handheldReason` |
+| Axes | `leftX`, `leftY`, `rightX`, `rightY` in `[-1, 1]` after deadzone |
+| Triggers | `leftTrigger`, `rightTrigger` in `[0, 1]` after deadzone |
+| Held buttons | south/east/west/north, back, guide, start, stick clicks, shoulders, d-pad |
+| Pressed edges | `*Pressed` variants computed from current vs previous frame |
+
+Button naming follows Xbox-style SDL gamepad layout:
+
+- south = A,
+- east = B,
+- west = X,
+- north = Y,
+- back = View,
+- start = Menu/Start.
+
+## Platform translation
+
+### Windows
+
+`Win32Framework` uses SDL3 for keyboard, mouse, text, wheel, window, and gamepad events. It also uses Win32 APIs for HWND lookup, cursor confinement, global cursor position, and registry-based handheld detection.
+
+```mermaid
+flowchart TD
+  SDL["SDL_PollEvent"] --> Keys["SDL_EVENT_KEY_* -> KeyStates"]
+  SDL --> MouseButtons["SDL_EVENT_MOUSE_BUTTON_* -> MouseButtonStates"]
+  SDL --> Wheel["SDL_EVENT_MOUSE_WHEEL -> scrollDelta"]
+  SDL --> Text["SDL_EVENT_TEXT_INPUT -> textInput"]
+  SDL --> Touch["finger/touch mouse events -> touchCursorVisible + cursor pos"]
+  SDL --> GamepadHotplug["GAMEPAD_ADDED/REMOVED"]
+  GamepadHotplug --> OpenClose["OpenGamepad / CloseGamepad"]
+  OpenClose --> Refresh["RefreshGamepadState"]
+  Refresh --> Input["InputManager.Gamepad"]
+```
+
+Important Windows behavior:
+
+- `SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD)` enables gamepads.
+- `DetectWindowsHandheldReason()` checks BIOS/board registry strings for ROG Ally, Legion Go, Steam Deck, MSI Claw, AYANEO, ONEXPLAYER, GPD, and AOKZOE-style devices.
+- `RefreshGamepadState()` normalizes axes with deadzones, triggers with trigger deadzones, and updates held/pressed flags.
+- Pressing gamepad View/Back requests app close in the framework.
+- Window focus/resize events reset mouse deltas and button state to avoid stale drags.
+- `UpdateMouseMode()` enables SDL relative mouse mode and hides the cursor when `AppBase::WantsRelativeMouseMode()` is true.
+- In relative mode, `xDelta`/`yDelta` come from `SDL_GetRelativeMouseState()`.
+- Outside relative mode, deltas are computed from absolute cursor movement.
+
+### Linux and Steam Deck
+
+`LinuxFramework` is Vulkan-only and uses SDL3 for the same key/mouse/text/wheel/gamepad event categories.
+
+Linux-specific behavior:
+
+- Steam Deck detection reads DMI product/board/vendor strings from `/sys/devices/virtual/dmi/id/*`.
+- `SDL_EVENT_MOUSE_MOTION` contributes `xrel`/`yrel` to `xDelta`/`yDelta`.
+- `SDL_GetMouseState()` refreshes `mouseX`/`mouseY` after the event loop.
+- Window resize/pixel-size events update the app dimensions, reset input, and resize the Vulkan swapchain.
+- Gamepad add/remove/open/refresh mirrors the Windows path.
+- Pressing gamepad View/Back is logged; app close behavior is not currently forced here.
+
+### Android
+
+`AndroidFramework` is Vulkan-only and receives native activity input events.
+
+Input routing is app-first:
+
+1. `AndroidFramework::OnInputEvent()` calls `AppBase::HandleAndroidInputEvent(event)`.
+2. If the app/scene handles a motion event, the framework clears generic touch state and stops.
+3. Otherwise the framework maps touch input to mouse-like state.
+4. Back key maps to Escape/close behavior unless the app consumed it.
+
+Generic Android touch fallback:
+
+- one finger down sets left mouse button and position;
+- one finger move updates `xDelta`/`yDelta`;
+- two fingers activate pinch mode;
+- pinch distance changes become `scrollDelta`;
+- pointer up/cancel clears touch state and left mouse button.
+
+`ResetTransientInput()` clears mouse delta and scroll after each rendered frame. `ClearTouchState()` also clears left mouse button state.
+
+## Runtime app and ImGui routing
+
+`DayScene/Application.cpp` owns runtime ImGui visibility and high-level input policy.
+
+Desktop runtime behavior:
+
+- `WantsRelativeMouseMode()` returns true when ImGui is ready, the runtime GUI is hidden, and no modal text/keyboard input is active.
+- Runtime GUI calls `SubmitRuntimeGamepadGuiInput()` before drawing panels.
+- When GUI is visible, `DrawHandheldGuiFooter()` draws controller hints.
+- `DrawHandheldControllerHelpOverlay()` draws the hold-RT mapping overlay whenever a gamepad is connected and enabled.
+
+Android runtime behavior:
+
+- Back closes the ImGui overlay first when the overlay is visible.
+- When ImGui is hidden, Android motion events are offered to the active scene's virtual controls.
+- If a scene did not handle the touch as virtual controls, the app can register a tap to reopen the Android GUI.
+- Android virtual controls are drawn by the active scene before ImGui draw data is rendered as a pre-present overlay.
+
+## Handheld controller overlay and ImGui navigation
+
+`HandheldControllerOverlay.h` is header-only and provides three groups of helpers:
+
+| Helper | Role |
+|---|---|
+| `SubmitGamepadGuiNavigation(gamepad, guiVisible)` | Submits full ImGui gamepad key/analog events: start/back/face buttons/triggers/sticks/d-pad. |
+| `SubmitGamepadGuiDirectionalNavigation(gamepad, guiVisible)` | Submits a smaller navigation set: A, d-pad, and left-stick direction. |
+| `DrawHandheldControllerHelpOverlay(gamepad)` | Draws a centered controller mapping overlay while RT is held. |
+| `DrawHandheldGuiFooter(gamepad)` | Draws footer hints while runtime GUI is visible. |
+
+Both submit helpers set `ImGuiConfigFlags_NavEnableGamepad`. They set or clear `ImGuiBackendFlags_HasGamepad` based on whether the gamepad is connected and enabled. They only submit active input when `guiVisible` is true.
+
+## Camera input state
+
+Scenes and editor free-fly mode convert `InputManager` into `CameraInputState`.
+
+| Field group | Meaning |
+|---|---|
+| Movement booleans | `moveForward`, `moveBackward`, `moveLeft`, `moveRight`, `moveUp`, `moveDown` |
+| Movement analogs | `moveForwardAmount`, `moveRightAmount` |
+| Character actions | `jump`, `crouch`, `sprint` |
+| Look/orbit modes | `mouseLook`, `orbitRotate`, `orbitPan`, `orbitZoom` |
+| Deltas | `mouseDeltaX`, `mouseDeltaY`, `scrollDelta` |
+
+`ApplyGamepadToCameraInput()` maps gamepad state into this structure:
+
+- left stick controls forward/right movement;
+- A/south sets `jump`;
+- B/east sets `crouch`;
+- left stick click sets `sprint`;
+- right stick becomes look deltas when look is allowed.
+
+The right-stick look mapping is expressed as mouse-like deltas scaled by frame time, so existing mouse look paths are reused.
+
+## CameraController and profiles
+
+`CameraController` owns one instance of each profile and applies the active profile to an attached `Camera`.
+
+```mermaid
+classDiagram
+  class CameraController {
+    +AttachCamera(Camera*)
+    +SetActiveProfile(CameraProfileType)
+    +HandleInput(CameraInputState)
+    +Update(deltaSeconds, CameraUpdateContext)
+  }
+  class CameraProfile {
+    +OnActivated(Camera)
+    +HandleInput(CameraInputState)
+    +Update(Camera, deltaSeconds, context)
+  }
+  class OrbitCameraProfile
+  class FreeFlyCameraProfile
+  class CollidingFlyCameraProfile
+  class KinematicFpsCameraProfile
+  class GroundedFpsCameraProfile
+  class CodFpsCameraProfile
+  class Quake3FpsCameraProfile
+
+  CameraController --> CameraProfile
+  CameraProfile <|-- OrbitCameraProfile
+  CameraProfile <|-- FreeFlyCameraProfile
+  FreeFlyCameraProfile <|-- CollidingFlyCameraProfile
+  CameraProfile <|-- KinematicFpsCameraProfile
+  KinematicFpsCameraProfile <|-- GroundedFpsCameraProfile
+  KinematicFpsCameraProfile <|-- CodFpsCameraProfile
+  KinematicFpsCameraProfile <|-- Quake3FpsCameraProfile
+```
+
+Available profile names:
+
+| Type | Name | Behavior |
+|---|---|---|
+| `Orbit` | `Orbit` | Spherical camera around a target with pan, zoom, yaw, pitch, distance, and model radius. |
+| `FreeFly` | `Free Fly` | Mouse-look camera with free XYZ movement. |
+| `CollidingFly` | `Colliding Fly` | Free-fly movement clipped by capsule sweeps against `CameraCollisionWorld`. |
+| `GroundedFps` | `Grounded FPS` | Kinematic character FPS movement with default T850 settings. |
+| `CodFps` | `COD FPS` | Kinematic FPS tuned for faster grounded movement, higher acceleration, stronger friction, and lower jump speed. |
+| `Quake3Fps` | `Quake 3 FPS` | Quake 3-style kinematic movement using box collision and Quake-scaled speed/gravity/jump values. |
+
+## Profile behavior details
+
+### Orbit
+
+`OrbitCameraProfile` stores `OrbitCameraState`:
+
+- `target`,
+- `panOffset`,
+- `yaw`,
+- `pitch`,
+- `distance`,
+- `modelRadius`.
+
+Runtime input conventions from `SceneTemplate::BuildCameraInputState()`:
+
+- left mouse drag rotates;
+- middle mouse drag pans;
+- right mouse drag zooms by vertical mouse delta;
+- scroll wheel zooms;
+- F9 can cycle out of Orbit to another profile.
+
+T8ditor's main `EditorCamera` has a separate orbit implementation and different editor-oriented conventions:
+
+- middle drag pans;
+- right drag or Alt+left drag orbits;
+- wheel and `+`/`-` zoom;
+- arrow keys orbit;
+- `F` frames the target.
+
+### Free Fly and Colliding Fly
+
+`FreeFlyCameraProfile` applies mouse look, then moves along camera look/right/up:
+
+- W/S and analog forward control forward/back;
+- A/D and analog right control strafe;
+- Q/E control up/down;
+- Shift/left stick click selects sprint speed;
+- default walk/sprint speeds are 10/20.
+
+`CollidingFlyCameraProfile` reuses free fly but enables capsule sliding through `CameraUpdateContext::collisionWorld`; its walk/sprint speeds are 8/16 and capsule radius/half-height are 0.35/0.55.
+
+### Grounded FPS, COD FPS, and Quake 3 FPS
+
+`KinematicFpsCameraProfile` wraps `KinematicCharacterController`.
+
+Shared behavior:
+
+- mouse look updates camera yaw/pitch;
+- input is flattened onto camera forward/right vectors;
+- collision uses `CharacterCollisionWorld` sweeps when supplied;
+- no collision world means movement is allowed and the controller treats itself as grounded.
+
+`GroundedFpsCameraProfile` uses default `KinematicCharacterSettings`:
+
+- capsule collision,
+- walk speed 8,
+- sprint speed 10,
+- gravity 18,
+- jump speed 5,
+- eye height 1.6.
+
+`CodFpsCameraProfile` customizes the defaults:
+
+- walk speed 7,
+- sprint speed 11,
+- ground acceleration 45,
+- air acceleration 1.5,
+- friction 12,
+- stop speed 2.5,
+- jump speed 4.3,
+- gravity 20.
+
+`Quake3FpsCameraProfile` uses `MakeQuake3CharacterSettings()`:
+
+- box collision,
+- Quake units scaled by `1 / 32`,
+- walk speed 320 Quake units,
+- gravity 800 Quake units,
+- jump speed 270 Quake units,
+- no sprint,
+- Quake-style update path through `UpdateQuake3()`.
+
+## SceneTemplate runtime flow
+
+`SceneTemplate` is the long-term runtime target for editor-authored `.t8scene` files and is the cleanest current camera-profile integration point.
+
+Initialization:
+
+1. `m_cameraController.AttachCamera(&Cam)`.
+2. Default profile selection is Orbit.
+3. Android virtual controls are reset.
+4. Orbit state is synced from legacy sandbox orbit variables.
+5. `SetCameraProfile(Orbit)` activates the profile.
+
+Scene-load behavior:
+
+- If the loaded scene has authored cameras, SceneTemplate applies the selected camera pose.
+- If no scene camera is available in the Quake/SceneTemplate fallback path, it switches to `Quake3Fps`.
+- Runtime profile settings can be overridden from scene profile/player settings before `SetCameraProfile(profileType)`.
+
+Update/input behavior:
+
+```mermaid
+flowchart TD
+  OnInput["SceneTemplate::OnInput"] --> F9["F9 cycles CameraProfileType"]
+  OnInput --> Build["BuildCameraInputState"]
+  Build --> ControllerInput["CameraController::HandleInput"]
+  OnUpdate["OnUpdate"] --> OrbitSyncIn["sync orbit legacy state into profile when active"]
+  OrbitSyncIn --> Update["CameraController::Update"]
+  Update --> Collision["CameraUpdateContext.collisionWorld = SceneTemplate"]
+  Update --> OrbitSyncOut["sync profile orbit state back to legacy fields"]
+```
+
+`BuildCameraInputState()` maps:
+
+- W/S/A/D to move,
+- Q/E to vertical move for fly profiles,
+- Space to jump,
+- Ctrl to crouch,
+- Shift to sprint,
+- mouse deltas and scroll,
+- ImGui mouse capture gates,
+- gamepad through `ApplyGamepadToCameraInput()`,
+- Android virtual sticks/buttons when visible.
+
+Profile selection is exposed in the runtime dev GUI through a `SelectorDesc` named `camera_profile`, and the UI text explicitly says F9 cycles profiles.
+
+SceneTemplate saves the active camera profile index into sandbox save state as `SandboxCameraDesc::profile`, along with camera pose and orbit state. `.t8scene` camera entries (`SceneCameraDesc`) currently store camera pose/projection data, not a camera profile field.
+
+## Quake3Mock and SandboxScene
+
+`Quake3Mock` and `SandboxScene` still carry older copies of the same camera-profile pattern:
+
+- default Orbit setup;
+- Quake/default model paths can switch to `Quake3Fps` or `FreeFly`;
+- F9 profile cycling;
+- dev-GUI camera profile selector;
+- `BuildCameraInputState()` mapping similar to SceneTemplate;
+- save-state persistence of active profile/pose/orbit state.
+
+When changing camera profile behavior, update SceneTemplate first and audit these older scene variants for duplicated logic.
+
+## Android virtual controls
+
+Runtime scene virtual controls are implemented in SceneTemplate, SandboxScene, Quake3Mock, DayScene, and RagdollEditor variants.
+
+SceneTemplate behavior:
+
+- controls are visible only when an active camera exists and the active profile is not Orbit;
+- motion events are handled only when runtime ImGui is hidden;
+- a left virtual stick drives `m_androidMoveAxis`;
+- a right virtual stick drives `m_androidLookAxis`;
+- `JMP` drives jump, or upward movement for fly profiles;
+- `RUN` drives sprint;
+- controls draw as foreground ImGui circles over the rendered scene.
+
+The Android app dispatch path calls the active scene's `HandleAndroidVirtualControls()` before generic framework touch handling. This prevents scene-control touches from also becoming mouse drags.
+
+## T8ditor main viewport input
+
+T8ditor has two main camera modes selected from the toolbar:
+
+| Mode | Implementation | Behavior |
+|---|---|---|
+| Orbit | `EditorCamera` and active camera orbit helpers | Main authoring camera, framing, object selection, gizmos, active scene-camera orbit. |
+| Free | `m_editorCameraController` forced to `FreeFly` | WASD/QE/Shift movement plus right-mouse look; can control the editor camera or selected authored camera/light camera. |
+
+`EditorApp::OnInput()` reads ImGui capture flags first:
+
+- `io.WantCaptureMouse` gates mouse orbit/pick/look;
+- `io.WantCaptureKeyboard` gates toolbar camera hotkeys and selection input;
+- `io.WantTextInput` gates text-sensitive shortcuts and free-fly movement.
+
+Undo/redo shortcuts are still allowed after hierarchy selection as long as text input is not active. Delete works while panels have focus, but not while text input is active.
+
+In free mode, the editor forces `m_editorCameraController` to `FreeFly`, attaches either the editor camera or the active authored camera/light camera, applies input, then syncs the authored camera/light camera back from the runtime camera.
+
+## Hosted window routing
+
+T8ditor hosted windows are modal from the application perspective:
+
+- `IsModalActive()` returns true while Mesh Edit, Play Scene, or Ragdoll Edit is open/closing.
+- Escape closes the active hosted window and clears mouse deltas.
+- `WantsRelativeMouseMode()` returns true only for loaded Play Scene when its GUI is hidden.
+
+`HostedRenderViewport` records the ImGui image rect and whether the viewport image is active. This is used to distinguish scene viewport input from panel input.
+
+| Hosted window | Input behavior |
+|---|---|
+| Play Scene | Press `G` to show/hide runtime controls. When loaded, editor remaps mouse coordinates into the Play Scene viewport and calls `m_playScene->OnInput(&IManager)`. It sets `SetIgnoreImGuiMouseCaptureForInput()` when the mouse is over or actively interacting with the viewport. |
+| Mesh Edit | Press `G` to show/hide controls. The editor remaps mouse coordinates into the Mesh Edit viewport and calls `m_meshEditorScene->OnInput(&IManager)`. |
+| Ragdoll Edit | Modal hosted tool window. The viewport tracks active/hovered state through `HostedRenderViewport::InputActive()`, then the panel uses ImGui/tool interactions for ragdoll body/joint/bone editing rather than forwarding a whole runtime scene `OnInput()` path. |
+
+This split matters because Play Scene and Mesh Edit host runtime scene controllers, while Ragdoll Edit is an editor tool surface with its own manipulation code.
+
+## Extension rules
+
+When adding a new platform input path:
+
+1. Write only normalized state into `InputManager`.
+2. Clear one-shot latch state on release.
+3. Reset deltas/buttons on focus loss, resize, pause, or surface loss.
+4. Keep text input separate from key state.
+5. Preserve ImGui capture gates in app/editor code instead of hiding raw state from `InputManager`.
+
+When adding a new camera profile:
+
+1. Add the enum value before `Count`.
+2. Update `CameraProfileName()`, `CameraProfileNames()`, and `CameraController` construction.
+3. Define activation/reset behavior in `OnActivated()`.
+4. Decide whether it needs `CameraUpdateContext::collisionWorld`.
+5. Update SceneTemplate, duplicated scene variants, dev-GUI selectors, save-state profile handling, and this document.
+
+When adding a hosted editor viewport:
+
+1. Store the image rect through `HostedRenderViewport`.
+2. Convert global/main viewport mouse coordinates to local scene coordinates before forwarding.
+3. Set an explicit ImGui-capture override only when the mouse is over or actively dragging the scene viewport.
+4. Clear input deltas when toggling GUI visibility or closing.
+
+## Known limitations and gotchas
+
+- SceneTemplate, SandboxScene, and Quake3Mock still duplicate substantial camera input/profile code.
+- `.t8scene` camera descriptors do not directly store camera profile type; profile persistence currently lives in sandbox/runtime save state.
+- Android virtual controls are per-scene duplicated and only appear for non-Orbit profiles.
+- Windows uses relative mouse mode for runtime/play-scene style capture; Linux currently uses SDL motion deltas without the same app-level relative-mode branch.
+- T8ditor has both `EditorCamera` orbit controls and Framework `CameraController` free-fly controls; changes to one do not automatically affect the other.
+- Gamepad GUI navigation is submitted only by call sites that explicitly invoke the handheld helpers.
+
+## Debugging checklist
+
+1. If a key shortcut fires repeatedly, check whether the release path clears both `KeyStates[0]` and `KeyStates[1]`.
+2. If mouse look jumps after resize/focus change, check `ResetInputAfterWindowStateChange()` or `ResetMouseDeltaBaseline()`.
+3. If desktop runtime mouse look does not work, check `WantsRelativeMouseMode()` and whether the runtime GUI is visible.
+4. If gamepad input is ignored, check `Gamepad.connected`, `Gamepad.enabled`, deadzone thresholds, and whether a gamepad was opened by SDL.
+5. If handheld hints do not appear, check `DrawHandheldControllerHelpOverlay()` and `Gamepad.rightTrigger`.
+6. If Android touch controls also move the mouse/camera, verify the app consumed the scene virtual-control event before framework fallback handling.
+7. If a camera profile does not collide, confirm `CameraUpdateContext.collisionWorld` is supplied and the scene implements the sweep functions.
+8. If hosted Play Scene/Mesh Edit input uses wrong coordinates, inspect `HostedRenderViewport` image rect and local coordinate conversion.

--- a/documentation/navigation/navmesh-detour.md
+++ b/documentation/navigation/navmesh-detour.md
@@ -1,0 +1,8 @@
+# NavMesh and Detour
+
+Status: planned.
+
+This document will cover Recast/Detour integration, source geometry, NavMesh volumes, area costs, links, `.t8nav`, and editor/runtime workflows.
+
+See [stage-plan.md](../stage-plan.md#stage-8--navmesh-and-detour).
+

--- a/documentation/navigation/navmesh-detour.md
+++ b/documentation/navigation/navmesh-detour.md
@@ -1,8 +1,457 @@
 # NavMesh and Detour
 
-Status: planned.
+Status: Stage 8 draft.
 
-This document will cover Recast/Detour integration, source geometry, NavMesh volumes, area costs, links, `.t8nav`, and editor/runtime workflows.
+This document explains T850's navigation system: Recast build, Detour queries, navigation source geometry, authored volumes and links, area costs, automatic drop/jump links, `.t8nav` cache and baked assets, runtime SceneTemplate integration, editor authoring workflows, debug rendering, physics validation, limitations, and debugging.
 
-See [stage-plan.md](../stage-plan.md#stage-8--navmesh-and-detour).
+Related documents:
 
+- [Loading geometry](../geometry/loading-geometry.md)
+- [Resource locator and cache paths](../architecture/resource-locator.md)
+- [Dependency map](../dependency-map.md)
+- [Render graph](../rendering/render-graph.md)
+- [Jolt physics](../physics/jolt-physics.md)
+- [Scene format and runtime](../scenes/scene-format-and-runtime.md)
+
+## Purpose and responsibilities
+
+Navigation builds a Detour queryable mesh from scene geometry and authoring metadata. Runtime and editor systems use it to project points, find paths, inspect source triangle classification, draw debug overlays, generate or author traversal links, and save baked assets.
+
+```mermaid
+flowchart LR
+  Sources["RenderMesh / XDataBase sources"] --> Geometry["NavMeshGeometry"]
+  SceneMeta[".t8scene navigation_mesh"] --> Geometry
+  Geometry --> Recast["Recast build pipeline"]
+  Recast --> DetourData["Detour navmesh data"]
+  DetourData --> Query["dtNavMeshQuery"]
+  Query --> Runtime["ProjectPoint / FindPath / agents"]
+  Query --> Debug["NavMeshDebugRenderer"]
+  DetourData --> Cache[".t8nav cache or baked asset"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `Framework/include/navigation/NavigationSystem.h` | Public navigation API: build settings, source geometry, volume modifiers, links, `NavMesh`, `NavigationWorld`, classification helpers. |
+| `Framework/src/navigation/NavigationSystem.cpp` | Recast build, Detour initialization/query, cache/bake load/save, geometry extraction, volumes, off-mesh link generation. |
+| `Framework/include/navigation/NavigationDebugRenderer.h` | Debug renderer API and shape modes. |
+| `Framework/src/navigation/NavigationDebugRenderer.cpp` | Builds line buffers for navmesh geometry, nodes, graph edges, and off-mesh links. |
+| `Framework/include/scene/EditorSceneFile.h` | `.t8scene` navigation schema: build settings, volumes, authored links, runtime mode, baked asset. |
+| `DayScene/SceneTemplate.cpp` | Runtime scene load/build/cache/baked NavMesh flow, physics validation, test agents, debug overlay. |
+| `T8ditor/EditorApp.cpp` | Editor NavMesh authoring state, build/regenerate, triangle classification, volumes/links, bake asset UI. |
+| `T8ditor/PlayScenePanel.cpp` | Regenerates stale authored NavMesh before exporting Play Scene. |
+| `Framework/src/physics/PhysicsAuthoring.cpp` | `ValidateNavOffMeshLinkWithPhysics()` for Jolt-backed link validation. |
+
+## Build availability
+
+Navigation has compile-time Recast support behind `T850_ENABLE_RECAST`.
+
+When Recast is unavailable:
+
+- `ValidateNavigationBackend()` reports unavailable backend state.
+- `NavMesh::Build()`, `LoadBaked()`, `FindPath()`, and classification return errors.
+
+`NavigationBackendInfo` exposes whether Recast, Detour, DetourCrowd, and DetourTileCache are available. The current runtime path uses Detour navmesh/query directly; crowd and tile cache are detected but not the active scene path.
+
+## Data model
+
+`NavMeshGeometry` is the build input:
+
+| Field | Meaning |
+|---|---|
+| `vertices` | World-space source vertices. |
+| `indices` | Triangle-list indices. |
+| `offMeshLinks` | Explicit authored links. |
+| `volumeModifiers` | Include/exclude/area/link modifiers. |
+| `areaCosts` | Per-area traversal costs. |
+| `offMeshLinkValidator` | Optional validator for explicit/automatic links. |
+| `offMeshHybridLinkValidator` | Optional validator for hybrid jump-intent links. |
+
+`NavMeshBuildSettings` contains Recast settings and T850 traversal-link generation settings:
+
+- cell size/height,
+- agent height/radius/climb/slope,
+- region and contour simplification settings,
+- detail mesh settings,
+- query extents,
+- auto drop/jump/hybrid link settings,
+- off-mesh validation key used in cache hashing.
+
+`NavMeshBuildStats` records source and build output counts:
+
+- vertex/triangle count,
+- Recast grid width/height,
+- polygon/detail triangle count,
+- off-mesh/drop/jump/jump-pad link counts.
+
+## Source geometry extraction
+
+Navigation geometry is extracted from render meshes through `XDataBase`.
+
+```mermaid
+flowchart TD
+  Source["NavSourceInstance"] --> Checks["include/static/visible/skinned checks"]
+  Checks --> XDB["RenderMesh::xFile / XDataBase"]
+  XDB --> Final["xFinalGeometry positions"]
+  XDB --> Indices["xMeshGeometry Triangles/Triangles32"]
+  Final --> Transform["Apply world transform"]
+  Indices --> Append["Append to NavMeshGeometry"]
+```
+
+`AppendGeometryFromXDataBase()`:
+
+- reads interleaved position data from `xFinalGeometry::pData`,
+- applies the supplied world transform,
+- handles both 16-bit and 32-bit triangle arrays,
+- appends vertices and triangle indices to `NavMeshGeometry`.
+
+`BuildGeometryFromNavSources()` supports either direct `XDataBase` pointers or `PrimitiveInst` instances. It skips:
+
+- sources with `includeInNavigation == false`,
+- non-static sources,
+- missing primitives,
+- skinned meshes,
+- invalid meshes/databases.
+
+It reports `NavSourceBuildStats` with considered/included/skipped counts.
+
+SceneTemplate builds `NavSourceInstance` entries from scene meshes and per-object navigation metadata:
+
+- `include`,
+- `static_object`,
+- `walkable`,
+- area mapping.
+
+Explicitly included but hidden objects are treated as visible for navigation source purposes.
+
+## `.t8scene` navigation schema
+
+Navigation metadata lives in `SceneNavigationMeshDesc` under top-level `navigation_mesh`.
+
+Important fields:
+
+| Field | Meaning |
+|---|---|
+| `enabled` | Whether the scene has authored navigation. |
+| `visible`, `frozen`, `show_wire` | Editor/runtime UI state. |
+| `debug_offset` | Vertical offset for debug wireframe. |
+| `debug_shape_mode` | Geometry or node debug view. |
+| `runtime_mode` | `build_cached`, `build`, or `baked_asset`. |
+| `baked_asset` | Path to a baked `.t8nav` asset. |
+| `build_settings` | Recast/Detour build settings. |
+| `volumes` | Include/exclude/area/link modifier volumes. |
+| `authored_links` | Explicit off-mesh links. |
+
+Per-object `SceneObjectNavigationDesc` controls whether each mesh contributes to navigation:
+
+- `include`,
+- `walkable`,
+- `static_object`,
+- `area`,
+- `cost`.
+
+## Volume modifiers
+
+`SceneNavMeshVolumeDesc` maps to `NavMeshVolumeModifier`.
+
+Supported volume types:
+
+| Scene type | Runtime mode | Effect |
+|---|---|---|
+| `include_bounds` | `Include` | If any include volume exists, triangles must be inside an include volume to be considered. |
+| `exclude` | `Exclude` | Triangles whose centroid is inside are removed. |
+| `area_cost` | `Area` | Triangles inside receive an area id and cost. |
+| `link_include` | `LinkInclude` | Automatic/off-mesh links must touch a link include volume unless they are explicit links. |
+| `link_exclude` | `LinkExclude` | Links touching the volume are removed. |
+
+Volume tests use oriented boxes. The triangle test uses triangle centroid after Recast slope classification.
+
+Important behavior:
+
+- Slope-excluded triangles remain excluded, even if inside an area volume.
+- Classification overlay can show volume effects on slope-excluded triangles for debugging.
+- Area costs update Detour query filter area costs.
+- Link include/exclude volumes apply to generated and explicit normalized link lists, with explicit links exempt from link-include gating.
+
+## Triangle classification and editor paint workflow
+
+`ClassifyNavMeshTriangles()` is an editor/source preview helper.
+
+It:
+
+1. Validates geometry/settings.
+2. Runs `rcMarkWalkableTriangles()`.
+3. Applies volume modifiers with reason tracking.
+4. Emits one `NavTriangleClassification` per source triangle.
+
+Classification reasons:
+
+- included,
+- excluded by slope,
+- outside include volume,
+- excluded by volume,
+- invalid geometry.
+
+T8ditor uses this for:
+
+- source preview overlay colors,
+- picking source triangles from the mouse ray,
+- multi-select/brush triangle selection,
+- creating merged exclude/area/link include/link exclude volumes from selected triangles.
+
+## Recast build pipeline
+
+`NavMesh::BuildCached()` runs the Recast pipeline when no cache/baked asset is loaded.
+
+```mermaid
+flowchart TD
+  Geometry["NavMeshGeometry"] --> Config["rcConfig from NavMeshBuildSettings"]
+  Config --> Heightfield["rcCreateHeightfield"]
+  Heightfield --> Mark["rcMarkWalkableTriangles"]
+  Mark --> Volumes["ApplyNavVolumeModifiers"]
+  Volumes --> Raster["rcRasterizeTriangles"]
+  Raster --> Filters["low-hanging / ledge / low-height filters"]
+  Filters --> Compact["rcBuildCompactHeightfield"]
+  Compact --> Erode["rcErodeWalkableArea"]
+  Erode --> Distance["rcBuildDistanceField"]
+  Distance --> Regions["rcBuildRegions"]
+  Regions --> Contours["rcBuildContours"]
+  Contours --> Poly["rcBuildPolyMesh"]
+  Poly --> Detail["rcBuildPolyMeshDetail"]
+  Detail --> Detour["dtCreateNavMeshData"]
+```
+
+The build maps settings to `rcConfig`:
+
+- `cs`, `ch`,
+- walkable slope/height/climb/radius,
+- edge length/error,
+- region min/merge areas,
+- vertices per poly,
+- detail sample settings.
+
+After `rcBuildPolyMesh`, polygons get walk flags by default. Area ids are derived from volume modifiers, and Detour area costs are stored in the `NavMesh` implementation.
+
+## Off-mesh links
+
+T850 supports explicit and generated off-mesh links.
+
+Traversal types:
+
+- `Walk`,
+- `Drop`,
+- `Jump`,
+- `JumpPad`,
+- `JumpIntent`.
+
+Explicit links come from `.t8scene` `authored_links` and are normalized:
+
+- endpoints are projected onto the current Detour mesh,
+- invalid or zero-length links are skipped,
+- duplicate links are removed,
+- user ids encode traversal type.
+
+Automatic links:
+
+- drop links are generated from open polygon edges to lower reachable polygons,
+- jump links are generated between separated reachable polygons,
+- hybrid jump links can fall back to `JumpIntent` when validation rejects a full jump,
+- counts are capped to avoid runaway link generation.
+
+Generated and explicit links are passed to Detour through:
+
+- `offMeshConVerts`,
+- `offMeshConRad`,
+- `offMeshConFlags`,
+- `offMeshConAreas`,
+- `offMeshConDir`,
+- `offMeshConUserID`.
+
+Detour user ids encode the T850 traversal type. Path results decode off-mesh refs into `NavPathResult::Segment` traversal metadata.
+
+## Physics validation for links
+
+When Jolt physics is initialized, SceneTemplate and T8ditor install an off-mesh link validator:
+
+```text
+ValidateNavOffMeshLinkWithPhysics(physics, settings, link)
+```
+
+This validation is used for drop, jump, and jump-intent links. It checks against live physics debug bodies and uses capsule casts to reject links that collide with static triangle mesh bodies. The validation key is XOR'd into the build cache key so cached navmeshes differ depending on whether physics-backed validation was active.
+
+## Detour query path
+
+`NavMesh` owns:
+
+- `dtNavMesh`,
+- `dtNavMeshQuery`,
+- serialized nav data bytes,
+- area costs,
+- build settings and stats.
+
+`ProjectPoint()`:
+
+- validates readiness and finite point,
+- uses `findNearestPoly()`,
+- uses a walk-only filter,
+- returns nearest point.
+
+`FindPath(start, end)`:
+
+- projects start/end to nearest polys,
+- calls `findPath()`,
+- calls `findStraightPath()`,
+- returns straight path points.
+
+`FindPath(NavPathRequest)`:
+
+- uses traversal filter with all walk/drop/jump/jump-pad/jump-intent flags,
+- applies area costs,
+- returns points plus segment traversal types.
+
+`FindPaths()` batches multiple requests and records runtime telemetry counters.
+When available, the implementation can fan batch requests out through the global thread pool and create a per-request Detour query object so path requests do not share mutable query state.
+
+## Cache and baked assets
+
+There are two `.t8nav` workflows:
+
+| Workflow | Path | Meaning |
+|---|---|---|
+| Build cache | `Navigation/.t8cache/navmesh_<key>.t8nav` | Generated cache for `build_cached` runtime mode. |
+| Baked asset | User path, usually `Navigation/<scene>.t8nav` | Explicit saved asset referenced by `.t8scene`. |
+
+Cache key includes:
+
+- cache version,
+- build settings,
+- geometry vertices/indices,
+- off-mesh links,
+- volume modifiers,
+- area costs,
+- scene/object file signatures in SceneTemplate,
+- link validation key.
+
+`runtime_mode`:
+
+- `build_cached`: load generated cache if available; otherwise build and save cache.
+- `build`: always build, no cache key.
+- `baked_asset`: try `LoadBaked()` first; fall back to cached build if loading fails.
+
+The cache file header uses magic `T8NAVCHE` and cache version `5`, then stores build stats and raw Detour navmesh data. `LoadNavMeshCache()` reconstructs `dtNavMesh` and `dtNavMeshQuery` from that payload.
+
+T8ditor UI supports:
+
+- selecting runtime mode,
+- suggesting a baked asset path,
+- showing baked asset status,
+- `Bake NavMesh Asset`,
+- `Bake + Save Scene`.
+
+## Runtime SceneTemplate flow
+
+`SceneTemplate::EnsureNavMeshBuilt()`:
+
+1. Returns if navmesh is already ready.
+2. Skips if the scene has no authored navigation.
+3. Creates a cache key from scene path, source meshes, transforms, settings, links, volumes, and physics validation.
+4. Handles baked asset mode.
+5. Handles generated cache mode.
+6. Extracts navigation sources from loaded meshes.
+7. Attaches Jolt-backed link validators when available.
+8. Adds authored volumes and authored links to geometry.
+9. Builds navmesh.
+10. Invalidates debug renderer and logs stats.
+
+Runtime debug drawing uses `NavMeshDebugRenderer` when `showNavMesh` is enabled and `EnsureNavMeshBuilt()` succeeds.
+
+## Editor authoring workflow
+
+T8ditor stores editor NavMesh state on `EditorApp`:
+
+- `m_editorNavMesh`,
+- `m_editorNavMeshBuildSettings`,
+- `m_editorNavMeshVolumes`,
+- `m_editorNavMeshLinks`,
+- classification result and selected triangles,
+- selected volume/link/node,
+- runtime mode and baked asset path.
+
+Main editor operations:
+
+- create/regenerate navmesh from current scene objects,
+- destroy navmesh,
+- mark dirty when authoring changes,
+- restore from `.t8scene`,
+- build `.t8scene` descriptor,
+- classify source triangles,
+- pick triangles/nodes from mouse,
+- create volumes from selected triangles,
+- draw classification overlay,
+- draw selected link overlay,
+- bake `.t8nav` assets.
+
+The editor can also dump human-readable NavMesh wire/debug geometry to `Logs/navmesh_wire_*.txt`, and authored link tools can pick/snap start and end points from viewport Detour node positions.
+
+NavMesh authoring is also integrated with Play Scene: if the authored navmesh is dirty, Play Scene attempts to regenerate it before exporting the temporary scene.
+
+## Debug rendering
+
+`NavMeshDebugRenderer` draws:
+
+- mesh geometry wireframe,
+- node markers,
+- graph edges,
+- drop links,
+- jump links,
+- jump-pad links.
+
+It supports:
+
+- geometry or node shape mode,
+- vertical offsets for mesh and graph overlays,
+- auxiliary geometry toggle,
+- depth textures for overlay depth testing.
+
+It caches uploaded line buffers until navmesh stats, offsets, shape mode, or auxiliary geometry settings change.
+
+## Extension points
+
+To extend navigation:
+
+1. Add new scene metadata to `EditorSceneFile.h`.
+2. Map it in SceneTemplate and T8ditor conversion helpers.
+3. Add new modifier/link behavior in `NavigationSystem.cpp`.
+4. Include new settings in cache hashing.
+5. Update editor classification/overlay colors if authoring should be visible.
+6. Update baked asset version/cache version when serialized `.t8nav` compatibility changes.
+7. If using physics validation, include validation-affecting data in `offMeshLinkValidationKey`.
+
+## Known limitations and gotchas
+
+- Recast/Detour must be enabled at build time.
+- Build execution is whole-mesh, not tiled streaming.
+- DetourCrowd and DetourTileCache are detected but not the active runtime agent system.
+- Skinned meshes are skipped as navigation sources.
+- If any include volume exists, triangles outside include volumes are removed.
+- Triangle volume modifiers use centroid tests, not triangle-volume intersection.
+- Auto links depend on generated polygon boundaries and projection queries; small setting changes can change link counts.
+- Physics validation only affects drop/jump/jump-intent links when Jolt is initialized and static triangle bodies exist.
+- `build_cached` can return stale-looking results if cache key inputs are missing a new authoring field; update hashing when extending schema.
+- `baked_asset` falls back to cached build if load fails.
+
+## Debugging checklist
+
+1. Confirm `ValidateNavigationBackend()` reports Recast and Detour available.
+2. Check source stats: considered, included, skipped invisible, skipped skinned, skipped invalid.
+3. Use classification overlay to see included/excluded/slope/volume buckets before building.
+4. Check `NavMeshBuildStats` for zero polygons or unexpected off-mesh link counts.
+5. Verify object navigation metadata: include/static/walkable flags.
+6. Verify include volumes are not unintentionally excluding everything.
+7. Check authored link endpoints project onto different polygons.
+8. Check Jolt physics is initialized if link validation is expected.
+9. For baked mode, verify the `.t8nav` path exists and loads; otherwise SceneTemplate will fall back.
+10. Use `GetDebugWireframe`, graph edges, off-mesh link overlays, and `Logs/navmesh_wire_*.txt` dumps to inspect runtime output.
+11. If path projection succeeds but traversal ignores links, remember `ProjectPoint()` uses a walk-only filter while `FindPath()` uses the full traversal filter.
+12. If Play Scene export fails, resolve stale NavMesh regeneration first.

--- a/documentation/physics/jolt-physics.md
+++ b/documentation/physics/jolt-physics.md
@@ -1,0 +1,8 @@
+# Jolt Physics
+
+Status: planned.
+
+This document will cover Jolt initialization, static triangle meshes, character controllers, ragdoll authoring, animation-to-ragdoll flow, and collision debugging.
+
+See [stage-plan.md](../stage-plan.md#stage-7--physics).
+

--- a/documentation/physics/jolt-physics.md
+++ b/documentation/physics/jolt-physics.md
@@ -1,8 +1,430 @@
 # Jolt Physics
 
-Status: planned.
+Status: Stage 7 draft.
 
-This document will cover Jolt initialization, static triangle meshes, character controllers, ragdoll authoring, animation-to-ragdoll flow, and collision debugging.
+This document explains T850's physics system: Jolt lifecycle, body and shape creation, collision layers, triangle mesh cooking, scene/editor authoring metadata, kinematic character movement, ragdoll generation and authoring, animation-to-ragdoll handoff, Play Scene integration, debug rendering, limitations, and debugging workflows.
 
-See [stage-plan.md](../stage-plan.md#stage-7--physics).
+Related documents:
 
+- [Main architecture](../architecture/main-architecture.md)
+- [Resource locator and cache paths](../architecture/resource-locator.md)
+- [Input, camera, and controls](../input/camera-and-controls.md)
+- [Dependency map](../dependency-map.md)
+- [Loading geometry](../geometry/loading-geometry.md)
+- [Animation system](../animation/animation-system.md)
+- [Scene format and runtime](../scenes/scene-format-and-runtime.md)
+- [NavMesh and Detour](../navigation/navmesh-detour.md)
+
+## Purpose and responsibilities
+
+Physics is exposed to engine scenes through `JoltPhysicsSystem` in `EngineContext`. Scene/editor systems create high-level `PhysicsBodyDesc`, `PhysicsTriangleMeshBodyDesc`, or `PhysicsRagdollDesc` data; `JoltPhysicsSystem` converts those into Jolt shapes, bodies, constraints, casts, and debug records.
+
+```mermaid
+flowchart LR
+  Scene["SceneTemplate / editor Play Scene"] --> Authoring["PhysicsAuthoring helpers"]
+  Authoring --> Descs["PhysicsBodyDesc / TriangleMesh / RagdollDesc"]
+  Descs --> Jolt["JoltPhysicsSystem"]
+  Jolt --> Bodies["Jolt bodies + constraints"]
+  Bodies --> Update["Physics update"]
+  Update --> Runtime["Body/ragdoll state"]
+  Runtime --> Character["Kinematic character sweeps"]
+  Runtime --> Ragdoll["Skeleton/ragdoll handoff"]
+  Runtime --> Debug["PhysicsDebugRenderer"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `Framework/include/physics/JoltPhysicsSystem.h` | Public physics system API: lifecycle, bodies, casts, ragdolls, debug body queries. |
+| `Framework/src/physics/JoltPhysicsSystem.cpp` | Jolt integration, shape/body creation, triangle mesh cache/cooking, simulation update, casts, ragdoll constraints. |
+| `Framework/include/physics/PhysicsTypes.h` | Physics handle, shape, body, triangle mesh, cast, ragdoll, and authoring structs. |
+| `Framework/include/physics/PhysicsAuthoring.h` | Helpers that build physics descriptors from render meshes and skeletons. |
+| `Framework/src/physics/PhysicsAuthoring.cpp` | Static mesh extraction, ragdoll generation/binding/load/save, animation-physics pose conversion. |
+| `Framework/include/physics/CharacterController.h` | Kinematic character settings, input, collision world interface, and controller API. |
+| `Framework/src/physics/CharacterController.cpp` | FPS and Quake3-style kinematic movement using capsule/box sweeps. |
+| `Framework/include/physics/PhysicsDebugRenderer.h` | Physics debug draw API. |
+| `Framework/src/physics/PhysicsDebugRenderer.cpp` | Builds line geometry for boxes, capsules, spheres, cylinders, and triangle meshes. |
+| `Framework/include/physics/RagdollEditorTool.h` | Ragdoll editor state helpers, selection modes, frozen state, undo snapshots. |
+| `Framework/src/physics/RagdollEditorTool.cpp` | Ragdoll authoring state normalization and comparison helpers. |
+| `Framework/include/scene/EditorSceneFile.h` | `.t8scene` physics object/entity/ragdoll/character schema. |
+| `DayScene/SceneTemplate.cpp` | Runtime `.t8scene` physics load, static collision creation, characters, ragdolls, physics debug overlays. |
+| `T8ditor/RagdollEditorPanel.cpp` and `FrameworkImGui/src/RagdollEditorGui.cpp` | Ragdoll authoring UI and hosted viewport tools. |
+| `T8ditor/PlayScenePanel.cpp` | Exports temporary `.t8scene` snapshots for Play Scene. |
+
+## Build/runtime availability
+
+`JoltPhysicsSystem.cpp` is compiled in two modes:
+
+- With `T850_ENABLE_JOLT`, it uses Jolt and provides full body/ragdoll/cast behavior.
+- Without `T850_ENABLE_JOLT`, the same public methods compile as stubs and `IsAvailable()` is false.
+
+Scenes should always check `IsInitialized()` before creating or updating runtime physics.
+
+## Lifecycle and EngineContext
+
+`DayScene/Application.cpp` owns the main `JoltPhysicsSystem` instance, stores it in `EngineContext::physics`, initializes it during app setup, and updates it once per app frame after scene update.
+
+`EngineContext` contains:
+
+```text
+JoltPhysicsSystem* physics
+```
+
+The editor also owns a separate `m_playScenePhysics` for hosted Play Scene execution.
+
+```mermaid
+sequenceDiagram
+  participant App
+  participant Context as EngineContext
+  participant Physics as JoltPhysicsSystem
+  participant Scene
+
+  App->>Context: physics = &m_physics
+  App->>Physics: Initialize()
+  App->>Scene: SetEngineContext(&context)
+  loop frame
+    App->>Scene: OnUpdate(dt)
+    App->>Physics: Update(dt)
+    App->>Scene: OnDraw()
+  end
+  App->>Physics: Shutdown()
+```
+
+`Initialize()`:
+
+- initializes global Jolt allocator/factory/type registration through a refcounted global path,
+- creates the system implementation,
+- initializes `JPH::PhysicsSystem` with 65536 max bodies/body pairs and 10240 contact constraints,
+- creates broadphase/layer filters,
+- calls `OptimizeBroadPhase()`.
+
+`Shutdown()` destroys all ragdolls and bodies, deletes the implementation, and releases global Jolt state when the last instance shuts down.
+
+## Collision layers
+
+The current layer model is intentionally simple:
+
+| Engine/Jolt layer | Meaning |
+|---|---|
+| `Layers::NonMoving` | Static bodies. |
+| `Layers::Moving` | Kinematic/dynamic bodies. |
+
+Layer filtering:
+
+- static/non-moving collides only with moving,
+- moving collides with everything.
+
+There is no per-gameplay-category collision matrix yet. Scene metadata has string fields such as `collision_layer`, but the runtime Jolt filter currently uses only static vs moving object layers.
+
+## Bodies and shapes
+
+Public body creation uses `PhysicsBodyDesc`.
+
+Supported `PhysicsShapeType` values:
+
+- `Box`
+- `Capsule`
+- `Sphere`
+- `Cylinder`
+- `TriangleMesh`
+
+Supported motion modes:
+
+- `Static`
+- `Kinematic`
+- `Dynamic`
+
+`CreateBodyInternal()` validates coordinates and extents before creating a Jolt shape. Oversized or non-finite transforms/shapes are rejected and logged. Body creation sets:
+
+- Jolt shape,
+- position/rotation from row-vector engine transform,
+- Jolt motion type,
+- object layer from motion,
+- user data with entity id and bone index,
+- friction/restitution,
+- sensor flag,
+- optional collision group,
+- mass override for non-static bodies.
+
+`PhysicsBodyHandle` is an index into the system's body slot array. `PrimitiveInst` stores the handle through `AttachPhysicsBody()`.
+
+## Static triangle mesh cooking
+
+Static collision for render meshes is built by `PhysicsAuthoring` and cooked by `JoltPhysicsSystem`.
+
+```mermaid
+flowchart TD
+  Mesh["RenderMesh xFile/MeshInfo"] --> Extract["BuildStaticTriangleMeshBodyDesc"]
+  Extract --> WorldVerts["Transform vertices to world"]
+  WorldVerts --> Center["Center vertices around local body origin"]
+  Center --> Desc["PhysicsTriangleMeshBodyDesc"]
+  Desc --> Hash["BuildTriangleMeshCookHash"]
+  Hash --> Cache{" .t8jolt cache hit? "}
+  Cache -->|yes| Load["Restore Jolt shape"]
+  Cache -->|no| Cook["JPH::MeshShapeSettings::Create"]
+  Cook --> Save["Save .t8jolt cache"]
+  Load --> Body["Create static Jolt body"]
+  Save --> Body
+```
+
+`BuildStaticTriangleMeshBodyDesc()`:
+
+- walks `RenderMesh::xFile->MeshInfo` and `xMeshContainer::Geometry`,
+- reads interleaved position data from `xFinalGeometry::pData`,
+- transforms vertices by the mesh instance world matrix,
+- supports both 16-bit and 32-bit source index arrays,
+- computes world bounds,
+- recenters vertices around the body origin,
+- stores local bounds, source path, vertices, indices, and cook settings.
+
+`CreateTriangleMeshBody()`:
+
+- calls `CreateOrLoadTriangleMeshShape()`,
+- creates a static Jolt body on `Layers::NonMoving`,
+- stores debug vertices and generated line indices for physics debug drawing,
+- returns a `PhysicsBodyHandle`.
+
+Cook cache:
+
+- file extension: `.t8jolt`,
+- location: source parent `.t8cache` directory,
+- key includes geometry, source path, Jolt version/features, platform tag, and cook settings,
+- stores/restores serialized Jolt shape data with a `T8JPHYSM` magic header.
+
+`AttachStaticTriangleMeshBody()` attaches the created body handle to the `PrimitiveInst`.
+
+## Scene and `.t8scene` authoring metadata
+
+Physics metadata is stored in `.t8scene` through `EditorSceneFile.h`.
+
+Per render object:
+
+| Field | Meaning |
+|---|---|
+| `physics` | Optional `SceneObjectPhysicsDesc`. |
+| `ragdoll_authoring` | Optional `SceneObjectRagdollDesc`. |
+| `ragdoll` | Legacy ragdoll authoring asset path. |
+
+`SceneObjectPhysicsDesc` includes:
+
+- `enabled`,
+- `body_type`,
+- `motion`,
+- `collision_layer`,
+- `generate_collision`,
+- `collision_asset`.
+
+Top-level `physics_entities[]` uses `ScenePhysicsEntityDesc` and can define:
+
+- static triangle mesh entities tied to a `source_object`,
+- player/character entities,
+- shape settings such as box/capsule/sphere/cylinder dimensions,
+- friction/restitution/sensor,
+- triangle mesh cook settings,
+- character parameters.
+
+SceneTemplate load behavior:
+
+1. Load scene objects as render meshes.
+2. If object physics metadata requests `static_triangle_mesh` and no top-level physics entity already owns that object, attach static collision.
+3. Iterate `scene.physics_entities`.
+4. For `static_triangle_mesh` entities, find the source object and attach static collision with the entity's cook settings.
+5. For `player` entities, store authored player settings and configure the camera controller.
+6. Character entities are used for runtime navigation/agent character settings; static entity creation skips `type == "character"` in the static physics loop.
+
+## Play Scene export
+
+T8ditor's Play Scene path exports a temporary `.t8scene`:
+
+- stale NavMesh is regenerated before export,
+- `RefreshVirtualEditorScene()` builds a scene snapshot,
+- physics entities, objects, ragdoll metadata, cameras, and lights are written,
+- `SaveSceneToFile()` writes the temp file under `%TEMP%\T850\T8ditorPlay`.
+
+The hosted `SceneTemplate` then loads the same physics metadata as a normal runtime scene, using `m_playScenePhysics` through its local `EngineContext`.
+
+## Kinematic character controller
+
+T850 has an engine-side kinematic controller in `CharacterController.cpp`. It is not currently a direct Jolt `CharacterVirtual` wrapper, even though scene metadata has fields named for virtual/character settings.
+
+The controller depends on a `CharacterCollisionWorld` interface:
+
+- `SweepCapsule()`
+- `SweepBox()`
+- `QueryTriggerTouch()`
+
+`SceneTemplate` implements collision queries by calling the Jolt physics casts.
+
+Character modes:
+
+- `UpdateFps()` implements a grounded FPS controller with friction, acceleration, gravity, jump, step-slide, and capsule sweeps.
+- `UpdateQuake3()` implements Quake3-style movement, command scaling, ground tracing, air/ground movement, clipping planes, and step-slide.
+
+`MakeQuake3CharacterSettings()` converts Quake units to engine units with `1/32` scale and uses a box-shaped collision profile by default.
+
+Scene authoring fields are converted by `CharacterSettingsFromPhysicsEntity()`, including shape, radius/half-height/half-extents, slope angle, probe distance, and step height.
+
+## Ragdoll descriptors
+
+Core ragdoll data lives in `PhysicsTypes.h`.
+
+| Structure | Meaning |
+|---|---|
+| `PhysicsRagdollBoneDesc` | Body shape, parent bone, joint type, joint anchor/frame axes, swing/twist limits. |
+| `PhysicsRagdollDesc` | Full ragdoll body list plus animation/physics blend metadata. |
+| `PhysicsRagdollAnimationBinding` | Mapping between animation skeleton bones and ragdoll bodies/joints. |
+| `PhysicsRagdollAuthoringDesc` | Saved/editable authoring state, parent/joint overrides, frozen flags, contact-joint flags. |
+
+Joint types:
+
+- `SwingTwist`
+- `Fixed`
+
+Ragdoll authoring schema version is currently `kPhysicsRagdollEditSchemaVersion = 11`.
+
+## Ragdoll generation and loading
+
+`BuildRagdollDescFromSkeleton()` generates a ragdoll from a `RenderSkinnedMesh`:
+
+- finds a reference skeleton,
+- selects ragdoll bones,
+- optionally fits capsules to weighted skinned vertex samples,
+- infers body shape, length, radius, mass, and transform,
+- infers parent links and joint limits,
+- initializes joint frames,
+- logs generation statistics.
+
+`BuildRagdollAnimationBinding()` computes:
+
+- `bodyFromBone` transforms,
+- joint anchor offsets relative to bones,
+- parent/child joint frame axes,
+- controlled bone lists,
+- controlled body-from-bone transforms.
+
+`BuildRagdollAuthoringFromSkeleton()` wraps generated pose and binding into editable authoring state.
+
+Saved authoring files:
+
+- path builder: `Models/RagdollEdits/<model-key>.json`,
+- loader: `LoadRagdollAuthoringAsset()`,
+- saver: `SaveRagdollAuthoringAsset()`,
+- write path resolution uses resource lookup on desktop and cache path on Android.
+
+The loader is schema-aware and can remap saved bodies by index or bone index, repair/normalize joint anchors and axes, recover contact anchors, preserve frozen flags, and fill missing controlled-bone data.
+
+## Runtime ragdolls and animation handoff
+
+`JoltPhysicsSystem::CreateRagdoll()`:
+
+1. Creates a Jolt collision group/filter table for the ragdoll.
+2. Creates one body per ragdoll bone, usually kinematic at first.
+3. Creates `FixedConstraint` or `SwingTwistConstraint` between parent and child bodies.
+4. Stores body handles and constraints in a ragdoll slot.
+
+SceneTemplate loads authored ragdolls with `AttachSceneObjectRagdoll()`:
+
+1. Get the skinned mesh.
+2. Generate a ragdoll authoring binding.
+3. Load saved authoring asset.
+4. Create a kinematic Jolt ragdoll.
+5. Store a `SceneRagdollRuntime` with mesh index, binding, pose, resource path, and state.
+6. Attach the ragdoll handle to the `PrimitiveInst`.
+
+Animation-to-physics flow:
+
+```mermaid
+flowchart TD
+  Anim["RenderSkinnedMesh animated skeleton"] --> Pose["BuildRagdollPoseFromAnimation"]
+  Pose --> Drive["DriveRagdollFromPose"]
+  Drive --> Kinematic["Kinematic ragdoll follows animation"]
+  Kinematic --> Switch["SwitchSceneRagdollsToPhysics"]
+  Switch --> Dynamic["SetRagdollMotion(Dynamic) + pause animation"]
+  Dynamic --> State["GetRagdollState"]
+  State --> Skeleton["BuildSkeletonPoseFromRagdollState"]
+  Skeleton --> Mesh["ApplyCombinedPoseOverrides / snapshot pose"]
+```
+
+Important functions:
+
+- `BuildRagdollPoseFromAnimation()` maps current animated skeleton to ragdoll body transforms.
+- `DriveRagdollFromPose()` drives ragdoll bodies kinematically.
+- `SwitchSceneRagdollsToPhysics()` drives current pose once, switches bodies to dynamic, clears velocities, marks runtime as physics-driven, pauses animation, and clears snapshot matrices.
+- `BuildSkeletonPoseFromRagdollState()` maps dynamic body state back into skeleton combined matrices for mesh pose updates.
+
+## Ragdoll editor tools
+
+The hosted ragdoll editor is split between:
+
+- `T8ditor/RagdollEditorPanel.cpp`: hosted viewport, object selection, load/save/reset/simulation callbacks.
+- `FrameworkImGui/src/RagdollEditorGui.cpp`: ImGui controls.
+- `RagdollEditorTool`: authoring state utilities.
+
+Editor functionality includes:
+
+- selection modes for bodies, joints, and bones,
+- select/edit/move/rotate tools,
+- physics and skeleton debug toggles,
+- start simulation,
+- simulation speed slider,
+- fixed 1/60 physics delta toggle,
+- reset physics/animation,
+- undo via authoring snapshots,
+- load/save ragdoll edits,
+- delete/clear/reset bodies,
+- frozen body/joint state.
+
+## Debug rendering
+
+`PhysicsDebugRenderer` obtains live body debug data through `JoltPhysicsSystem::GetDebugBodies()`.
+
+It renders:
+
+- boxes,
+- capsules,
+- spheres,
+- cylinders,
+- triangle mesh edge lists when debug vertices/indices are available.
+
+The renderer builds dynamic line buffers and draws through `LineRenderer`, with optional depth-texture occlusion using render graph depth targets.
+
+SceneTemplate draws physics debug overlays when the `show_physics` editor/runtime toggle is enabled.
+
+## Extension points
+
+To extend physics:
+
+1. Add new shape metadata to `PhysicsTypes.h`, conversion to Jolt in `CreateJoltShape()`, debug rendering, and `.t8scene` schema fields.
+2. Add richer collision layers by extending object layers, broadphase layers, and scene metadata mapping.
+3. Add true Jolt `CharacterVirtual` support by creating a runtime wrapper instead of only using the current kinematic controller/casts.
+4. Extend triangle mesh cook settings carefully; update cache hash/version when serialized Jolt output compatibility changes.
+5. Add ragdoll joint profiles by extending `PhysicsRagdollBoneDesc`, authoring JSON, loader/saver, and Jolt constraint creation.
+6. Keep animation/physics handoff code in sync with `RenderSkinnedMesh` and `AnimationController` pose conventions.
+
+## Known limitations and gotchas
+
+- The physics step is either frame-delta driven or one fixed 1/60 step per frame; there is no accumulator/substep scheduler yet.
+- Collision layers are currently only static/non-moving vs moving.
+- Scene `collision_layer` strings are metadata; Jolt filtering currently does not consume a full named layer matrix.
+- The "virtual" character metadata does not mean the runtime uses Jolt `CharacterVirtual`; current movement uses T850's kinematic sweep controller.
+- Jolt rejects non-finite or extremely large coordinates; T850 validates against a broadphase coordinate limit.
+- Triangle mesh cache files are sensitive to geometry, source path, platform, Jolt version/features, and cook settings.
+- Ragdoll authoring files are schema-driven; old files may be repaired/remapped during load.
+- Static triangle meshes are intended for static world collision, not moving dynamic mesh bodies.
+- Debug triangle mesh rendering depends on retained debug vertices/line indices.
+
+## Debugging checklist
+
+1. Confirm `JoltPhysicsSystem::IsAvailable()` and `IsInitialized()`.
+2. Look for `Jolt Physics initialized` and Jolt update telemetry counters.
+3. Check body creation return handles with `IsValid()`.
+4. Check logs for invalid/oversized transform or shape rejection.
+5. For static collision, inspect cook stats: cache hit/miss, vertex count, triangle count, and total cook time.
+6. Confirm `.t8scene` `physics_entities` source object names match loaded object names.
+7. For characters, verify the scene object implements `CharacterCollisionWorld` casts and that sweep hit normals/grounding are sane.
+8. For ragdolls, verify generated binding sizes match body counts.
+9. Use physics debug rendering to confirm body positions and triangle mesh wireframes.
+10. Use skeleton debug rendering to compare ragdoll state against skinned mesh pose.
+11. For animation-to-ragdoll handoff, check that `BuildRagdollPoseFromAnimation()` succeeds before switching to dynamic motion.
+12. If Play Scene physics differs from editor state, inspect the temporary `.t8scene` exported by Play Scene and verify physics/ragdoll metadata was saved.

--- a/documentation/rendering/geometry-rendering-flow.md
+++ b/documentation/rendering/geometry-rendering-flow.md
@@ -1,8 +1,417 @@
 # Geometry Rendering Flow
 
-Status: planned.
+Status: Stage 5 draft.
 
-This document will cover `PrimitiveInst`, `RenderMesh`, `RenderSkinnedMesh`, state tracking, shader/PSO selection, VB/IB binding, and `DrawIndexed`.
+This document follows a mesh from scene/editor ownership through `PrimitiveInst`, `RenderGraph`, `RenderMesh` / `RenderSkinnedMesh`, state tracking, shader and PSO selection, vertex/index buffer binding, and the final API `DrawIndexed` call.
 
-See [stage-plan.md](../stage-plan.md#stage-5--rendering-geometry-flow).
+Related documents:
+
+- [Loading geometry](../geometry/loading-geometry.md)
+- [Shader management](shader-management.md)
+- [Render graph](render-graph.md)
+- [Animation system](../animation/animation-system.md)
+
+## Purpose and responsibilities
+
+Geometry rendering is where per-instance scene state, shared mesh assets, material data, pass signatures, and backend API state meet.
+
+The runtime path is still centered on `PrimitiveInst::Draw()` and `RenderMesh::Draw()` / `RenderSkinnedMesh::Draw()`. `RenderQueue` and `DrawItem` types exist as scaffolding for a future flat, sortable queue, but the current draw path still walks each `RenderMesh` instance directly.
+
+```mermaid
+flowchart LR
+  Scene["Scene or T8ditor"] --> Inst["PrimitiveInst"]
+  RG["RenderGraph pass"] --> Inst
+  Inst --> Base["PrimitiveBase"]
+  Base --> Static["RenderMesh::Draw"]
+  Base --> Skin["RenderSkinnedMesh::Draw"]
+  Static --> Tracker["MeshDrawStateTracker"]
+  Skin --> Tracker
+  Tracker --> API["DeviceContext + buffers"]
+  Static --> Shader["BaseDriver::GetShader"]
+  Skin --> Shader
+  Shader --> PSO["D3D12/Vulkan PSO or GL/D3D11 shader bind"]
+  API --> Draw["DrawIndexed"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `Framework/include/scene/PrimitiveInstance.h` | Per-scene instance wrapper: transform, visibility, global key, override textures, environment map, physics links. |
+| `Framework/src/scene/PrimitiveInstance.cpp` | Composes transforms and bridges instance state into `PrimitiveBase::Draw()`. |
+| `Framework/include/scene/PrimitiveBase.h` | Abstract render primitive interface and shared per-draw state fields. |
+| `Framework/src/scene/RenderGraph.cpp` | Sets per-pass `ShaderKey` signatures and brackets multi-mesh pass scopes. |
+| `Framework/src/scene/RenderMesh.cpp` | Static mesh draw path: culling, sorting, material CBs, shader selection, VB/IB binding, texture binding, draw calls. |
+| `Framework/src/scene/RenderSkinnedMesh.cpp` | Skinned mesh draw path: bone texture, skinned shader variants, skinned wireframe/skeleton debug. |
+| `Framework/include/scene/RenderQueue.h` | Future flat draw-list structures plus current `MeshDrawStateTracker` declaration. |
+| `Framework/src/scene/RenderQueue.cpp` | State tracker implementation for deduping binds across a pass. |
+| `Framework/include/scene/MeshPool.h` and `Framework/src/scene/MeshPool.cpp` | Shared vertex/index pool buffers used by mesh assets. |
+| `Framework/include/video/BaseDriver.h` | `DeviceContext`, `VertexBuffer`, `IndexBuffer`, `ConstantBuffer`, `ShaderBase`, and driver interfaces. |
+| API buffer/context files under `Framework/src/video/*` | Backend mappings for VB/IB bind, topology, constant buffers, and `DrawIndexed`. |
+
+## High-level runtime flow
+
+```mermaid
+sequenceDiagram
+  participant RG as RenderGraph
+  participant Inst as PrimitiveInst
+  participant Mesh as RenderMesh/RenderSkinnedMesh
+  participant Tracker as MeshDrawStateTracker
+  participant Driver as BaseDriver
+  participant DC as DeviceContext
+
+  RG->>Inst: SetGlobalKey(pass signature)
+  RG->>Inst: SetTexture / SetEnvironmentMap
+  RG->>Inst: Draw()
+  Inst->>Inst: use Final transform
+  Inst->>Mesh: copy textures/env/key to PrimitiveBase
+  Inst->>Mesh: Draw(world, viewProj)
+  Mesh->>Tracker: Begin or reuse pass scope
+  Mesh->>Driver: GetShader(finalKey)
+  Mesh->>DC: bind topology/VB/IB/CB/textures
+  Mesh->>Driver: ShaderBase::Set()
+  Mesh->>DC: DrawIndexed(count, startIndex, baseVertex)
+  Mesh->>Tracker: End if private scope
+  Inst->>Mesh: restore previous PrimitiveBase state
+```
+
+## `PrimitiveInst`: scene instance to primitive draw
+
+`PrimitiveInst` is the per-scene wrapper around a shared `PrimitiveBase` implementation.
+
+It stores:
+
+- `pBase`: the concrete primitive (`RenderMesh`, `RenderSkinnedMesh`, `RenderQuad`, etc.).
+- `pViewProj`: pointer to the view-projection matrix used for the draw.
+- transform matrices: `Scale`, `RotationX`, `RotationY`, `RotationZ`, `Position`, and final `Final`.
+- `gKey`: global pass/effect key supplied by the scene or render graph.
+- per-instance override textures and environment map.
+- visibility and physics/ragdoll handles.
+
+`PrimitiveInst::Update()` composes the world matrix as:
+
+```text
+Final = Scale * RotationX * RotationY * RotationZ * Position
+```
+
+`PrimitiveInst::Draw()`:
+
+1. Early-outs when not visible or no primitive is bound.
+2. Saves the current mutable state on `pBase`.
+3. Copies instance textures, environment map, global key, brightness, and parallax state into `pBase`.
+4. Calls `pBase->Draw(&Final.m[0][0], &pViewProj->m[0][0])`.
+5. Restores the previous `pBase` state.
+
+The save/restore behavior allows several `PrimitiveInst` objects to reference the same primitive resource while still supplying per-instance draw state.
+
+## RenderGraph bridge
+
+`RenderGraph::ExecutePass()` sets the pass signature before each mesh draw:
+
+1. `ResolveSignature(draw.signature)` creates a pass `ShaderKey`.
+2. `extra_signatures` are OR'd into that key.
+3. Each target `PrimitiveInst` receives `SetGlobalKey(sig)`.
+4. `PrimitiveInst::Draw()` is called.
+5. The instance is reset to a forward pass key afterward.
+
+`RenderGraph` also opens a pass-scoped `MeshDrawStateTracker::Begin()` around multi-mesh draw sections and closes it with `End()`. This lets state dedupe survive across multiple `RenderMesh::Draw()` calls inside the same graph pass.
+
+Without an outer pass scope, `RenderMesh::Draw()` and `RenderSkinnedMesh::Draw()` create a private tracker scope, preserving legacy per-draw behavior.
+
+## Static mesh draw path
+
+`RenderMesh::Draw()` is the main static geometry path.
+
+```mermaid
+flowchart TD
+  Start["RenderMesh::Draw(world, vp)"] --> Context["Resolve driver/deviceContext/camera/pass"]
+  Context --> Cull["Classify geometry AABBs against frustum"]
+  Cull --> SortGeo["Sort geometry order by pass/material/depth groups"]
+  SortGeo --> LoopGeo["For each visible geometry"]
+  LoopGeo --> CBs["Build instance/frame constant buffers"]
+  CBs --> VB["Resolve vertex buffer: mesh pool or legacy VB"]
+  VB --> SortSub["Sort subsets"]
+  SortSub --> LoopSubset["For each drawable subset"]
+  LoopSubset --> SubCull["Subset/cluster culling"]
+  SubCull --> Mat["Fill material constant buffer from MaterialAsset"]
+  Mat --> IB["Resolve index buffer: mesh pool or legacy IB"]
+  IB --> BindGeom["Bind topology + VB + IB through MeshDrawStateTracker"]
+  BindGeom --> Key["Build final ShaderKey"]
+  Key --> Shader["GetShader(finalKey), Shader::Set"]
+  Shader --> BindCB["Bind frame/instance/material CBs"]
+  BindCB --> Textures["Bind material/env/pass textures"]
+  Textures --> Draw["DeviceContext::DrawIndexed"]
+```
+
+### Pass and camera setup
+
+`RenderMesh::Draw()` reads the current pass from `gKey.getPass()`. It uses `SceneProps::GetPrimaryCamera()` as the render camera, but can use `SceneProps::pCullingCamera` for GBuffer/Forward culling when available.
+
+The draw path extracts frustum planes once per draw. It can classify geometry AABBs serially or in parallel through the engine thread pool when the mesh count is large.
+
+### Culling and subset filtering
+
+Static meshes use multiple levels of culling/filtering:
+
+- geometry AABB frustum test,
+- subset AABB frustum test when the parent geometry is intersecting,
+- optional cluster culling for GBuffer when culling metadata is ready.
+
+Subset pass rules:
+
+- `GBUFFER`, `SHADOW_MAP`, and `RADIAL_DEPTH` draw only non-forward-only subsets.
+- `FORWARD` draws only forward-only subsets.
+- A subset is forward-only when `alphaMode == BLEND` or `transmissionFactor > 0`.
+
+This is why transparent/transmission materials are drawn in a forward pass after deferred opaque work.
+
+### Sorting
+
+Geometry and subsets are sorted before drawing:
+
+- Forward pass groups transmission before other transparent subsets and sorts by depth.
+- GBuffer/shadow/radial-depth group opaque and masked subsets.
+- Remaining ordering falls back to final shader key bits to reduce shader/PSO switches.
+
+This is not yet a global scene-wide sort. It is per `RenderMesh::Draw()` call, with cross-instance state dedupe supplied by `MeshDrawStateTracker` when the render graph opens a pass scope.
+
+## Material and constant buffers
+
+Per geometry, `RenderMesh::Draw()` builds:
+
+- `MeshInstanceCBuffer`: `WVP`, `World`, `WorldView`.
+- `MeshFrameCBuffer`: light data, camera data, parallax settings, packed lights.
+- `MeshMaterialCBuffer`: material parameters and UV transforms for the current subset.
+
+Material data source:
+
+1. Prefer `sub_info->matAsset` and `MaterialAsset::params/textures`.
+2. Fall back to legacy `SubSetInfo` material fields if `matAsset` is missing.
+
+On OpenGL, the path binds the legacy combined `RenderMesh::CBuffer` at slot 0. On D3D/Vulkan, the path binds split buffers:
+
+- slot 0: frame data,
+- slot 1: instance data,
+- slot 2: material data.
+
+`MeshDrawStateTracker::UpdateAndBindConstantBuffer()` compares the new data against the buffer's last system-memory copy. It updates and binds only when the contents or bound slot changed.
+
+## Vertex and index buffer binding
+
+The preferred runtime path uses shared mesh pools populated by `MeshAssetCache`:
+
+- `MeshInfo::vbPoolAlloc` selects a `VertexPool`.
+- `SubSetInfo::ibPoolAlloc` selects an `IndexPool`.
+- `VertexPool::GetGPUBuffer()` / `IndexPool::GetGPUBuffer()` return the shared GPU buffers after explicit upload.
+- Draw calls pass `offsetElems` values as `startIndex` and `baseVertex`.
+
+Fallbacks still exist:
+
+- `MeshInfo::VB` for legacy per-geometry vertex buffers.
+- `SubSetInfo::IB` for legacy per-subset index buffers.
+
+If no uploaded VB/IB can be resolved, the subset/geometry is skipped and an error is logged.
+
+```mermaid
+flowchart LR
+  MeshInfo["MeshInfo"] --> VBAlloc["vbPoolAlloc valid?"]
+  VBAlloc -->|yes| VPool["MeshAssetCache::GetVertexPool"]
+  VBAlloc -->|no| LegacyVB["MeshInfo::VB"]
+  VPool --> VBGPU["VertexPool::GetGPUBuffer"]
+  Subset["SubSetInfo"] --> IBAlloc["ibPoolAlloc valid?"]
+  IBAlloc -->|yes| IPool["MeshAssetCache::GetIndexPool"]
+  IBAlloc -->|no| LegacyIB["SubSetInfo::IB"]
+  IPool --> IBGPU["IndexPool::GetGPUBuffer"]
+  VBGPU --> Bind["BindIndexedGeometry"]
+  LegacyVB --> Bind
+  IBGPU --> Bind
+  LegacyIB --> Bind
+```
+
+`MeshDrawStateTracker::BindIndexedGeometry()` dedupes:
+
+- primitive topology,
+- vertex buffer pointer/stride/offset,
+- index buffer pointer/index format.
+
+It calls:
+
+- `DeviceContext::SetPrimitiveTopology()`,
+- `VertexBuffer::Set()`,
+- `IndexBuffer::Set()`.
+
+## Shader selection and PSO resolution
+
+For each drawable subset, `RenderMesh::Draw()` builds the final shader key:
+
+1. Start from `SubSetInfo::key` (material features plus vertex-layout bits).
+2. Set the global pass from `gKey.getPass()`.
+3. OR low feature/toggle bits from `gKey`.
+4. Add `PARALLAX` for `FORWARD` or `GBUFFER` when the subset has a height map and parallax is enabled.
+5. Resolve the shader through `BaseDriver::GetShader(finalKey)`.
+
+After `s->Set(*deviceContext)`:
+
+- D3D11 binds VS/PS/input layout.
+- OpenGL binds a linked program and enables shader-reflected attributes.
+- D3D12 resolves and binds a PSO from shader, current RT formats, blend/depth/cull, and topology.
+- Vulkan resolves and binds a graphics pipeline from shader, render pass/format, topology, vertex stride, blend/depth/cull.
+
+`MeshDrawStateTracker::OnShaderChanged(s)` is called after shader bind. This invalidates cached texture and CB bindings when the shader changes, which is required because D3D12 texture/root-parameter mappings are per shader.
+
+## Texture binding
+
+Static mesh texture binding is feature-driven:
+
+- If the shader key has `DIFFUSE_MAP`, bind base color to slot 0.
+- If it has `NORMAL_MAP`, bind normal to slot 3.
+- If it has `HEIGHT_MAP`, bind height/parallax to slot 5.
+- Advanced PBR maps bind to the material texture slots described in the render graph and shader docs.
+
+The graph/scene can also inject per-pass textures into `PrimitiveInst::Textures`, such as:
+
+- scene depth (`Textures[7]`),
+- scene color (`Textures[9]`),
+- IBL/environment textures (slots 10-15).
+
+For static meshes, `RenderMesh::Draw()` uses `MeshDrawStateTracker::ShouldBindTexture()` and `ShouldBindEnvMap()` to skip redundant texture binds across subsets and across mesh instances in a render-graph pass scope. Samplers are still set each time because the backend may need per-shader sampler-slot lookup.
+
+## `DrawIndexed`
+
+The final draw call uses one of three paths:
+
+| Path | Call |
+|---|---|
+| Cluster culling path | `DrawIndexed(cluster.indexCount, subsetIndexOffset + cluster.indexOffset, vertexPoolOffset)` |
+| Shared pool subset | `DrawIndexed(subsetIndexCount, subsetIndexOffset, vertexPoolOffset)` |
+| Legacy fallback | `DrawIndexed(subset.NumVertex, 0, 0)` |
+
+Backend mappings:
+
+| Backend | Mapping |
+|---|---|
+| D3D11 | `ID3D11DeviceContext::DrawIndexed(indexCount, startIndex, baseVertex)` |
+| D3D12 | `ID3D12GraphicsCommandList::DrawIndexedInstanced(indexCount, 1, startIndex, baseVertex, 0)` |
+| OpenGL | `glDrawElements()` or `glDrawElementsBaseVertex()`; `startIndex` becomes a byte offset using the bound index format. |
+| Vulkan | `vkCmdDrawIndexed(commandBuffer, indexCount, 1, startIndex, baseVertex, 0)` |
+
+## Skinned mesh draw path
+
+`RenderSkinnedMesh::Draw()` mirrors much of `RenderMesh::Draw()` but adds skinning requirements:
+
+- If `m_hasSkin` is false, it falls back to `RenderMesh::Draw()`.
+- It expects animation/bone update and bone texture upload to have happened before rendering.
+- It uses the same mesh pool lookup and final key composition.
+- The subset key includes `HAS_SKINNING_TEX`, which generates `USE_SKINNING_TEXTURE`.
+- It binds the bone texture to vertex-shader slot 24 through `Texture::SetVS()`.
+
+Differences from static meshes:
+
+- The current path does not use static bind-pose AABB culling for skinned subsets because GPU-skinned vertices can move outside bind-pose bounds.
+- Some texture binding still reads legacy `SubSetInfo` texture fields directly, although material constants are filled from `MaterialAsset` when available.
+- The bone matrix data is sampled in `VS_Mesh.hlsl` from `BoneTexture`.
+
+```mermaid
+flowchart TD
+  SkinDraw["RenderSkinnedMesh::Draw"] --> HasSkin{"m_hasSkin?"}
+  HasSkin -->|no| Static["RenderMesh::Draw"]
+  HasSkin -->|yes| CB["Build base/frame/instance/material CBs"]
+  CB --> Pools["Resolve VB/IB pools"]
+  Pools --> Key["Final key includes HAS_SKINNING_TEX"]
+  Key --> Shader["GetShader + Shader::Set"]
+  Shader --> BoneTex["Bind BoneTexture to VS slot 24"]
+  BoneTex --> Draw["DrawIndexed"]
+```
+
+## State tracker and RenderQueue status
+
+`RenderQueue` and `DrawItem` are present as Phase C scaffolding:
+
+- `DrawItem` describes one dispatchable submesh draw with sort key, final shader key, pool references, material pointer, constant buffer pointer, and draw ranges.
+- `RenderQueue` stores and sorts `DrawItem` entries.
+- Its execution path is not wired yet; current rendering still happens through per-instance `RenderMesh::Draw()`.
+
+`MeshDrawStateTracker` is the active optimization layer today. It tracks the last:
+
+- shader,
+- textures,
+- environment map,
+- constant buffers,
+- vertex buffer and stride/offset,
+- index buffer and format,
+- topology.
+
+It is process-wide and pass-scoped by `Begin()` / `End()`. D3D12 invariants are explicitly considered: `Shader::Set()` is still called each draw because PSO depends on current render state and RT formats, while the tracker only invalidates dependent caches when the shader changes.
+
+## Wireframe and debug geometry
+
+### Static mesh wireframe
+
+`RenderMesh::DrawWireframe()`:
+
+- requires `LineRenderer` and wire geometry buffers,
+- uses the active scene camera,
+- resolves the same shared vertex pool when available,
+- uses per-geometry wireframe index buffers,
+- draws through `LineRenderer::DrawLines()`,
+- can bind primary/secondary depth textures for overlay depth testing.
+
+### Skinned mesh wireframe
+
+`RenderSkinnedMesh::DrawWireframe()`:
+
+- uses a dedicated wire shader with skinning bits,
+- binds the shared vertex pool or fallback VB,
+- binds per-geometry wireframe IBs as `LINE_LIST`,
+- binds constant buffers and bone texture,
+- optionally binds GBuffer depth textures for manual depth comparison,
+- calls `DrawIndexed()` with the wire index count and base vertex.
+
+### Skeleton debug
+
+`RenderSkinnedMesh::DrawSkeleton()`:
+
+- updates CPU skeleton line positions from the current animated pose,
+- uploads the skeleton VB,
+- draws grey base skeleton lines plus optional highlighted bone sets through `LineRenderer`,
+- disables depth testing for the skeleton overlay.
+
+## Extension points
+
+When extending geometry rendering:
+
+1. Add or reuse a `ShaderKey` bit for new compiled shader behavior.
+2. Ensure `RenderMesh::GatherInfo()` / `RenderSkinnedMesh` compiles that key for every needed pass.
+3. Feed per-instance state through `PrimitiveInst` or through a future `RenderEntity`/`DrawItem`.
+4. Add material parameters to `MaterialAsset` and update constant-buffer fill code.
+5. Add texture slots consistently across `MaterialAsset`, render graph resource binding, shader registers, and draw binding code.
+6. If the feature changes vertex layout, update import, `SubSetInfo`/`MeshInfo`, shader input, and API reflection assumptions.
+7. If batching is the goal, continue wiring `RenderQueue::Execute()` instead of adding more per-instance loops.
+
+## Known limitations and gotchas
+
+- `RenderQueue` is not the active executor yet; state dedupe is handled by `MeshDrawStateTracker`.
+- `PrimitiveInst::Draw()` mutates and restores shared `PrimitiveBase` state, so missing restore logic can leak state between instances.
+- `PrimitiveInst::SetTexture()` does not bounds-check the texture slot.
+- `RenderMesh` still carries legacy VB/IB and material fields as fallbacks.
+- Skinned meshes do not currently perform conservative animation-aware frustum culling.
+- `Shader::Set()` must still be called for every subset/draw on D3D12/Vulkan because PSO/pipeline state depends on render state and RT formats.
+- Unknown or uncompiled final shader keys cause `GetShader` misses and skipped subsets.
+- Mesh pool accessors return null and log when pools are dirty or not uploaded.
+- GL shared-pool drawing with nonzero base vertex relies on `glDrawElementsBaseVertex()` on the desktop GL path.
+
+## Debugging checklist
+
+1. Confirm `PrimitiveInst::Visible`, `pBase`, and `pViewProj` are valid.
+2. Confirm `PrimitiveInst::Update()` was called after transform edits.
+3. Log `gKey.bits` and `gKey.getPass()` before draw.
+4. Check `ShouldDrawSubsetInPass()` expectations for alpha/transmission materials.
+5. Check `MeshInfo::vbPoolAlloc` and `SubSetInfo::ibPoolAlloc`; if invalid, confirm legacy `VB`/`IB` exist.
+6. Look for `[RenderMesh] Skipped geometry/subset: no uploaded vertex/index buffer`.
+7. Check `MaterialAsset*` and fallback `SubSetInfo` material fields.
+8. Check `BaseDriver::GetShader(finalKey)` misses.
+9. For D3D12/Vulkan, inspect PSO/pipeline creation logs if `Shader::Set()` succeeds but drawing fails.
+10. For texture issues, verify feature bits in `s->key` match the texture slots actually bound.
+11. For culling issues, temporarily disable frustum culling or check geometry/subset/cluster bounds.
+12. For skinned meshes disappearing, remember bind-pose bounds are not conservative for GPU skinning and the current skinned path avoids subset AABB culling.
 

--- a/documentation/rendering/geometry-rendering-flow.md
+++ b/documentation/rendering/geometry-rendering-flow.md
@@ -1,0 +1,8 @@
+# Geometry Rendering Flow
+
+Status: planned.
+
+This document will cover `PrimitiveInst`, `RenderMesh`, `RenderSkinnedMesh`, state tracking, shader/PSO selection, VB/IB binding, and `DrawIndexed`.
+
+See [stage-plan.md](../stage-plan.md#stage-5--rendering-geometry-flow).
+

--- a/documentation/rendering/geometry-rendering-flow.md
+++ b/documentation/rendering/geometry-rendering-flow.md
@@ -7,7 +7,9 @@ This document follows a mesh from scene/editor ownership through `PrimitiveInst`
 Related documents:
 
 - [Loading geometry](../geometry/loading-geometry.md)
+- [Dependency map](../dependency-map.md)
 - [Shader management](shader-management.md)
+- [Textures, samplers, and IBL](textures-and-ibl.md)
 - [Render graph](render-graph.md)
 - [Animation system](../animation/animation-system.md)
 
@@ -414,4 +416,3 @@ When extending geometry rendering:
 10. For texture issues, verify feature bits in `s->key` match the texture slots actually bound.
 11. For culling issues, temporarily disable frustum culling or check geometry/subset/cluster bounds.
 12. For skinned meshes disappearing, remember bind-pose bounds are not conservative for GPU skinning and the current skinned path avoids subset AABB culling.
-

--- a/documentation/rendering/render-graph.md
+++ b/documentation/rendering/render-graph.md
@@ -1,0 +1,8 @@
+# Render Graph
+
+Status: planned.
+
+This document will cover render graph descriptors, passes, render targets, push/pop RT, post-processing, shader passes, and final backbuffer composition.
+
+See [stage-plan.md](../stage-plan.md#stage-4--render-graph).
+

--- a/documentation/rendering/render-graph.md
+++ b/documentation/rendering/render-graph.md
@@ -1,8 +1,459 @@
 # Render Graph
 
-Status: planned.
+Status: Stage 4 draft.
 
-This document will cover render graph descriptors, passes, render targets, push/pop RT, post-processing, shader passes, and final backbuffer composition.
+This document explains T850's data-driven render graph: JSON descriptors, render target creation, pass execution, input/output edges, render-target push/pop behavior, state overrides, mesh and fullscreen-quad draws, post-processing, and final output routing.
 
-See [stage-plan.md](../stage-plan.md#stage-4--render-graph).
+Related documents:
+
+- [Main architecture](../architecture/main-architecture.md)
+- [Loading geometry](../geometry/loading-geometry.md)
+- [Shader management](shader-management.md)
+- [Geometry rendering flow](geometry-rendering-flow.md)
+
+## Purpose and responsibilities
+
+The render graph is a runtime description of the frame pipeline. It does not replace the low-level API drivers; instead, it tells the Framework which render targets to allocate, which passes to run, which textures to bind between passes, which shader pass signature to use, and which render state overrides to apply.
+
+```mermaid
+flowchart LR
+  JSON["*_RenderGraph.json"] --> Desc["RenderGraphDesc"]
+  Desc --> RTs["CreateRenderTargets"]
+  Desc --> DAG["BuildGraph nodes/edges"]
+  RTs --> Execute["RenderGraph::Execute"]
+  DAG --> Execute
+  Execute --> Mesh["mesh draw commands"]
+  Execute --> Quad["fullscreen/final quad commands"]
+  Execute --> Driver["BaseDriver PushRT/PopRT/SetState"]
+  Driver --> API["D3D11/D3D12/GL/Vulkan backends"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `Framework/include/scene/RenderGraphDescriptor.h` | JSON-facing descriptor structs: `RTDesc`, `TextureInput`, `StateDesc`, `DrawCmd`, `RenderPassDesc`, `RenderGraphDesc`. |
+| `Framework/include/scene/RenderGraph.h` | Runtime graph class, graph nodes/edges, environment texture slots, load/create/execute APIs. |
+| `Framework/src/scene/RenderGraph.cpp` | Descriptor loading, string-to-enum maps, RT creation/destruction, graph-edge construction, pass execution. |
+| `Framework/include/scene/RenderQuad.h` and `Framework/src/scene/RenderQuad.cpp` | Fullscreen quad primitive and post-process shader permutation creation. |
+| `Framework/src/scene/RenderContainer.cpp` | Reusable wrapper that owns a `RenderGraph`, quads, scene props, and mesh instances. |
+| `Framework/src/video/BaseDriver.cpp` | Generic `PushRT`, `PushRTLoad`, offscreen target binding, and shared RT state tracking. |
+| API driver `PopRT()` implementations | Transition RT outputs back to shader-readable/backbuffer states and generate mips where supported. |
+| `Assets/Scenes/*_RenderGraph.json` | Data-driven graph files for DayScene, SceneTemplate, SandboxScene, T8ditor, RagdollEditor, and Quake3Mock. |
+| Scene/editor integration files | `DayScene.cpp`, `SceneTemplate.cpp`, `Quake3Mock.cpp`, `RagdollEditor.cpp`, `SandboxScene.cpp`, `EditorApp.cpp`. |
+
+## Runtime ownership and lifetime
+
+`RenderGraph` owns descriptor and graph metadata, but not GPU resources directly. GPU render targets are owned by `BaseDriver::RTs`; `RenderGraph` stores the driver RT handles by name in `m_rtHandles`.
+
+```mermaid
+classDiagram
+  class RenderGraph {
+    +Load(path)
+    +CreateRenderTargets(driver, props)
+    +DestroyRenderTargets(driver)
+    +Execute(driver, props, meshes, quads, cameras, envMaps, finalOutputRT)
+    +GetRTHandle(name)
+  }
+  class RenderGraphDesc {
+    +render_targets
+    +passes
+  }
+  class GraphNode {
+    +index
+    +desc
+    +rt_handle
+    +inputs_from
+    +outputs_to
+  }
+  class GraphEdge {
+    +from_pass
+    +to_pass
+    +rt
+    +attachment
+    +slot
+  }
+  class BaseDriver {
+    +RTs
+    +CreateRT()
+    +PushRT()
+    +PushRTLoad()
+    +PopRT()
+  }
+  RenderGraph --> RenderGraphDesc
+  RenderGraph --> GraphNode
+  RenderGraph --> GraphEdge
+  RenderGraph --> BaseDriver
+```
+
+Typical lifetime:
+
+1. Scene/editor calls `m_renderGraph.Load("Scenes/..._RenderGraph.json")`.
+2. Scene/editor calls `CreateRenderTargets()` after the driver and `SceneProps` are initialized.
+3. `CreateRenderTargets()` allocates every `RTDesc` through `BaseDriver::CreateRT()` and then calls `BuildGraph()`.
+4. Each frame calls `Execute()`.
+5. Resize or graph reload calls `DestroyRenderTargets()` and `CreateRenderTargets()` again.
+6. Scene shutdown calls `DestroyRenderTargets()`.
+
+`RenderContainer` packages the same pattern for systems that want a reusable render target/graph container. It creates its own fullscreen quads, stores a `RenderGraph`, can own or borrow `SceneProps`, recreates RTs on resize, and executes the graph with either internally stored meshes or supplied mesh arrays.
+
+## Descriptor JSON schema
+
+The graph is loaded with glaze from JSON into `RenderGraphDesc`. Unknown keys are ignored, which lets JSON files carry future/editor-only fields without breaking current runtime parsing.
+
+Top-level shape:
+
+```json
+{
+  "render_targets": [],
+  "passes": []
+}
+```
+
+### Render targets
+
+`render_targets[]` entries map to `RTDesc`.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `name` | string | Logical name used by pass targets and texture inputs. |
+| `color_count` | int | Number of color attachments. Use `0` for depth-only targets. |
+| `color_format` | string | Shared color format when `color_formats` is empty. |
+| `color_formats` | string array | Per-color-attachment formats. Overrides `color_format`. |
+| `depth_format` | string | Depth format, commonly `F32`, `CUBE_F32`, or `NONE`. |
+| `size` | `[int,int]` | Explicit dimensions; `[0,0]` means screen/override size. |
+| `linear_filter` | bool | Sets RT texture filtering to linear or nearest. |
+| `generate_mips` | bool | Requests mip generation where supported. |
+| `size_ref` | string | Named dynamic size such as `$shadow_resolution` or `$god_rays_resolution`. |
+
+Supported color format strings:
+
+- `NONE`
+- `RGBA8`
+- `RGBA16F`
+- `RGBA32F`
+- `R8`
+- `F16`
+- `RGB8`
+
+Supported depth format strings:
+
+- `NONE`
+- `F32`
+- `CUBE_F32`
+
+`size_ref` is resolved from `SceneProps`:
+
+- `$shadow_resolution` -> `SceneProps::ShadowMapResolution`
+- `$god_rays_resolution` -> `SceneProps::GoodRaysResolution`
+
+On Android, screen-sized render targets can be scaled by the hard-coded Android render scale in `RenderGraph::CreateRenderTargets()`. Width/height overrides are used for `[0,0]` targets when supplied by scenes/editor viewport hosts.
+
+### Passes
+
+`passes[]` entries map to `RenderPassDesc`.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `name` | string | Human-readable pass name and graph node id. Some runtime skips are name-based. |
+| `target` | string | Render target name to bind. Empty string means draw to backbuffer/offscreen/final output. |
+| `clear` | bool | Whether to clear after target binding. |
+| `clear_color` | `[float,float,float,float]` | Clear color used when `clear` is true. |
+| `clear_depth` | float | Descriptor field exists, but current clear path uses driver clear defaults rather than this value directly. |
+| `state` | object | Pre-pass depth/cull/blend overrides. |
+| `post_state` | object | Explicit state restoration after pass. |
+| `camera` | string | `main`, `light`, or empty. |
+| `gauss_kernel` | int | Sets `SceneProps::ActiveGaussKernel` for blur passes. |
+| `active_light_camera` | int | Sets `SceneProps::ActiveLightCamera`. |
+| `inputs` | array | Texture inputs consumed by this pass. |
+| `bind_environment_map` | bool | Binds sky/IBL environment resources to quad/mesh slots. |
+| `draws` | array | Mesh or quad draw commands. |
+| `pop` | bool | Whether to pop/end the RT after drawing. Default true. |
+| `push` | bool | Whether to push/bind the target before drawing. Default true. |
+| `cube_faces` | int | Cubemap loop count, usually `6`. |
+| `per_face_camera` | string | `omni` selects `omniCams[face]` during cubemap loops. |
+
+### Texture inputs
+
+`TextureInput` entries bind a source texture to a primitive texture slot.
+
+```json
+{ "source": "GBuffer:DEPTH", "slot": 4 }
+```
+
+Source format:
+
+- `RTName:COLOR0` through `RTName:COLOR7`
+- `RTName:DEPTH`
+- `RTName` as shorthand for `RTName:COLOR0`
+- built-ins beginning with `@`
+
+Currently implemented built-in input:
+
+- `@ssao_noise` -> `SceneProps::SSAOKernel.NoiseTex`
+
+`RenderGraphDescriptor.h` mentions `@environment_map`, but the current execution path binds environment maps through `bind_environment_map`, not through this input string.
+
+### State overrides
+
+`state` and `post_state` use `StateDesc`.
+
+Supported values:
+
+| Field | Values |
+|---|---|
+| `depth_stencil` | `READ_WRITE`, `READ`, `NONE` |
+| `cull_face` | `FRONT_FACES`, `BACK_FACES`, `FRONT_AND_BACK` |
+| `blend` | `BLEND_DEFAULT`, `BLEND_OPAQUE`, `ADDITIVE`, `ALPHA_BLEND`, `NON_PREMULTIPLIED` |
+
+State is only changed when a field is non-empty and recognized. Restoration is not automatic; use `post_state` when a pass changes state that later passes should not inherit.
+
+### Draw commands
+
+`DrawCmd` entries describe the work inside a pass.
+
+| Field | Meaning |
+|---|---|
+| `type` | `mesh`, `fullscreen_quad`, or `final_quad`. Default is `fullscreen_quad`. |
+| `mesh_indices` | Mesh indices to draw for `mesh`; empty array means draw all meshes. |
+| `signature` | Render graph signature string resolved to a `ShaderKey` pass. |
+| `extra_signatures` | Feature signatures OR'd into the main key. Currently used for `USE_OMNIDIRECTIONAL_SHADOWS`. |
+
+Supported pass signatures include:
+
+- `FORWARD_PASS`
+- `GBUFF_PASS`
+- `SHADOW_MAP_PASS`
+- `FSQUAD_1_TEX`, `FSQUAD_2_TEX`, `FSQUAD_3_TEX`
+- `DEFERRED_PASS`
+- `SHADOW_COMP_PASS`
+- `VERTICAL_BLUR_PASS`, `HORIZONTAL_BLUR_PASS`
+- `BRIGHT_PASS`, `HDR_COMP_PASS`
+- `ADAPT_LUMINANCE_PASS`
+- `COC_PASS`, `COMBINE_COC_PASS`
+- `DOF_PASS`, `DOF_PASS_2`
+- `BACKBUFFER_PASS`
+- `RAY_MARCH`
+- `RADIAL_DEPTH_PASS`
+- `LIGHT_RAY_MARCHING`
+- `LIGHT_ADD`
+- `FADE_PASS`
+- `GOD_RAY_CALCULATION_PASS`, `GOD_RAY_BLEND_PASS`
+- `SSAO_PASS`
+- `DEFERRED_LDR_PASS`
+- `DEFERRED_LIGHT_VOLUME_PASS`
+
+Unknown signatures log an error and resolve to an empty valid key.
+
+## Graph construction
+
+`BuildGraph()` creates one `GraphNode` per pass and one `GraphEdge` per RT input dependency.
+
+```mermaid
+flowchart TD
+  Passes["Pass array in JSON order"] --> LastWriter["Track last writer per RT name"]
+  LastWriter --> Inputs["For each input RTName:ATTACHMENT"]
+  Inputs --> Edge["Create GraphEdge from last writer to consumer"]
+  Edge --> NodeAdj["Fill inputs_from / outputs_to"]
+  Passes --> Target["If pass has target, update lastWriter[target]"]
+```
+
+Important behavior:
+
+- The graph stores dependency edges for inspection/debugging.
+- Execution still happens in JSON pass order; there is no topological sort.
+- Dependencies are resolved against the last writer seen so far, so pass ordering in JSON is meaningful.
+- Built-in inputs beginning with `@` do not create graph edges.
+
+## Execution flow
+
+`RenderGraph::Execute()` receives:
+
+- driver,
+- `SceneProps`,
+- contiguous `PrimitiveInst` mesh array,
+- quad primitive array,
+- main/light/omni cameras,
+- environment texture indices,
+- optional `finalOutputRT`.
+
+It first scans enabled passes to detect whether `DEFERRED_LIGHT_VOLUME_PASS` is present and sets `SceneProps::DeferredLightVolumesEnabled`. Then it executes nodes in JSON order.
+
+Some pass skipping is hard-coded:
+
+- `Shadow Depth` is skipped when shadows are disabled.
+- `Shadow Accumulation`, `Shadow Blur V`, and `Shadow Blur H` are skipped when both shadows and SSAO are disabled.
+- Certain inputs are skipped/cleared when shadows or SSAO are disabled, such as `DepthPass:DEPTH`, `GBuffer:COLOR3`, `@ssao_noise`, and `ShadowAccum:*`.
+
+```mermaid
+sequenceDiagram
+  participant Scene
+  participant RG as RenderGraph
+  participant Driver as BaseDriver
+  participant Mesh as PrimitiveInst mesh
+  participant Quad as Fullscreen quad
+
+  Scene->>RG: Execute(driver, props, meshes, quads, cameras, envMaps)
+  loop pass in JSON order
+    RG->>Driver: SetDepth/Cull/Blend from state
+    RG->>RG: select camera/kernel/light camera
+    RG->>Driver: PushRT / PushRTLoad / final output/offscreen bind
+    RG->>Quad: bind pass inputs to texture slots
+    alt mesh draw
+      RG->>Mesh: bind pass inputs/env maps
+      RG->>Mesh: SetGlobalKey(signature)
+      RG->>Mesh: Draw()
+    else fullscreen/final quad
+      RG->>Quad: SetGlobalKey(signature)
+      RG->>Quad: Draw()
+    end
+    RG->>Driver: PopRT when pass.pop requires it
+    RG->>Driver: apply post_state
+  end
+```
+
+## Render-target push/pop behavior
+
+The graph drives the backend RT stack through `BaseDriver`.
+
+| Graph/driver operation | Meaning |
+|---|---|
+| `PushRT(handle)` | Bind an RT for rendering using the backend's normal set/clear path. If another RT is current, it is popped first. |
+| `PushRTLoad(handle)` | Bind an RT while preserving/loading existing contents. Used when `push=false` and the target was not already current. |
+| `PopRT()` | End RT rendering and resume backbuffer/offscreen handling. Backends also transition resources or generate mips. |
+| `BindOffscreenTarget(false)` | Used for offscreen mode when a pass targets the default output instead of a named RT. |
+
+Graph flags:
+
+- `push=true`, `pop=true`: normal isolated pass.
+- `push=true`, `pop=false`: opens a target and leaves it current for a later continuation pass.
+- `push=false`, `pop=false`: continue rendering into an already-open target.
+- `push=false`, `pop=true`: continue/load a target and close it after drawing.
+
+The SceneTemplate graph uses this for deferred composition, deferred light volumes, and forward transparent rendering into the same `Deferred` target.
+
+Backend-specific `PopRT()` responsibilities:
+
+- D3D11 and OpenGL generate mips for RTs marked `GenMips`.
+- D3D12 transitions color/depth resources to shader-readable states.
+- Vulkan ends the active render pass and transitions color/depth images to shader-read layouts.
+- All backends reset `CurrentRT` or bind the active offscreen target as appropriate.
+
+## Standard deferred pipeline
+
+The common SceneTemplate graph follows this frame shape:
+
+```mermaid
+flowchart TD
+  Shadow["Shadow Depth -> DepthPass"] --> ShadowAccum["Shadow Accumulation -> ShadowAccum"]
+  GBuffer["GBuffer -> GBuffer RT"] --> ShadowAccum
+  ShadowAccum --> ShadowBlur["Shadow Blur V/H"]
+  GBuffer --> Deferred["Deferred fullscreen -> Deferred RT"]
+  ShadowBlur --> Deferred
+  Deferred --> LightVolumes["Deferred Light Volumes, additive, same Deferred RT"]
+  LightVolumes --> Copy["Opaque Scene Copy -> Extra16F"]
+  Copy --> Forward["Forward Transparent -> Deferred RT"]
+  Deferred --> LightAdd["Light Add -> Extra16F"]
+  LightAdd --> Luminance["Adapt/Store Luminance"]
+  Luminance --> Bloom["Bright + Bloom Blur"]
+  Bloom --> HDR["HDR Composition -> ExtraHelper"]
+  HDR --> BackBuffer["BackBuffer final_quad"]
+```
+
+DayScene adds more post-processing, such as god rays and depth-of-field/CoC passes. T8ditor and SceneTemplate use smaller graph variants oriented around editor/runtime viewport needs.
+
+## Fullscreen and final quads
+
+`RenderQuad::Create()` creates the fullscreen quad primitive and precompiles many `FS_Quad` pass variants:
+
+- deferred composition,
+- fullscreen copy variants,
+- blur passes,
+- bright/HDR/luminance/DoF passes,
+- backbuffer/final pass,
+- god rays,
+- SSAO,
+- ray marching,
+- light add,
+- fade and lens flare passes.
+
+During graph execution:
+
+- `fullscreen_quad` draws use `quads[0]`.
+- `final_quad` also currently uses `quads[0]`; its distinct type mainly changes the intent and makes sure input textures are rebound before final output.
+- Mesh draw commands use the provided mesh `PrimitiveInst` array.
+
+The `quads` comment in `RenderGraph.h` says `quads[7] = final`, but `RenderGraph::ExecutePass()` currently draws `quads[0]` for both fullscreen and final quad types. Editor debug overrides may draw selected RTs with other quad instances outside the graph.
+
+## Environment and material texture slots
+
+`RenderGraph.h` reserves slots for environment and advanced material resources:
+
+| Slot | Meaning |
+|---|---|
+| 10 | diffuse IBL |
+| 11 | specular IBL |
+| 12 | BRDF LUT |
+| 13 | Charlie IBL |
+| 14 | Charlie LUT |
+| 15 | Sheen E LUT |
+| 16-23 | advanced material maps such as sheen, clearcoat, occlusion, specular, transmission |
+| 25 | lightmap |
+
+When `bind_environment_map` is true, the graph binds sky/environment resources to both fullscreen quads and mesh instances as appropriate. When false, it clears those slots to avoid leaking a previous pass's resources.
+
+## Scene and editor integration
+
+Examples:
+
+- `DayScene` loads `Scenes/DayScene_RenderGraph.json`, creates RTs, caches RT handles, and calls `m_renderGraph.Execute()` each frame.
+- `SceneTemplate` can choose a graph from a `.t8scene` render profile, falls back to `Scenes/SceneTemplate_RenderGraph.json`, and supports viewport/final-output RT overrides.
+- `Quake3Mock`, `SandboxScene`, and `RagdollEditor` each load their own graph JSON.
+- T8ditor loads `Scenes/T8ditor_RenderGraph.json`, copies visible editor objects into a contiguous mesh array, executes the graph, and can override the backbuffer with a selected RT debug texture afterward.
+- `MeshEditorPanel` uses `Scenes/RagdollEditor_RenderGraph.json` for the embedded mesh editor view.
+
+`GetRTHandle(name)` is used by scenes/editor overlays to access graph-created RTs for:
+
+- debug RT viewing,
+- adapting older pass handle fields,
+- depth textures for wireframe overlays,
+- benchmark/offscreen capture routing.
+
+## Extension points
+
+To add a new render graph feature:
+
+1. Add fields to `RenderGraphDescriptor.h` if the JSON schema needs new data.
+2. Add string mappings in `RenderGraph.cpp` for new formats, signatures, state names, or built-ins.
+3. Precompile the matching shader pass in `RenderQuad::Create()`, `RenderMesh::GatherInfo()`, or the relevant primitive.
+4. Extend `ExecutePass()` for new draw types, built-in texture sources, camera selectors, or pass-level behavior.
+5. Update graph JSON files in `Assets/Scenes`.
+6. Verify D3D12/Vulkan PSO behavior if the change alters RT formats, topology, input layout, or resource binding.
+
+## Known limitations and gotchas
+
+- Execution is JSON order, not topologically sorted graph order.
+- Dependency edges only reflect RT inputs from the most recent prior writer.
+- Unknown JSON keys are ignored; typos in unused fields may not fail parsing.
+- Unknown signatures log an error but resolve to an empty valid `ShaderKey`, which may cause a later shader miss rather than a parse failure.
+- `clear_depth` exists in the descriptor but is not directly used by the current clear call.
+- State restoration is explicit. If a pass sets blend/depth/cull without `post_state`, later passes inherit that state.
+- `@environment_map` is documented in comments as a possible built-in source, but current execution uses `bind_environment_map`.
+- Pass skip logic for shadows/SSAO depends on specific pass names.
+- `push=false`/`pop=false` continuation passes require careful ordering and can leave a target current longer than expected.
+- D3D11/GL mip generation on pop is implemented, but D3D12/Vulkan mip generation is not equivalent in this path.
+- `RenderGraph::Execute()` needs a contiguous `PrimitiveInst` array; editor code copies visible objects into one before executing.
+
+## Debugging checklist
+
+1. Check `[RenderGraph] Loaded` and `[RenderGraph] Created RT` logs for descriptor load and RT allocation.
+2. Check `[RenderGraph] Built graph` node/edge count after `CreateRenderTargets()`.
+3. Use `PrintGraph()` at debug log level to inspect pass dependencies and RT handles.
+4. Verify JSON pass order when an input samples an RT written by another pass.
+5. Confirm `GetRTHandle(name)` returns a non-negative handle for each expected RT.
+6. For black fullscreen passes, verify `inputs[].source` and `slot` match the shader's expected texture registers.
+7. For missing mesh output, verify draw `signature`, mesh index selection, pass camera, and depth/cull state.
+8. For wrong blending or culling, check both `state` and `post_state`.
+9. For D3D12/Vulkan issues, inspect RT format/depth format changes because they create distinct PSO/pipeline entries.
+10. For editor output issues, confirm the editor passed a contiguous mesh array and the intended final-output RT.
 

--- a/documentation/rendering/render-graph.md
+++ b/documentation/rendering/render-graph.md
@@ -7,8 +7,10 @@ This document explains T850's data-driven render graph: JSON descriptors, render
 Related documents:
 
 - [Main architecture](../architecture/main-architecture.md)
+- [Dependency map](../dependency-map.md)
 - [Loading geometry](../geometry/loading-geometry.md)
 - [Shader management](shader-management.md)
+- [Textures, samplers, and IBL](textures-and-ibl.md)
 - [Geometry rendering flow](geometry-rendering-flow.md)
 
 ## Purpose and responsibilities
@@ -456,4 +458,3 @@ To add a new render graph feature:
 8. For wrong blending or culling, check both `state` and `post_state`.
 9. For D3D12/Vulkan issues, inspect RT format/depth format changes because they create distinct PSO/pipeline entries.
 10. For editor output issues, confirm the editor passed a contiguous mesh array and the intended final-output RT.
-

--- a/documentation/rendering/shader-management.md
+++ b/documentation/rendering/shader-management.md
@@ -7,7 +7,10 @@ This document explains how T850 selects shader source files, builds `ShaderKey` 
 Related documents:
 
 - [Main architecture](../architecture/main-architecture.md)
+- [Resource locator and cache paths](../architecture/resource-locator.md)
+- [Dependency map](../dependency-map.md)
 - [Loading geometry](../geometry/loading-geometry.md)
+- [Textures, samplers, and IBL](textures-and-ibl.md)
 - [Render graph](render-graph.md)
 - [Geometry rendering flow](geometry-rendering-flow.md)
 
@@ -385,4 +388,3 @@ When adding shader features:
 8. For D3D12 PSO failures, inspect the logged blend/depth/cull/topology/RT formats and root signature resources.
 9. For OpenGL issues, check shader link logs, active attribute locations, and stale attribute disable behavior.
 10. Regenerate or inspect `shader_permutations.json` if a runtime path is missing a prewarmed key.
-

--- a/documentation/rendering/shader-management.md
+++ b/documentation/rendering/shader-management.md
@@ -1,0 +1,8 @@
+# Shader Management
+
+Status: planned.
+
+This document will cover shader keys, permutations, defines, HLSL/Vulkan, GLSL/GL, shader cache, offline compilation, reflection, and binding.
+
+See [stage-plan.md](../stage-plan.md#stage-3--shader-management).
+

--- a/documentation/rendering/shader-management.md
+++ b/documentation/rendering/shader-management.md
@@ -1,8 +1,388 @@
 # Shader Management
 
-Status: planned.
+Status: Stage 3 draft.
 
-This document will cover shader keys, permutations, defines, HLSL/Vulkan, GLSL/GL, shader cache, offline compilation, reflection, and binding.
+This document explains how T850 selects shader source files, builds `ShaderKey` permutations, prepends compile-time defines, compiles/caches shaders for D3D11, D3D12, OpenGL, and Vulkan, reflects resource/input layouts, and resolves explicit PSO objects on D3D12 and Vulkan.
 
-See [stage-plan.md](../stage-plan.md#stage-3--shader-management).
+Related documents:
+
+- [Main architecture](../architecture/main-architecture.md)
+- [Loading geometry](../geometry/loading-geometry.md)
+- [Render graph](render-graph.md)
+- [Geometry rendering flow](geometry-rendering-flow.md)
+
+## Purpose and responsibilities
+
+The shader system is responsible for:
+
+1. Turning engine state into a stable `ShaderKey`.
+2. Generating compile-time `#define` blocks from that key.
+3. Selecting HLSL or GLSL source based on backend.
+4. Creating backend shader objects and reflected input/resource layouts.
+5. Caching compiled artifacts on disk and compiled shader objects in memory.
+6. Feeding explicit pipeline-state caches on D3D12 and Vulkan.
+
+```mermaid
+flowchart LR
+  Mesh["Geometry/material/pass state"] --> Key["ShaderKey bits"]
+  Key --> Defines["ShaderBase::CreateShader prepends defines"]
+  Defines --> Source{"Backend"}
+  Source -->|D3D11/D3D12| HLSL["HLSL -> DXBC"]
+  Source -->|Vulkan| SPV["HLSL -> SPIR-V"]
+  Source -->|OpenGL| GLSL["GLSL -> GL program"]
+  HLSL --> ReflectD3D["D3D reflection"]
+  SPV --> ReflectSPV["SPIRVReflection"]
+  GLSL --> ReflectGL["GL parser + GL locations"]
+  ReflectD3D --> Runtime["ShaderBase in BaseDriver cache"]
+  ReflectSPV --> Runtime
+  ReflectGL --> Runtime
+  Runtime --> PSO["D3D12/Vulkan PSO cache"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `T850/Framework/Descriptors.h` | Defines `PassType`, `ShaderKey`, render formats, topology, buffer types, and related descriptors. |
+| `Framework/include/video/BaseDriver.h` | Declares `ShaderBase`, `BaseDriver::CreateShader()`, `GetShader()`, and the in-memory shader cache. |
+| `Framework/src/video/BaseDriver.cpp` | Builds `#define` strings from `ShaderKey`, creates backend shaders, records permutation dumps, and manages `m_shaderCache`. |
+| `Framework/src/scene/RenderMesh.cpp` | Builds material/attribute keys for static meshes and requests common pass permutations. |
+| `Framework/src/scene/RenderSkinnedMesh.cpp` | Adds skinning key bits and compiles skinned variants. |
+| `Framework/src/video/d3d11/D3D11Shader.cpp` | D3D11 HLSL compile/cache/reflection/input-layout path. |
+| `Framework/src/video/d3d12/D3D12Shader.cpp` | D3D12 HLSL compile/cache/reflection/root-signature path. |
+| `Framework/src/video/gl/GLShader.cpp` | OpenGL GLSL compile/link or GL program-binary cache path. |
+| `Framework/src/video/vulkan/VulkanShader.cpp` | Vulkan HLSL-to-SPIR-V compile/cache/reflection/descriptor-layout path. |
+| `Framework/src/utils/ShaderDiskCache.cpp` | Cross-API on-disk shader artifact cache under `Shaders/.t8shadercache`. |
+| `Framework/src/utils/SPIRVReflection.cpp` | Lightweight SPIR-V reflection for Vulkan descriptor bindings and vertex inputs. |
+| `Framework/src/utils/ShaderPermutationDump.cpp` | Records requested `ShaderKey` permutations to JSON for offline/prewarm workflows. |
+| `T850/Assets/Shaders/*` | HLSL and GLSL shader sources plus `shader_permutations.json`. |
+
+## `ShaderKey`
+
+`ShaderKey` is a 64-bit bitfield in `T850/Framework/Descriptors.h`. It combines vertex layout, material features, global toggles, and pass type into one lookup key.
+
+Important details:
+
+- `ShaderKey(0)` means an empty valid key.
+- `ShaderKey()` means `0xFFFFFFFFFFFFFFFF` and is an invalid sentinel.
+- `BaseDriver::m_shaderCache` stores compiled `ShaderBase*` by `ShaderKey::bits`.
+- `BaseDriver::GetShader()` logs a cache miss with key bits and pass number.
+- Pass type uses bits 20-25: `PASS_SHIFT = 20`, `PASS_MASK = 0x3F << 20`.
+
+| Bit group | Meaning |
+|---|---|
+| Bits 0-4 plus 39-40 | Vertex layout bits: normals, tangents, binormals, UV0-UV3. |
+| Bits 5-11 plus 31-38 and 41 | Texture/material maps: diffuse, specular, gloss, normal, height, metallic, clearcoat, sheen, occlusion, specular, transmission, lightmap. |
+| Bits 12-14 | Special modes such as no-light, fresnel, omni shadows. |
+| Bits 15-19 | Effect toggles: parallax, shadows, SSAO, autofocus, god rays. |
+| Bits 20-25 | Mutually exclusive `PassType`. |
+| Bits 26-30 | Extended toggles: parallax shadow, glTF tangent convention, skinning modes. |
+
+`ShaderKey::VERTEX_ATTRIB_MASK` includes the bits that affect vertex input layout. `MaterialAsset.featureKey` deliberately strips `VERTEX_ATTRIB_MASK` and `PASS_MASK`, so material cache entries do not multiply by vertex layout or render pass.
+
+## Pass types
+
+`PassType` is a 6-bit enum. Common values include:
+
+| Pass | Purpose |
+|---|---|
+| `FORWARD` | Default lit mesh rendering. |
+| `GBUFFER` | Deferred geometry output. |
+| `SHADOW_MAP` | Depth/shadow pass. |
+| `RADIAL_DEPTH` | Radial/depth shadow or light-depth variant. |
+| `FSQUAD_1_TEX`, `FSQUAD_2_TEX`, `FSQUAD_3_TEX` | Fullscreen quad variants by texture input count. |
+| `DEFERRED`, `DEFERRED_LDR`, `DEFERRED_LIGHT_VOLUME` | Deferred composition/light volume passes. |
+| `BRIGHT`, `HDR_COMP`, `COC`, `DOF`, `GOD_RAY_*`, `SSAO`, `FADE`, `LENS_FLARE_*` | Post-processing and effects passes. |
+
+`ShaderBase::CreateShader()` maps pass values to defines such as `G_BUFFER_PASS`, `SHADOW_MAP_PASS`, `FSQUAD_1_TEX`, `DEFERRED_PASS`, `RADIAL_DEPTH_PASS`, `GOD_RAY_BLEND_PASS`, and others.
+
+## Key creation flow for mesh shaders
+
+`RenderMesh::GatherInfo()` builds the base key for each material subset:
+
+1. Start with `ShaderKey(0)`.
+2. Add vertex layout bits from `xMeshGeometry::VertexAttributes`.
+3. Add material/texture bits from `xMaterial::EffectInstance.pDefaults`.
+4. Add material conventions such as `GLTF_TANGENT_SPACE`.
+5. Precompile a base material key and common pass variants.
+
+```mermaid
+flowchart TD
+  XGeom["xMeshGeometry::VertexAttributes"] --> VertexBits["HAS_NORMALS, HAS_TEXCOORD*, HAS_TANGENTS, HAS_BINORMALS"]
+  Material["xEffectDefault material entries"] --> FeatureBits["DIFFUSE_MAP, NORMAL_MAP, HEIGHT_MAP, etc."]
+  VertexBits --> SubsetKey["SubSetInfo::key"]
+  FeatureBits --> SubsetKey
+  SubsetKey --> Compile["BaseDriver::CreateShader"]
+  Compile --> Variants["FORWARD, GBUFFER, SHADOW_MAP, RADIAL_DEPTH"]
+  Variants --> Cache["BaseDriver::m_shaderCache"]
+```
+
+During draw, the final key is recomposed:
+
+1. Copy `SubSetInfo::key`.
+2. Set the current global pass from `gKey.getPass()`.
+3. OR in low feature bits from `gKey` using `(1 << PASS_SHIFT) - 1`.
+4. If the subset has `HEIGHT_MAP` and runtime parallax is enabled, add `PARALLAX` for `FORWARD` or `GBUFFER`.
+5. Call `BaseDriver::GetShader(finalKey)`.
+
+`RenderSkinnedMesh` adds `HAS_SKINNING_TEX` to each subset key, creates a bone texture, and recompiles the same mesh shader sources with skinning defines enabled. It also creates pass variants for `FORWARD`, `GBUFFER`, `SHADOW_MAP`, and `RADIAL_DEPTH`.
+
+## Defines generated from `ShaderKey`
+
+All backends pass through `ShaderBase::CreateShader()`, which prepends defines to the source before backend compilation.
+
+Common define mappings:
+
+| Key bit / pass | Define |
+|---|---|
+| `HAS_NORMALS` | `USE_NORMALS` |
+| `HAS_TEXCOORD0..3` | `USE_TEXCOORD0..3` |
+| `HAS_TANGENTS` / `HAS_BINORMALS` | `USE_TANGENTS` / `USE_BINORMALS` |
+| `DIFFUSE_MAP`, `NORMAL_MAP`, `HEIGHT_MAP`, etc. | Same-name map define, e.g. `DIFFUSE_MAP`, `NORMAL_MAP`, `HEIGHT_MAP`. |
+| `GLTF_TANGENT_SPACE` | `GLTF_TANGENT_SPACE` |
+| `HAS_SKINNING`, `HAS_SKINNING_QT`, `HAS_SKINNING_TEX` | `USE_SKINNING`, `USE_SKINNING_QT`, `USE_SKINNING_TEXTURE` |
+| `PARALLAX`, `SHADOWS`, `SSAO`, `AUTO_FOCUS`, `GOD_RAYS` | `ENABLE_PARALLAX`, `ENABLE_SHADOWS`, `ENABLE_SSAO`, `AUTO_FOCUS`, `ENABLE_GOD_RAYS` |
+| `PassType::GBUFFER` | `G_BUFFER_PASS` |
+| `PassType::SHADOW_MAP` | `SHADOW_MAP_PASS` |
+| `PassType::RADIAL_DEPTH` | `RADIAL_DEPTH_PASS` |
+
+For OpenGL, `ShaderBase::CreateShader()` also prepends `#version 330` or `#version 300 es` plus `ES_30`, depending on build/platform macros. D3D and Vulkan HLSL do not get GLSL version headers.
+
+## Source selection
+
+`BaseDriver::UsesGLSL()` returns true only for OpenGL. Vulkan is intentionally on the HLSL path.
+
+| Backend | Source files | Compile path |
+|---|---|---|
+| D3D11 | HLSL, e.g. `Shaders/VS_Mesh.hlsl`, `Shaders/FS_Mesh.hlsl` | `D3DCompile()` to `vs_5_0` / `ps_5_0`. |
+| D3D12 | HLSL | `D3DCompile()` to `vs_5_0` / `ps_5_0`, then root signature and PSO from reflection. |
+| Vulkan | HLSL | glslang with `EShSourceHlsl` to SPIR-V, entry points `VS` and `FS`. |
+| OpenGL | GLSL, e.g. `Shaders/VS_Mesh.glsl`, `Shaders/FS_Mesh.glsl` | GL shader compile/link or program-binary cache. |
+
+Important shader assets:
+
+- `VS_Mesh.hlsl` / `FS_Mesh.hlsl`
+- `VS_Mesh.glsl` / `FS_Mesh.glsl`
+- `VS_Quad.*` / `FS_Quad.*`
+- `VS_Text.*` / `FS_Text.*`
+- `VS_EditorLine.*` / `FS_EditorLine.*`
+- `VS_W.*` / `FS_W.*`
+- `FS_WireMesh.*`
+- `FS_LineFlat.*`
+- `shader_permutations.json`
+
+## Backend compilation and reflection
+
+### D3D11
+
+`D3D11Shader.cpp` compiles HLSL through `D3DCompile()`:
+
+- vertex shader entry point: `VS`, target `vs_5_0`;
+- pixel shader entry point: `FS`, target `ps_5_0`;
+- compiled artifacts are cached as `vs.dxbc` and `fs.dxbc`;
+- D3D reflection collects cbuffer bind slots;
+- VS reflection builds `D3D11_INPUT_ELEMENT_DESC` entries and creates the input layout;
+- `Set()` binds VS, PS, and input layout.
+
+### D3D12
+
+`D3D12Shader.cpp` also compiles HLSL to SM5 DXBC, but reflection is used more heavily:
+
+- VS reflection builds the input layout and vertex stride.
+- VS/FS reflection collects CBV/SRV/sampler resources.
+- `BuildRootSignature()` creates inline root CBV parameters and descriptor tables for SRV/samplers.
+- `Set()` binds descriptor heaps, root signature, and a cached PSO.
+
+The D3D12 PSO key includes:
+
+- shader pointer,
+- blend/depth/cull state,
+- topology,
+- color attachment count and formats,
+- depth format.
+
+### Vulkan
+
+`VulkanShader.cpp` compiles HLSL to SPIR-V through glslang:
+
+- glslang input language: HLSL;
+- entry points: `VS` and `FS`;
+- target: Vulkan 1.0 / SPIR-V 1.0;
+- automatic bindings and locations are enabled;
+- texture/sampler transform mode upgrades HLSL texture/sampler usage into Vulkan-compatible sampled images.
+
+On desktop Vulkan, the runtime shader disk cache stores `vs.spv` and `fs.spv`. On Android, the loader first tries precompiled SPIR-V candidates such as:
+
+- `Shaders/spirv/<shaderName>.<ShaderKey>.spv`
+- `Shaders/spirv/<shaderName>.spv`
+
+If precompiled SPIR-V is absent, runtime glslang compilation is attempted. No checked-in `Shaders/spirv/*.spv` files were present during this pass.
+
+`SPIRVReflection` parses the compiled module to classify:
+
+- uniform buffers,
+- sampled images,
+- vertex stage inputs,
+- cubemap sampled images.
+
+UBO bindings are shifted by `VulkanShader::kMaxTextureSlots` through `SPIRVReflection::ShiftUBOBindings()` so UBO bindings do not collide with texture binding slots. Vulkan then builds:
+
+- descriptor set layout from reflected UBO/image bindings,
+- pipeline layout from that descriptor set layout,
+- vertex input descriptions from reflected VS inputs.
+
+The Vulkan pipeline key includes:
+
+- shader pointer,
+- blend/depth/cull state,
+- topology,
+- vertex stride,
+- render target format/depth format,
+- render pass key.
+
+### OpenGL
+
+`GLShader.cpp` uses the GLSL shader sources:
+
+- attempts to load `program.glbin` if GL program binaries are supported;
+- otherwise compiles vertex/fragment shaders, links a program, and stores a binary when possible;
+- parses shader source to find attributes and uniforms;
+- queries attribute and uniform locations through GL;
+- `Set()` calls `glUseProgram()`, enables active vertex attributes, and disables stale attributes from a previous shader.
+
+OpenGL does not use engine SPIR-V, D3D reflection, root signatures, or explicit PSO objects.
+
+## Shader disk cache
+
+`ShaderDiskCache` stores artifacts under:
+
+```text
+Shaders/.t8shadercache/<api>/<sha1>/
+```
+
+The cache key includes:
+
+- cache format/version string,
+- API name,
+- driver signature,
+- `ShaderKey::bits`,
+- VS/FS names,
+- VS/FS source text after defines are prepended.
+
+The cache stores API-specific artifacts:
+
+| API | Artifact |
+|---|---|
+| D3D11 | `vs.dxbc`, `fs.dxbc` |
+| D3D12 | `vs.dxbc`, `fs.dxbc` |
+| Vulkan | `vs.spv`, `fs.spv` |
+| OpenGL | `program.glbin` |
+
+`metadata.json` stores driver signatures per API. If the signature for an API changes, that API's cache directory is cleared. This prevents reusing binaries across driver/device/compiler changes.
+
+## Shader permutation dump
+
+`ShaderPermutationDump` records permutations requested through `BaseDriver::CreateShader()`. This is useful for prewarm/offline workflows and for checking whether a runtime draw key has actually been requested.
+
+Enable it with:
+
+```text
+DayScene --dumpShaderPermutations --shaderPermutationOutput <path>
+```
+
+or with JSON config fields:
+
+```json
+{
+  "dumpShaderPermutations": true,
+  "shaderPermutationOutput": "Assets/Shaders/shader_permutations.json"
+}
+```
+
+`DayScene/App.cpp` starts recording before app/framework creation and flushes after creation instead of running the normal update loop. The output JSON records key bits, pass, shader filenames, and defines. Existing entries are merged by key.
+
+The checked-in `Assets/Shaders/shader_permutations.json` is an example/seed list of known requested permutations.
+
+## Resource binding conventions
+
+Mesh HLSL uses fixed register conventions. Examples from `VS_Mesh.hlsl` / `FS_Mesh.hlsl`:
+
+| Resource | Register |
+|---|---|
+| `MeshFrameCB` | `b0` |
+| `MeshInstanceCB` | `b1` |
+| `MeshMaterialCB` | `b2` |
+| `TextureRGB` | `t0` |
+| `TextureSpecular` | `t1` |
+| `TextureGloss` | `t2` |
+| `TextureNormal` | `t3` |
+| `texEnv` | `t4` |
+| `TextureHeight` | `t5` |
+| `TextureMetallic` | `t6` |
+| scene and IBL textures | `t7` through `t15` |
+| advanced PBR maps | `t16` through `t23` |
+| `BoneTexture` | `t24` |
+| `LightmapTex` | `t25` |
+| material samplers | `s0` and up |
+
+D3D backends use native register reflection. Vulkan reflects SPIR-V bindings after glslang auto-mapping and the engine UBO-binding shift. OpenGL uses names and locations.
+
+## PSO interaction
+
+D3D11 and OpenGL bind shader/program objects directly and keep most state mutable.
+
+D3D12 and Vulkan need explicit pipeline objects. T850 keeps shader compilation separate from PSO creation:
+
+1. Shader creation compiles source and reflects input/resources.
+2. Draw-time `Shader::Set()` asks the driver for a PSO/pipeline matching the current render state.
+3. The driver returns a cached object or creates a new one.
+
+```mermaid
+flowchart TD
+  ShaderSet["D3D12Shader/VulkanShader::Set"] --> State["Current blend/depth/cull/topology/RT state"]
+  State --> Key["PSO/pipeline key"]
+  Key --> Hit{"Cache hit?"}
+  Hit -->|yes| Bind["Bind PSO/pipeline"]
+  Hit -->|no| Create["CreateGraphicsPipelineState / vkCreateGraphicsPipelines"]
+  Create --> Bind
+```
+
+This means two draws with the same `ShaderKey` can still use different PSO objects if render target format, topology, culling, depth, blend, or render pass changes.
+
+## Extension points
+
+When adding shader features:
+
+1. Add a new `ShaderKey` bit if the feature changes compiled shader code.
+2. Add a define mapping in `ShaderBase::CreateShader()`.
+3. Set the bit from geometry/material/render state, usually in `RenderMesh::GatherInfo()` or a render-graph pass setup.
+4. Update HLSL and GLSL variants if the feature must support OpenGL.
+5. Update resource binding/reflection assumptions if new textures, buffers, or samplers are introduced.
+6. Add/prewarm representative permutations through `shader_permutations.json` or the dump workflow.
+7. Validate D3D12 and Vulkan PSO creation if the change affects input layout or resource layout.
+
+## Known limitations and gotchas
+
+- `ShaderKey()` is invalid by design. Use `ShaderKey(0)` when constructing a new key to set bits.
+- `EMISSIVE_MAP` aliases `REFLECT_MAP`, so emissive/reflect behavior shares one bit and define path.
+- `ShaderKey::VERTEX_ATTRIB_MASK` covers UV0-UV3 only; adding more UV channels requires new bits and layout handling.
+- D3D11/D3D12 shader model targets are hard-coded to `vs_5_0` and `ps_5_0`.
+- Vulkan desktop can compile HLSL at runtime when the SPIR-V cache misses. Android tries precompiled SPIR-V names first, then falls back to runtime compile.
+- OpenGL program binary caching only works if the driver reports program-binary support.
+- D3D12 and Vulkan PSO caches are keyed by shader pointer, not just `ShaderKey` bits, so destroying/recreating shaders invalidates PSO reuse.
+- Input layout is reflected from active shader inputs. If a define removes an input, the reflected stride/layout can change.
+- Adding a texture/resource changes D3D12 root signature and Vulkan descriptor set layout, not only shader source.
+
+## Debugging checklist
+
+1. Log or inspect the final `ShaderKey::bits` and `getPass()` used at draw time.
+2. Confirm `BaseDriver::CreateShader()` was called for that exact key before `GetShader()`.
+3. Check for `GetShader miss` logs.
+4. For mesh shaders, compare `xMeshGeometry::VertexAttributes`, `SubSetInfo::key`, `MeshAsset::vertexAttribMask`, and the reflected shader input layout.
+5. Check shader-cache logs: `[ShaderCache][D3D11]`, `[ShaderCache][D3D12]`, `[ShaderCache][Vulkan]`, `[ShaderCache][GL]`.
+6. For D3D compile failures, inspect the logged HLSL compiler error and the dumped define block.
+7. For Vulkan binding errors, enable/inspect SPIR-V reflection logs and compare `cbvBindings`, `srvBindings`, descriptor layout bindings, and shader registers.
+8. For D3D12 PSO failures, inspect the logged blend/depth/cull/topology/RT formats and root signature resources.
+9. For OpenGL issues, check shader link logs, active attribute locations, and stale attribute disable behavior.
+10. Regenerate or inspect `shader_permutations.json` if a runtime path is missing a prewarmed key.
 

--- a/documentation/rendering/textures-and-ibl.md
+++ b/documentation/rendering/textures-and-ibl.md
@@ -1,0 +1,477 @@
+# Textures, Samplers, and IBL Resources
+
+Status: Stage 17 draft.
+
+This document explains T850's texture loading and binding path, API-specific texture resources and samplers, material/environment texture slots, generated image-based lighting resources, and the scene/editor cubemap override workflow.
+
+Related documents:
+
+- [Resource locator and cache paths](../architecture/resource-locator.md)
+- [Shader management](shader-management.md)
+- [Render graph](render-graph.md)
+- [Geometry rendering flow](geometry-rendering-flow.md)
+- [Scene format and runtime](../scenes/scene-format-and-runtime.md)
+- [SceneSetup descriptors](../scenes/scene-setup-descriptors.md)
+- [FrameworkImGui runtime UI](../editor/imgui-system.md)
+
+## Purpose and responsibilities
+
+The texture system turns file or memory data into API resources that can be bound by mesh, quad, render-graph, ImGui, animation, and environment-lighting paths.
+
+It is responsible for:
+
+1. Loading regular textures and cubemaps from `Textures/`.
+2. Uploading memory-backed images from glTF, editor, generated resources, and debug helpers.
+3. Creating float textures for bone matrices and IBL LUTs.
+4. Creating float cubemaps for generated diffuse/specular/sheen IBL.
+5. Creating sampler state from `Texture::params`.
+6. Binding material, scene, environment, and IBL textures to stable shader slots.
+7. Caching generated IBL data under `Textures/GeneratedIBLCache`.
+
+```mermaid
+flowchart LR
+  Asset["texture path / memory buffer / generated floats"] --> TextureBase["Texture base helpers"]
+  TextureBase --> API["D3D11 / D3D12 / GL / Vulkan Texture"]
+  API --> Driver["BaseDriver::Textures slots"]
+  Driver --> Material["RenderMesh material slots"]
+  Driver --> RenderGraph["RenderGraph pass inputs"]
+  Driver --> IBL["EnvironmentMapSet / IBL slots"]
+  IBL --> Shader["mesh and quad shaders"]
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `Framework/include/video/BaseDriver.h` | Declares `Texture`, `Device::CreateTexture*`, `BaseDriver::CreateTexture*`, texture bind/update APIs, and render-target attachment formats. |
+| `Framework/src/video/BaseDriver.cpp` | Shared `Texture` loading from files/memory/cubemap memory, texture slot cache, destroy path, texture upload dump helper, and `BaseDriver::CreateTexture*` wrappers. |
+| `Framework/src/video/d3d11/D3D11Texture.cpp` / `Framework/src/video/d3d11/D3D11Device.cpp` | D3D11 texture upload, SRV/sampler creation, compressed DDS support, float textures/cubemaps, VS/PS binding. |
+| `Framework/src/video/d3d12/D3D12Texture.cpp` / `Framework/src/video/d3d12/D3D12Device.cpp` | D3D12 texture upload resources, SRV/sampler descriptors, compressed support, generated mip upload, float textures/cubemaps, update path. |
+| `Framework/src/video/gl/GLTexture.cpp` / `Framework/src/video/gl/GLDevice.cpp` | OpenGL texture upload, compressed support, GL sampler parameters, float texture/cubemap creation, shader uniform binding. |
+| `Framework/src/video/vulkan/VulkanTexture.cpp` / `Framework/src/video/vulkan/VulkanDevice.cpp` | Vulkan image/upload/sampler/image-view handling, BC decompression path, descriptor pending texture state, float textures/cubemaps. |
+| `Framework/include/scene/IBLResources.h` / `Framework/src/scene/IBLResources.cpp` | Environment IBL resource paths, generated IBL filters/LUTs, cache load/save, IBL texture creation, `SceneProps` IBL settings. |
+| `Framework/include/scene/RenderGraph.h` / `Framework/src/scene/RenderGraph.cpp` | Environment texture slots, material extension slots, pass input binding, environment binding to mesh/quad primitives. |
+| `Framework/include/scene/MaterialAsset.h` | Material texture slot enum and cached material texture ID/pointer records. |
+| `Framework/src/scene/RenderMesh.cpp` | Material texture loading, sampler params, material/env/IBL bind order, state-tracked dedup. |
+| `Framework/include/scene/SceneDescriptor.h` / `Framework/src/scene/SceneSetup.cpp` | Scene environment map and explicit IBL path fields loaded from descriptor JSON. |
+| `DayScene/SceneTemplate.cpp` | Runtime cubemap/profile selection, IBL load/regeneration, cubemap replacement, save-state cubemap path. |
+| `T8ditor/EditorApp.cpp` | Editor cubemap selector/profile path, deferred editor cubemap apply, editor fallback environment update. |
+
+## Shared Texture lifecycle
+
+`Texture` is the API-neutral base class. The common file path is:
+
+```mermaid
+flowchart TD
+  Driver["BaseDriver::CreateTexture(path)"] --> Device["Device::CreateTexture(path)"]
+  Device --> Texture["API Texture subclass"]
+  Texture --> Load["Texture::LoadTexture(path)"]
+  Load --> Exists["ResourceLocator::Exists(Textures/path)"]
+  Exists -->|missing| Checker["checker fallback"]
+  Exists -->|found| CIL["cil_load"]
+  CIL --> Props["props / cil_props / mipmaps / size"]
+  Props --> APIUpload{"compressed?"}
+  APIUpload -->|yes| Compressed["LoadAPITextureCompressed"]
+  APIUpload -->|no| Raw["LoadAPITexture"]
+  Raw --> Params["SetTextureParams"]
+  Compressed --> Params
+  Params --> Slot["BaseDriver::Textures slot"]
+```
+
+`Texture::LoadTexture(fn)` prepends `Textures/` to the requested name, checks the resource locator, and loads through `cil_load()`. If the file is missing, it uploads the built-in checker texture and logs an error.
+
+Common metadata:
+
+| Field | Meaning |
+|---|---|
+| `filepath` | Stored as `Textures/<requested path>` for file-backed loads. |
+| `props` | Engine channel flags such as `CH_RGB`, `CH_RGBA`, or `CH_ALPHA`. |
+| `params` | Engine sampler/wrap/filter flags such as `MIPMAPS`, `TILED`, `CLAMP_TO_EDGE`, `CLAMP_TO_BORDER`, `NEAREST_FILTER`, `LINEAR_FILTER`. |
+| `cil_props` | Loader flags such as cubemap, compressed, DXT format, half-float, RGB/RGBA. |
+| `x`, `y` | Base dimensions. |
+| `mipmaps` | Mip count reported by CIL or generated by the backend. |
+| `m_channels` | Source channel count. |
+
+`BaseDriver::CreateTexture()` reuses an existing non-null texture slot when `Textures[i]->filepath == "Textures/" + path`. Destroyed slots are reused for future textures.
+
+## File and memory creation APIs
+
+Texture creation entry points:
+
+| API | Use |
+|---|---|
+| `BaseDriver::CreateTexture(path)` | File-backed texture under `Textures/`. Deduplicates by stored `filepath`. |
+| `Device::CreateTexture(path)` | Backend allocation wrapper for a file-backed texture. |
+| `Texture::LoadTexture(fn)` | Shared file load, CIL decode, checker fallback, API upload dispatch. |
+| `Device::CreateTextureFromMemory(buff, w, h, channels, name)` | Memory-backed 2D texture, used by glTF/external decoded images and runtime-generated pixels. |
+| `Texture::LoadFromMemory(buff, w, h, channels, debugName)` | Shared memory metadata setup and API upload. |
+| `BaseDriver::CreateCubeMap(buff, w, h)` | Memory-backed RGBA cubemap. |
+| `BaseDriver::CreateFloatTexture(w, h, data)` | RGBA32F 2D texture for LUTs and bone/float data. |
+| `BaseDriver::CreateFloatCubeMap(size, mipCount, data)` | Face-major RGBA float cubemap with explicit mips for generated IBL. |
+
+Memory and generated textures are appended to `BaseDriver::Textures`; only file-backed `CreateTexture(path)` performs path-based deduplication.
+
+## CIL and DDS/cubemap loading
+
+The CIL loader is the texture file decoder used by `Texture::LoadTexture()` and IBL source cubemap filtering. It supplies:
+
+- dimensions,
+- mip count,
+- encoded buffer size,
+- channel/compression/format flags,
+- cubemap flag,
+- half-float flag,
+- compressed DXT flags.
+
+Backends branch on:
+
+| Flag/condition | Meaning |
+|---|---|
+| `CIL_COMPRESSED` | Upload with compressed path. |
+| `CIL_DXT1`, `CIL_DXT3`, `CIL_DXT5` | BC1/BC2/BC3 or GL compressed block format selection. |
+| `CIL_CUBE_MAP` | Six-face cubemap upload and cubemap SRV/image view. |
+| `CIL_HALF_FLOAT` | RGBA half-float source. |
+| `CIL_RGB`, `CIL_RGBA` | Source channel layout. |
+
+DDS cubemaps with mip chains are uploaded face-by-face and mip-by-mip when supported. Generated float IBL cubemaps are already in face-major, mip-major RGBA float layout expected by `CreateFloatCubeMap()`.
+
+## API-specific texture resources
+
+### D3D11
+
+D3D11 textures use:
+
+- `ID3D11Texture2D`,
+- `ID3D11ShaderResourceView`,
+- `ID3D11SamplerState`.
+
+Uncompressed uploads create `DXGI_FORMAT_R8_UNORM`, `DXGI_FORMAT_R16G16B16A16_FLOAT`, or `DXGI_FORMAT_R8G8B8A8_UNORM`. Source mip chains are passed as `D3D11_SUBRESOURCE_DATA`; otherwise D3D11 creates a mip-capable render-target texture and calls `GenerateMips()`.
+
+Compressed uploads use BC1/BC2/BC3 and explicit mip/face subresources.
+
+Float resources:
+
+- `CreateFloatTexture()` creates `DXGI_FORMAT_R32G32B32A32_FLOAT`, one mip, `CLAMP_TO_EDGE | NEAREST_FILTER`.
+- `CreateFloatCubeMap()` creates `DXGI_FORMAT_R32G32B32A32_FLOAT`, six faces, explicit mip count, `CLAMP_TO_EDGE | MIPMAPS`.
+
+Binding:
+
+- `Set()` calls `PSSetShaderResources(slot, 1, SRV)`.
+- `SetVS()` calls `VSSetShaderResources(slot, 1, SRV)`.
+- `SetSampler()` calls `PSSetSamplers(slot, 1, sampler)`.
+- `UpdateFloatData()` calls `UpdateSubresource()`.
+
+### D3D12
+
+D3D12 textures use:
+
+- default-heap `ID3D12Resource`,
+- upload heap resources for initial/per-frame data,
+- SRV descriptors in `D3D12Heap::CBV_SRV_UAV_VISIBLE`,
+- sampler descriptors resolved through `D3D12Driver::GetOrCreateSampler()`.
+
+For 8-bit uncompressed textures without source mips, D3D12 generates a CPU-side full mip chain before upload. Compressed textures upload BC1/BC2/BC3 block data to all face/mip subresources.
+
+Float resources:
+
+- `CreateFloatTexture()` creates `DXGI_FORMAT_R32G32B32A32_FLOAT`, persistent upload buffer, one SRV, `CLAMP_TO_EDGE | NEAREST_FILTER`.
+- `CreateFloatCubeMap()` creates `DXGI_FORMAT_R32G32B32A32_FLOAT`, six faces, explicit mips, SRV dimension `TEXTURECUBE`.
+
+Binding:
+
+- `Set()` looks up the shader's `srvSlots` root parameter by texture slot and calls `SetGraphicsRootDescriptorTable`.
+- `SetVS()` uses the same SRV slot map for vertex shader resources.
+- `SetSampler()` looks up the shader's `samplerSlots` root parameter by sampler slot and binds the sampler descriptor table.
+
+### OpenGL
+
+OpenGL textures use GL object IDs and shader uniform names.
+
+Uncompressed upload:
+
+- chooses `GL_RGBA16F` for half-float,
+- `GL_ALPHA`, `GL_RGB`, or `GL_RGBA` for regular sources,
+- uploads each cubemap face and mip with `glTexImage2D`,
+- generates mipmaps when the source has one or no mips.
+
+Compressed upload uses S3TC DXT1/DXT3/DXT5 formats and `glCompressedTexImage2D`.
+
+Float resources:
+
+- `CreateFloatTexture()` creates `GL_RGBA32F`, nearest filtering, clamp.
+- `CreateFloatCubeMap()` tries `GL_RGBA32F` first, then `GL_RGBA16F` fallback.
+
+Binding:
+
+- `Set()` and `SetVS()` call `glGetUniformLocation`, activate `GL_TEXTURE0 + slot`, bind the texture target, and set the sampler uniform to the slot.
+- `SetSampler()` is empty because sampler state is stored on the GL texture object through `SetTextureParams()`.
+
+### Vulkan
+
+Vulkan textures use:
+
+- `VkImage`,
+- VMA allocation,
+- `VkImageView`,
+- `VkSampler`,
+- staging buffers,
+- layout transitions,
+- pending descriptor state in `VulkanDriver::m_pendingTextures`.
+
+Important Vulkan differences:
+
+- RGB8 source textures are converted to RGBA8 because Vulkan RGB8 support is not assumed.
+- Vulkan can decompress DXT data to RGBA on the CPU path where direct compressed support is unsuitable.
+- `Set()` does not bind descriptors immediately. It records the image view and sampler into the driver's pending texture slot; the Vulkan shader/descriptor path commits them later.
+- `SetSampler()` is empty because samplers are part of the combined image sampler descriptor.
+
+Float resources:
+
+- `CreateFloatTexture()` creates `VK_FORMAT_R32G32B32A32_SFLOAT`, one mip, nearest clamp sampler.
+- `CreateFloatCubeMap()` uses `VK_FORMAT_R32G32B32A32_SFLOAT` on desktop/Linux/Windows and `VK_FORMAT_R16G16B16A16_SFLOAT` on Android to reduce mobile memory pressure.
+
+## Sampler parameter mapping
+
+Sampler state is rebuilt from `Texture::params` by each backend.
+
+| `Texture::params` | D3D11/D3D12 | GL | Vulkan |
+|---|---|---|---|
+| default | anisotropic, max 16 for regular 2D textures | linear mipmap linear, clamp, anisotropy for non-cubemaps | linear + linear mipmap, anisotropy when supported and not cube/special filter |
+| cubemap default | linear mipmap, anisotropy disabled | linear mipmap, clamp | linear mipmap, anisotropy disabled |
+| `NEAREST_FILTER` | point filter, `MaxLOD = 0` | nearest min/mag | nearest, nearest mip, `maxLod = 0` |
+| `LINEAR_FILTER` | linear min/mag with mip point, `MaxLOD = 0` | linear without mip chain when no mips | linear, nearest mip, `maxLod = 0` |
+| `TILED` | wrap | repeat | repeat |
+| `CLAMP_TO_EDGE` | clamp | clamp to edge | clamp to edge |
+| `CLAMP_TO_BORDER` | border, opaque white, linear mip | clamp to border, white border | clamp to border, opaque white |
+
+`RenderMesh::LoadTex()` sets `MIPMAPS` plus either `TILED` or `CLAMP_TO_EDGE`, then calls `SetTextureParams()` after the texture is loaded.
+
+## Material texture slots
+
+`MaterialAsset::MatTexSlot` mirrors the material texture pointer/id set used by `RenderMesh`.
+
+| Material asset slot | Shader key / draw slot |
+|---|---|
+| BaseColor | `DIFFUSE_MAP`, slot 0, `DiffuseTex` |
+| Specular | `SPECULAR_MAP`, slot 1, `SpecularTex` |
+| Gloss | `GLOSS_MAP`, slot 2, `GlossTex` |
+| Normal | `NORMAL_MAP`, slot 3, `NormalTex` |
+| Reflect | legacy material asset slot; environment map uses slot 4 separately |
+| Parallax | `HEIGHT_MAP`, slot 5, `HeightTex` |
+| Metallic | `METALLIC_MAP`, slot 6, `MetallicTex` |
+| Emissive | `EMISSIVE_MAP`, slot 8, `EmissiveTex` |
+| SheenColor | `SHEEN_COLOR_MAP`, slot 16, `SheenColorTex` |
+| SheenRoughness | `SHEEN_ROUGHNESS_MAP`, slot 17, `SheenRoughnessTex` |
+| Clearcoat | `CLEARCOAT_MAP`, slot 18, `ClearcoatTex` |
+| ClearcoatRoughness | `CLEARCOAT_ROUGHNESS_MAP`, slot 19, `ClearcoatRoughnessTex` |
+| Occlusion | `OCCLUSION_MAP`, slot 20, `OcclusionTex` |
+| SpecularFactor | `SPECULAR_FACTOR_MAP`, slot 21, `SpecularFactorTex` |
+| SpecularColor | `SPECULAR_COLOR_MAP`, slot 22, `SpecularColorTex` |
+| Transmission | `TRANSMISSION_MAP`, slot 23, `TransmissionTex` |
+| Lightmap | `LIGHTMAP_MAP`, slot 25, `LightmapTex` |
+
+Slot 24 is reserved for skinned bone textures. Scene depth and color are commonly bound at slots 7 and 9.
+
+Sampler slots used by mesh draw:
+
+- material sampler slot 0 for most material textures,
+- specific legacy sampler slots for slots 1-9,
+- lightmap sampler slot 7,
+- environment sampler slot 4,
+- IBL sampler slots use their texture slots.
+
+`MeshDrawStateTracker` skips redundant texture binds across subsets and across meshes inside a render-graph pass scope, but samplers are still submitted because backend shader sampler-slot lookup is cheap and backend-specific.
+
+## Render graph environment texture slots
+
+`RenderGraph.h` reserves environment slots:
+
+| Slot | Resource |
+|---|---|
+| 10 | `EnvironmentTextureSlot::DiffuseIBL` |
+| 11 | `EnvironmentTextureSlot::SpecularIBL` |
+| 12 | `EnvironmentTextureSlot::BrdfLUT` |
+| 13 | `EnvironmentTextureSlot::CharlieIBL` |
+| 14 | `EnvironmentTextureSlot::CharlieLUT` |
+| 15 | `EnvironmentTextureSlot::SheenELUT` |
+
+`RenderGraph::ExecutePass()` binds these resources when `bind_environment_map` is true. It chooses fallbacks:
+
+- `DiffuseIBL` falls back to sky,
+- `SpecularIBL` falls back to sky,
+- `CharlieIBL` falls back to explicit Charlie IBL, then specular IBL, then sky,
+- LUT slots are null when unavailable.
+
+Both quads and meshes can receive environment resources for a pass. Pass input textures from render targets are bound into the primitive texture array before drawing.
+
+## EnvironmentMapSet
+
+`EnvironmentMapSet` stores texture indices, not pointers:
+
+| Field | Meaning |
+|---|---|
+| `Sky` | The visible cubemap/environment map. |
+| `DiffuseIBL` | Lambertian filtered diffuse cubemap. |
+| `SpecularIBL` | GGX filtered specular cubemap. |
+| `BrdfLUT` | GGX BRDF integration LUT. |
+| `CharlieIBL` | Charlie/sheen filtered cubemap. |
+| `CharlieLUT` | Charlie LUT. |
+| `SheenELUT` | Sheen E LUT. |
+
+`SetFallback(textureIndex)` points sky, diffuse, specular, and Charlie IBL at the same cubemap and clears LUTs. This is the safe baseline before explicit or generated IBL resources are loaded.
+
+## IBL resource loading and generation
+
+`EnvironmentResourcePaths` contains optional explicit paths:
+
+- diffuse IBL,
+- specular IBL,
+- BRDF LUT,
+- sheen/Charlie IBL,
+- Charlie LUT,
+- sheen E LUT.
+
+`LoadEnvironmentIBLResources()` resolves environment data in this order:
+
+1. Load explicit descriptor paths when present.
+2. Try generated cache for diffuse/specular/Charlie cubemaps based on the current sky cubemap path.
+3. On desktop, generate missing diffuse/specular/Charlie cubemaps from the sky cubemap when possible.
+4. On Android, skip runtime generation and use cached assets or sky fallback.
+5. Load explicit LUT paths when present.
+6. Generate or load cached LUTs depending on platform.
+
+Generated constants:
+
+| Resource | Size/samples |
+|---|---|
+| diffuse Lambertian cubemap | 32x32, 1 mip, 128 samples |
+| GGX specular cubemap | 128x128, generated mip chain, 128 samples |
+| Charlie sheen cubemap | 128x128, generated mip chain, 128 samples |
+| GGX BRDF LUT | 256x256, 256 samples |
+| Charlie LUT | 256x256, 256 samples |
+| sheen E LUT | 256x256, 128 samples |
+
+Generated float data is cached under:
+
+```text
+Textures/GeneratedIBLCache/<kind>_v1_<hash>.t8ibl
+```
+
+Cache headers include magic `T8IBLF32`, cache version, kind, dimensions, face/mip/channel counts, sample count, and byte count. A mismatch logs a stale-cache message and regenerates or falls back.
+
+`UpdateSceneIBLSettings()` updates `SceneProps`:
+
+- `IBLMipCount` starts at 4 and uses specular texture mip count when available;
+- `IBLDiffuseMipLevel` is set to a high mip when diffuse falls back to sky;
+- `IBLBRDFLUTEnabled` is 1 when a BRDF LUT texture exists.
+
+## Scene descriptor and profile workflow
+
+`SceneDescriptor` has environment fields:
+
+| Field | Meaning |
+|---|---|
+| `environment_map` | Sky/environment cubemap path. |
+| `environment_diffuse_ibl` | Optional explicit diffuse IBL cubemap. |
+| `environment_specular_ibl` | Optional explicit specular IBL cubemap. |
+| `environment_brdf_lut` | Optional explicit GGX BRDF LUT. |
+| `environment_sheen_ibl` | Optional explicit Charlie/sheen cubemap. |
+| `environment_charlie_lut` | Optional explicit Charlie LUT. |
+| `environment_sheen_e_lut` | Optional sheen E LUT. |
+
+`SceneSetup::Load()` copies these fields into `SceneSetup` strings. Runtime scenes then build `EnvironmentResourcePaths` from those strings.
+
+`SandboxProfileDesc::cubemap_path` can override the startup cubemap. The runtime profile selection path normalizes this resource path and can map it back to the `cubemap` selector index.
+
+## SceneTemplate cubemap replacement flow
+
+SceneTemplate startup:
+
+1. Load the scene descriptor through `SceneSetup`.
+2. Resolve `startupCubemapPath` from `environment_map`, profile `cubemap_path`, selector defaults, or fallback `sky/Ennis.dds`.
+3. Load the sky cubemap with `BaseDriver::CreateTexture(startupCubemapPath)`.
+4. Call `EnvMaps.SetFallback(EnvMapTexIndex)`.
+5. Call `LoadEnvironmentIBLResources()` with descriptor IBL paths.
+6. Call `UpdateSceneIBLSettings()`.
+
+Runtime cubemap change:
+
+1. Wait for GPU to avoid destroying a texture still referenced by the previous frame.
+2. Create the new sky cubemap.
+3. Destroy the old environment texture if it differs.
+4. If descriptor IBL paths are empty, destroy generated diffuse/specular/sheen IBL textures so they can be regenerated or reloaded from cache for the new sky.
+5. Reset fallback, reload IBL resources, and update `SceneProps`.
+
+Quake3Mock and SandboxScene retain the same pattern.
+
+## T8ditor cubemap workflow
+
+T8ditor uses editor-specific selector helpers:
+
+- `EditorCubemapPathForSelectorIndex()` maps selector option to `sky/<option>`.
+- `EditorCubemapSelectorIndexForPath()` maps a resource path back to selector index.
+- `EditorCubemapSelectorIndexFromProfile()` reads profile selector overrides.
+
+`EditorApp::ApplyPendingEditorCubemap()`:
+
+1. Waits for GPU.
+2. Loads the new cubemap with `BaseDriver::CreateTexture()`.
+3. Destroys the old dummy environment map when safe.
+4. Updates `m_editorCurrentCubemapPath` and selector index.
+5. Creates an `EnvironmentMapSet` fallback from the new cubemap.
+6. Calls `UpdateSceneIBLSettings()` for editor scene props.
+7. Updates the deferred quad environment map when deferred resources are ready.
+
+The editor currently uses sky fallback for editor IBL rather than calling the full runtime `LoadEnvironmentIBLResources()` path.
+
+## Texture debugging
+
+Useful logs and diagnostics:
+
+- `Texture creation failed: '<path>'` from `BaseDriver::CreateTexture()`.
+- `Texture '<path>' not found, loading checker` from `Texture::LoadTexture()`.
+- backend-specific upload/SRV/sampler errors from D3D11/D3D12/GL/Vulkan texture files;
+- `[IBL] Loaded cached...`, `[IBL] Generated...`, or stale/truncated cache logs;
+- `T850_DUMP_TEXTURE_UPLOADS`, which writes uploaded textures as DDS plus metadata;
+- `RenderTrace`, which records texture/sampler binds and logical sampler signatures across APIs.
+
+## Extension rules
+
+When adding a material texture:
+
+1. Add a `MatTexSlot` entry if it must be cached in `MaterialAsset`.
+2. Add a render graph/material slot constant if it needs a fixed shader slot.
+3. Add shader key bits and material extraction from glTF/X data.
+4. Load the texture in `RenderMesh::Create()`/material gathering.
+5. Bind it in `RenderMesh::Draw()` with a stable shader texture name and sampler slot.
+6. Update shader resource declarations/reflection expectations.
+
+When adding an IBL resource:
+
+1. Add path fields to `EnvironmentResourcePaths` and `SceneDescriptor` if authorable.
+2. Add an `EnvironmentMapSet` slot and render graph slot.
+3. Update `LoadEnvironmentIBLResources()` and fallback rules.
+4. Include generation/cache version/key fields if the data is generated.
+5. Audit Android behavior; do not assume runtime generation is acceptable on mobile.
+
+## Known limitations and gotchas
+
+- `Texture::LoadTexture()` always prepends `Textures/`; callers should pass paths relative to that folder.
+- Missing textures load a checker fallback and can still produce a valid texture object.
+- File-backed texture dedup keys on stored `filepath`, so memory/generated textures are not deduplicated.
+- Texture `params` can be changed after load, but callers must call `SetTextureParams()` to rebuild backend sampler state.
+- Android skips runtime generated IBL and relies on cached/generated assets or sky fallback.
+- GL has its own shader names/uniform lookups; missing uniforms can silently skip non-bone binds.
+- Vulkan texture `Set()` records pending descriptors; actual descriptor commit happens later in the Vulkan shader path.
+- Slot 24 is reserved for bone textures; avoid assigning material or IBL resources there.
+
+## Debugging checklist
+
+1. Confirm the requested file path is relative to `Textures/` unless the caller intentionally bypasses `Texture::LoadTexture()`.
+2. Check whether the log says the checker fallback was used.
+3. Verify `cil_props`: cubemap, compressed, DXT type, half-float, and mip count.
+4. If sampling is wrong, check `Texture::params` and whether `SetTextureParams()` was called after changing params.
+5. If only one backend fails, compare format/mip/cubemap handling in the API texture implementation.
+6. If IBL is black or too sharp, check generated cache logs, `IBLMipCount`, `IBLDiffuseMipLevel`, and whether explicit IBL paths are empty.
+7. If Android lighting differs, verify `Textures/GeneratedIBLCache` contains packaged cache files or expect sky fallback.
+8. If shader binding differs across APIs, enable `T850_RENDER_TRACE` and compare texture/sampler bind events.

--- a/documentation/review-and-gaps.md
+++ b/documentation/review-and-gaps.md
@@ -1,0 +1,266 @@
+# Review and Gap Pass
+
+Status: Stage 12 draft.
+
+This document is the final documentation review pass for Stages 0-11. It records validation performed, coverage that looks solid, high-confidence gaps that remain, a troubleshooting index, and cross-subsystem limitations to keep visible for future agents.
+
+## Validation performed
+
+Validation completed in this pass:
+
+- Re-read current documentation map and stage plan.
+- Ran a Markdown relative-link audit across `documentation/**/*.md`; all relative links resolve.
+- Ran a code/file path reference audit for inline paths; corrected stale path references and re-ran successfully.
+- Reviewed completed subsystem docs against source inventories for architecture, geometry, shaders, render graph, geometry rendering, animation, physics, navigation, editor, scenes, and cross-system dependency map.
+- Ran two independent source-coverage review agents:
+  - one focused on documentation coverage;
+  - one focused on runtime subsystems that might be missing.
+- Directly checked flagged gap areas in source:
+  - `Framework/include/debug/*`
+  - `Framework/src/debug/*`
+  - `Framework/src/utils/ResourceLocator.cpp`
+  - `Framework/include/utils/InputManager.h`
+  - `Framework/include/utils/CameraProfiles.h`
+  - `Framework/include/utils/HandheldControllerOverlay.h`
+  - `FrameworkImGui/src/ImGuiSystem.cpp`
+  - `FrameworkImGui/src/DevGuiContext.cpp`
+
+## Coverage that looks strong
+
+These areas have enough detail for future agents to continue work confidently:
+
+| Area | Coverage |
+|---|---|
+| Architecture/platform lifecycle | [Main architecture](architecture/main-architecture.md), [Platform event loop](architecture/platform-event-loop.md) |
+| Geometry import to render-ready data | [Loading geometry](geometry/loading-geometry.md) |
+| Shader keys, shader cache, reflection, API-specific compilation | [Shader management](rendering/shader-management.md) |
+| Render graph schema and execution | [Render graph](rendering/render-graph.md) |
+| `PrimitiveInst`/mesh draw flow | [Geometry rendering flow](rendering/geometry-rendering-flow.md) |
+| Animation/skinning/bone texture | [Animation system](animation/animation-system.md) |
+| Jolt physics, ragdolls, static collision, character sweep controller | [Jolt physics](physics/jolt-physics.md) |
+| Recast/Detour navigation, volumes, links, `.t8nav` | [NavMesh and Detour](navigation/navmesh-detour.md) |
+| T8ditor authoring workflow | [Editor overview](editor/editor-overview.md) |
+| `.t8scene`, SceneTemplate, profiles, scene variants | [Scene format and runtime](scenes/scene-format-and-runtime.md) |
+| Cross-subsystem flows | [Dependency map](dependency-map.md) |
+| Resource lookup, Android packaged assets, generated cache paths | [Resource locator and cache paths](architecture/resource-locator.md) |
+| Input, controllers, camera profiles, and hosted viewport routing | [Input, camera, and controls](input/camera-and-controls.md) |
+| FrameworkImGui backend, runtime UI, and hosted scene panels | [FrameworkImGui runtime UI](editor/imgui-system.md) |
+| Texture loading, sampler state, IBL resources, and cubemap profiles | [Textures, samplers, and IBL](rendering/textures-and-ibl.md) |
+| SceneSetup descriptors, runtime control metadata, and `SceneProps` mapping | [SceneSetup descriptors](scenes/scene-setup-descriptors.md) |
+
+## High-confidence documentation gaps
+
+These are real gaps discovered by reviewing source coverage. They do not invalidate Stages 1-11, but they should become future documentation stages or appendix sections.
+
+### 1. Debug and diagnostics subsystem
+
+Addressed by [Debug and diagnostics](debug/diagnostics.md) in Stage 13. The notes below are retained as review history and as a checklist for future diagnostics changes.
+
+No dedicated document currently covers the diagnostic stack.
+
+Relevant code:
+
+- `Framework/include/debug/LoadingProgress.h`
+- `Framework/include/debug/RuntimeTelemetry.h`
+- `Framework/include/debug/FrameDumper.h`
+- `Framework/include/debug/RenderTrace.h`
+- `Framework/include/debug/Profiler.h`
+- `Framework/src/debug/RuntimeTelemetry.cpp`
+- `Framework/src/debug/FrameDumper.cpp`
+- `Framework/src/debug/FrameDumperIO.cpp`
+- `Framework/src/debug/RenderTrace.cpp`
+- `Framework/src/debug/Profiler.cpp`
+
+What to document:
+
+- loading progress snapshots and render callback,
+- runtime telemetry counters/timers/output JSON,
+- frame dump and replay snapshot format,
+- render trace events and PSO/shader/buffer/RT capture,
+- profiler scopes and draw-call counting,
+- how these systems are used from DayScene, SceneTemplate, T8ditor, render graph, physics, navigation, and shaders.
+
+Suggested future file:
+
+- `documentation/debug/diagnostics.md`
+
+### 2. Resource lookup and path resolution
+
+Addressed by [Resource locator and cache paths](architecture/resource-locator.md) in Stage 14. The notes below are retained as review history and as a checklist for future path/cache changes.
+
+Geometry docs mention `ResourceManager`, but there is no focused explanation of resource path normalization, lookup roots, Android packaged assets, cache path resolution, and recursive fallback behavior.
+
+Relevant code:
+
+- `Framework/include/utils/ResourceLocator.h`
+- `Framework/src/utils/ResourceLocator.cpp`
+- `Framework/src/utils/ResourceManager.cpp`
+- `Framework/src/scene/EditorSceneFile.cpp`
+
+What to document:
+
+- `Assets/` stripping and path normalization,
+- base path and cache path resolution,
+- desktop file lookup vs Android asset manager lookup,
+- case-insensitive Android asset fallback,
+- `ReadText`, `ReadBinary`, `Exists`, `ResolveFilePath`, `ResolveCachePath`,
+- how `.t8scene`, shader cache, mesh preprocess cache, `.t8jolt`, `.t8nav`, textures, and glTF buffers depend on this layer.
+
+Suggested future section/file:
+
+- add a "Resource lookup and cache paths" section to [Main architecture](architecture/main-architecture.md), or create `documentation/architecture/resource-locator.md`.
+
+### 3. Input, controller mapping, and camera profiles
+
+Addressed by [Input, camera, and controls](input/camera-and-controls.md) in Stage 15. The notes below are retained as review history and as a checklist for future input/camera changes.
+
+Input is mentioned in platform docs, but camera profile behavior and controller/handheld overlay paths are underdocumented.
+
+Relevant code:
+
+- `Framework/include/utils/InputManager.h`
+- `Framework/include/utils/CameraProfiles.h`
+- `Framework/src/utils/CameraProfiles.cpp`
+- `Framework/include/utils/HandheldControllerOverlay.h`
+- framework platform input paths in Windows/Linux/Android framework files.
+
+What to document:
+
+- keyboard/mouse/gamepad state model in `InputManager`,
+- active camera profiles: Orbit, Free Fly, Colliding Fly, Grounded FPS, COD FPS, Quake 3 FPS,
+- how SceneTemplate and editor select/use camera profiles,
+- handheld/controller overlay behavior,
+- Android/touch/controller differences.
+
+Suggested future file:
+
+- `documentation/input/camera-and-controls.md`
+
+### 4. FrameworkImGui runtime UI layer
+
+Addressed by [FrameworkImGui runtime UI](editor/imgui-system.md) in Stage 16. The notes below are retained as review history and as a checklist for future ImGui/backend changes.
+
+Stage 9 covers T8ditor's editor UI, but the reusable FrameworkImGui layer deserves explicit coverage.
+
+Relevant code:
+
+- `FrameworkImGui/include/imgui/ImGuiSystem.h`
+- `FrameworkImGui/src/ImGuiSystem.cpp`
+- `FrameworkImGui/include/imgui/DevGuiContext.h`
+- `FrameworkImGui/src/DevGuiContext.cpp`
+- editor hosted viewport code in `T8ditor/HostedViewportPanel.*`
+
+What to document:
+
+- SDL/Android platform backend setup,
+- renderer backend setup for D3D11/D3D12/GL/Vulkan,
+- docking and viewport enablement,
+- Android native window rebind,
+- `DevGuiContext`,
+- relationship between runtime debug UI and T8ditor panels.
+
+Suggested future file:
+
+- `documentation/editor/imgui-system.md` or `documentation/architecture/imgui-runtime.md`
+
+### 5. Texture, IBL, and material asset loading beyond mesh materials
+
+Addressed by [Textures, samplers, and IBL](rendering/textures-and-ibl.md) in Stage 17. The notes below are retained as review history and as a checklist for future texture/IBL changes.
+
+The geometry/shader/render docs cover material slots and texture binding, but not the broader texture and IBL loading path as a standalone topic.
+
+Relevant code:
+
+- API texture implementations under `Framework/src/video/*/*Texture.cpp`
+- texture creation in `BaseDriver.cpp`
+- IBL/environment slots in `RenderGraph.h`
+- SceneSetup environment map fields in `SceneDescriptor.h`
+- editor cubemap/profile selection in `EditorApp.cpp`
+
+What to document:
+
+- texture file formats and loader behavior,
+- cubemap/float texture paths,
+- IBL diffuse/specular/BRDF/Charlie/sheen LUT slots,
+- API-specific sampler behavior,
+- editor/runtime cubemap profile overrides.
+
+Suggested future section:
+
+- extend [Shader management](rendering/shader-management.md) or create `documentation/rendering/textures-and-ibl.md`.
+
+### 6. SceneSetup bridge details
+
+Addressed by [SceneSetup descriptors](scenes/scene-setup-descriptors.md) in Stage 18. The notes below are retained as review history and as a checklist for future descriptor changes.
+
+Stage 10 covers `SceneDescriptor` and `SceneSetup`, but future readers would benefit from a short deeper appendix because this is the old runtime descriptor path still used by DayScene/Quake3Mock/T8ditor render controls.
+
+Relevant code:
+
+- `Framework/include/scene/SceneDescriptor.h`
+- `Framework/src/scene/SceneDescriptor.cpp`
+- `Framework/include/scene/SceneSetup.h`
+- `Framework/src/scene/SceneSetup.cpp`
+
+What to add:
+
+- exact mapping from descriptor quality/settings to `SceneProps`,
+- how runtime UI sliders/checkboxes/selectors are defined by descriptor JSON,
+- how SceneTemplate combines `.t8scene` profiles with `SceneSetup`.
+
+Suggested location:
+
+- add a deeper appendix to [Scene format and runtime](scenes/scene-format-and-runtime.md).
+
+## Things checked that are not missing
+
+- No engine-owned audio subsystem was found under `Framework` or `DayScene`; only vendored/SDL audio references appear. There is no meaningful T850 audio system to document right now.
+- The physics documentation correctly states that current character movement is T850's kinematic sweep controller, not a direct Jolt `CharacterVirtual` wrapper.
+- The render docs correctly separate shader compilation/cache from D3D12/Vulkan PSO creation.
+- The navigation docs correctly distinguish baked `.t8nav` assets from generated cache files.
+
+## Troubleshooting index
+
+| Symptom | Start here |
+|---|---|
+| App does not create a window, input stalls, resize breaks | [Platform event loop](architecture/platform-event-loop.md) |
+| Mesh fails to load or has no geometry | [Loading geometry](geometry/loading-geometry.md) |
+| Mesh renders with wrong material/shader | [Shader management](rendering/shader-management.md), [Geometry rendering flow](rendering/geometry-rendering-flow.md) |
+| Render target or post-process pass is wrong | [Render graph](rendering/render-graph.md) |
+| Draw call exists but nothing appears | [Geometry rendering flow](rendering/geometry-rendering-flow.md) |
+| Skinned mesh does not animate | [Animation system](animation/animation-system.md) |
+| Ragdoll/physics body is missing | [Jolt physics](physics/jolt-physics.md) |
+| Character movement collides incorrectly | [Jolt physics](physics/jolt-physics.md), [Input, camera, and controls](input/camera-and-controls.md) |
+| NavMesh has no polygons or links | [NavMesh and Detour](navigation/navmesh-detour.md) |
+| T8ditor panel/action behaves incorrectly | [Editor overview](editor/editor-overview.md) |
+| Play Scene differs from editor | [Scene format and runtime](scenes/scene-format-and-runtime.md), [Editor overview](editor/editor-overview.md) |
+| Asset loads on desktop but not Android, or generated cache paths are confusing | [Resource locator and cache paths](architecture/resource-locator.md) |
+| Keyboard/gamepad/touch/camera profile behavior is wrong | [Input, camera, and controls](input/camera-and-controls.md), [Platform event loop](architecture/platform-event-loop.md) |
+| Runtime/editor ImGui, docking, platform-window, or hosted panel behavior is wrong | [FrameworkImGui runtime UI](editor/imgui-system.md), [Editor overview](editor/editor-overview.md) |
+| Texture, sampler, cubemap, or IBL output differs by backend/platform | [Textures, samplers, and IBL](rendering/textures-and-ibl.md), [Render graph](rendering/render-graph.md) |
+| Runtime UI descriptor control or profile override is ignored | [SceneSetup descriptors](scenes/scene-setup-descriptors.md), [Scene format and runtime](scenes/scene-format-and-runtime.md) |
+| Cross-subsystem change touches many files | [Dependency map](dependency-map.md) |
+
+## Cross-subsystem limitations summary
+
+These limitations appear in subsystem docs, but are worth keeping together:
+
+- `RenderQueue` is not the active mesh executor yet; `RenderMesh::Draw` still owns the draw walk.
+- D3D12/Vulkan PSO creation is draw-state dependent even when shader keys match.
+- Physics has no fixed-step accumulator/substep scheduler yet.
+- Physics layers are static/non-moving vs moving only.
+- Current character movement is a kinematic sweep controller, not direct Jolt `CharacterVirtual`.
+- Skinned mesh culling is conservative/limited because bind-pose bounds are not animation-aware.
+- Recast build is whole-mesh, not tiled streaming.
+- `.t8scene` unknown keys are ignored, so schema typos can be silent.
+- Hosted editor windows share some API resources and must be audited carefully for render-state isolation.
+- Resource path behavior differs between desktop filesystem lookup and Android packaged assets.
+
+## Recommended follow-up documentation stages
+
+1. **Stage 13** — Debug and diagnostics: loading progress, telemetry, frame dump/replay, render trace, profiler. Completed as [debug/diagnostics.md](debug/diagnostics.md).
+2. **Stage 14** — Resource locator and cache path architecture. Completed as [architecture/resource-locator.md](architecture/resource-locator.md).
+3. **Stage 15** — Input, controllers, handheld overlay, and camera profiles. Completed as [input/camera-and-controls.md](input/camera-and-controls.md).
+4. **Stage 16** — FrameworkImGui runtime UI and platform backend behavior. Completed as [editor/imgui-system.md](editor/imgui-system.md).
+5. **Stage 17** — Texture/IBL loading and sampler behavior. Completed as [rendering/textures-and-ibl.md](rendering/textures-and-ibl.md).
+6. **Stage 18** — SceneSetup/SceneDescriptor appendix with exact `SceneProps` mappings. Completed as [scenes/scene-setup-descriptors.md](scenes/scene-setup-descriptors.md).

--- a/documentation/scenes/scene-format-and-runtime.md
+++ b/documentation/scenes/scene-format-and-runtime.md
@@ -1,8 +1,464 @@
 # Scene Format and Runtime
 
-Status: planned.
+Status: Stage 10 draft.
 
-This document will cover `.t8scene`, editor serialization, SceneTemplate, DayScene, Quake3Mock, Quake3 Jolt, profiles, render graphs, and runtime differences.
+This document explains T850's scene formats and runtime scene loaders: `.t8scene`, editor serialization, `SceneTemplate`, legacy/runtime JSON descriptors, render graph references, profiles, cameras/lights/splines, physics, ragdolls, navigation, Quake3 scene variants, and the differences between DayScene, Quake3Mock, SceneTemplate, and editor Play Scene.
 
-See [stage-plan.md](../stage-plan.md#stage-10--scenes-and-formats).
+Related documents:
 
+- [Main architecture](../architecture/main-architecture.md)
+- [Resource locator and cache paths](../architecture/resource-locator.md)
+- [Input, camera, and controls](../input/camera-and-controls.md)
+- [FrameworkImGui runtime UI](../editor/imgui-system.md)
+- [Textures, samplers, and IBL](../rendering/textures-and-ibl.md)
+- [Dependency map](../dependency-map.md)
+- [SceneSetup descriptors](scene-setup-descriptors.md)
+- [Render graph](../rendering/render-graph.md)
+- [Loading geometry](../geometry/loading-geometry.md)
+- [Animation system](../animation/animation-system.md)
+- [Jolt physics](../physics/jolt-physics.md)
+- [NavMesh and Detour](../navigation/navmesh-detour.md)
+- [Editor overview](../editor/editor-overview.md)
+
+## Scene format families
+
+T850 currently has two important scene-description families.
+
+| Format | Primary structs | Main users | Purpose |
+|---|---|---|---|
+| `.t8scene` | `t850::scene::EditorSceneFile` | T8ditor, SceneTemplate, Play Scene | Authored game/editor scene with objects, cameras, physics, ragdolls, navigation, splines, profiles, lights, editor state. |
+| scene descriptor JSON | `t850::SceneDescriptor` | DayScene, Quake3Mock, SceneTemplate controls, editor rendering panel | Runtime/render settings descriptor: cameras, lights, Gauss kernels, splines, render quality, UI slider/checkbox/selector metadata, profiles. |
+| render graph JSON | `RenderGraphDesc` | All major scenes/editor | Data-driven render target/pass graph. See [Render graph](../rendering/render-graph.md). |
+
+```mermaid
+flowchart TD
+  T8ditor["T8ditor authored state"] --> T8Scene[".t8scene / EditorSceneFile"]
+  T8Scene --> SceneTemplate["SceneTemplate runtime"]
+  T8Scene --> Play["Play Scene temp export"]
+  SceneJson["SceneDescriptor JSON"] --> SceneSetup["SceneSetup"]
+  SceneSetup --> SceneProps["SceneProps controls/lights/cameras"]
+  RenderGraphJson["*_RenderGraph.json"] --> RenderGraph["RenderGraph"]
+  SceneTemplate --> RenderGraph
+  DayScene["DayScene"] --> RenderGraph
+  Quake["Quake3Mock"] --> RenderGraph
+```
+
+## Key files and classes
+
+| File/class | Role |
+|---|---|
+| `Framework/include/scene/EditorSceneFile.h` | Full `.t8scene` schema. |
+| `Framework/src/scene/EditorSceneFile.cpp` | `.t8scene` Glaze JSON load/save and mesh fallback resolution. |
+| `T8ditor/EditorScene.cpp` | Editor wrapper for save/load dialogs and scene file IO. |
+| `T8ditor/EditorApp.cpp` | Builds editor scene snapshots, loads editor scenes into editor state, exports Play Scene temp files. |
+| `T8ditor/EditorSceneSerialization.cpp` | Conversion helpers between editor/runtime structs and scene schema for NavMesh, physics, links, volumes. |
+| `Framework/include/scene/SceneDescriptor.h` | Runtime scene descriptor schema for settings, controls, lights, cameras, profiles. |
+| `Framework/src/scene/SceneDescriptor.cpp` | Glaze load/save for runtime `SceneDescriptor`. |
+| `Framework/include/scene/SceneSetup.h` and `Framework/src/scene/SceneSetup.cpp` | Builds cameras/lights/kernels/splines from `SceneDescriptor` and applies them to `SceneProps`. |
+| `documentation/scenes/scene-setup-descriptors.md` | Deep appendix for `SceneDescriptor`, `SceneSetup`, control metadata, profile overrides, and `SceneProps` mappings. |
+| `DayScene/SceneTemplate.cpp` | Main `.t8scene` runtime loader and long-term editor-authored scene runtime. |
+| `DayScene/DayScene.cpp` | Older runtime/demo scene with its own setup and benchmark matrix support. |
+| `DayScene/Quake3Mock.cpp` | Quake3-oriented runtime scene with Q3 collision/navigation/gameplay experiments. |
+| `Assets/Scenes/*.t8scene` | Authored scene examples such as `DayScene.t8scene`, `Nexus.t8scene`, and Q3 scenes. |
+| `Assets/Scenes/*_RenderGraph.json` | Render graph files referenced by scenes. |
+
+## `.t8scene` schema
+
+The `.t8scene` root maps to `EditorSceneFile`.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `version` | int | Scene format version. Current default is `1`. |
+| `collision` | string | Optional legacy/Q3 collision resource, e.g. `.t8q3clip`. |
+| `render_graph` | string | Optional render graph override path. |
+| `editor` | `EditorStateDesc` | Editor camera, view toggles, layout mode/data. |
+| `objects` | array | Mesh scene objects. |
+| `game_entities` | array | Higher-level entity links between mesh, physics, camera, AI, ragdoll. |
+| `physics_entities` | array | Authored runtime physics/player/character/static collision entities. |
+| `navigation_mesh` | optional object | Authored NavMesh settings, volumes, links, baked asset path. |
+| `splines` | array | Camera/agent path splines. |
+| `cameras` | array | Authored scene cameras. |
+| `light_cameras` | array | Authored shadow/God Rays light cameras. |
+| `camera_animations` | array | Timeline/keyframe camera animation data. |
+| `god_rays_volume` | optional object | Authored God Rays clipping volume. |
+| `lights` | array | Directional/omni lights, including optional Q3 source metadata. |
+| `profiles` | array | Runtime/profile overrides using `SandboxProfileDesc`. |
+
+Unknown JSON keys are ignored by Glaze on load, so older/newer scene files can carry extra metadata without failing immediately.
+
+## Object records
+
+`SceneObjectDesc` stores one render object.
+
+Important fields:
+
+- `name`
+- `mesh`
+- legacy `ragdoll`
+- `position`, `rotation`, `scale`
+- `visible`, `mobile_visible`, `frozen`, `show_wire`, `show_orientation`
+- Nav agent metadata: `nav_agent_front_yaw_offset_deg`, `nav_agent_face_yaw_sign`, `nav_agent_target_mode`, `nav_agent_follow_distance`, `nav_agent_side_offset`, `nav_agent_formation_depth_step`, `nav_agent_slot`
+- optional `physics`
+- optional `navigation`
+- optional `ragdoll_authoring`
+
+Runtime notes:
+
+- `SceneTemplate` skips invisible objects for rendering, except navigation source extraction can still include hidden objects when they have explicit navigation include metadata.
+- Android can skip objects with `mobile_visible == false`.
+- Rotation is stored in degrees in `.t8scene`; `PrimitiveInst` APIs also expect degrees for absolute rotation.
+- `mesh` is normalized through resource lookup/fallback logic.
+
+## Editor state and layout
+
+`EditorStateDesc` stores:
+
+- orbit camera target/yaw/pitch/distance,
+- `show_skybox`,
+- `show_wireframe`,
+- `allow_custom_layout`,
+- optional `imgui_layout`.
+
+T8ditor only stores scene-specific ImGui layout when `allow_custom_layout` is true. Otherwise the scene clears `imgui_layout` and the global ImGui layout is used.
+
+## Cameras, lights, splines, and God Rays
+
+`SceneCameraDesc`:
+
+- perspective/ortho type,
+- position and target,
+- FOV/ortho dimensions,
+- near/far planes,
+- visibility/frozen state.
+
+`SceneLightDesc`:
+
+- directional or omni/point type,
+- position/direction/color/intensity/radius,
+- enabled/visible/frozen,
+- optional `SceneQ3LightDesc` source metadata.
+
+`SceneLightCameraDesc`:
+
+- perspective/ortho light camera,
+- attached light index,
+- yaw rate,
+- visibility/frozen state.
+
+`SceneSplineDesc`:
+
+- named point list,
+- loop flag,
+- agent velocity/offset,
+- attached camera,
+- editor visibility/frozen/wire state.
+
+`SceneCameraAnimationDesc`:
+
+- target kind: camera or light camera,
+- camera index,
+- start time/duration/loop,
+- velocities,
+- optional keyframes for position/target/rotation/FOV/ortho size.
+
+`SceneGodRaysVolumeDesc`:
+
+- position and half extents,
+- assigned light camera,
+- enabled/clip/visible/frozen/wire flags,
+- authored marker.
+
+## Physics, ragdoll, and navigation metadata
+
+Physics:
+
+- Per-object `SceneObjectPhysicsDesc` is a quick object-owned physics request.
+- Top-level `ScenePhysicsEntityDesc` provides authored static triangle mesh, player, and character data.
+- `ScenePhysicsCookSettingsDesc` configures Jolt triangle mesh cook/cache behavior.
+- `ScenePhysicsCharacterDesc` stores runtime movement/character settings.
+
+Ragdoll:
+
+- Legacy `object.ragdoll` stores a direct ragdoll authoring asset path.
+- `object.ragdoll_authoring` stores richer metadata: enabled state, asset path, preview flag, drive-from-animation flag, runtime motion.
+- Runtime ragdoll authoring assets live under `Models/RagdollEdits`.
+
+Navigation:
+
+- Per-object `SceneObjectNavigationDesc` controls source inclusion/static/walkable/area/cost.
+- Top-level `SceneNavigationMeshDesc` stores build settings, runtime mode, baked asset, volumes, and authored off-mesh links.
+- Runtime modes are `build_cached`, `build`, and `baked_asset`.
+
+See [Jolt physics](../physics/jolt-physics.md) and [NavMesh and Detour](../navigation/navmesh-detour.md) for subsystem details.
+
+## Editor save path
+
+T8ditor writes `.t8scene` through `EditorApp::BuildEditorSceneSnapshot()` and `SaveEditorSceneSnapshot()`.
+
+```mermaid
+flowchart TD
+  EditorWorld["EditorWorld state"] --> Snapshot["BuildEditorSceneSnapshot"]
+  Snapshot --> Objects["objects + unloaded objects"]
+  Snapshot --> Metadata["physics/nav/ragdoll/splines/lights/cameras/profiles"]
+  Snapshot --> Layout["editor camera/layout state"]
+  Snapshot --> Save["SaveSceneToFile"]
+  Save --> FrameworkSave["SaveEditorSceneFile"]
+  FrameworkSave --> JSON["Glaze prettified JSON"]
+  JSON --> Disk[".t8scene"]
+```
+
+`BuildEditorSceneSnapshot()`:
+
+- starts from loaded scene file if available,
+- writes editor camera and layout state,
+- skips transient objects,
+- writes mesh objects and their authored metadata,
+- preserves unloaded scene objects,
+- writes game entities, splines, light cameras, camera animations, God Rays, physics entities, NavMesh, cameras, lights, collision path, and profiles,
+- upserts the current editor profile.
+
+`SaveEditorSceneFile()`:
+
+- serializes with `glz::write` and prettify,
+- creates parent directories,
+- writes the JSON file,
+- logs success/failure.
+
+## Editor load path
+
+`LoadEditorSceneFile()`:
+
+1. Reads JSON through `ResourceLocator`.
+2. Parses with Glaze, ignoring unknown keys.
+3. Resolves missing glTF mesh paths using fallback directories.
+4. Logs object/camera/light counts.
+
+`EditorApp::ApplyEditorUndoState()` and the scene-load path rebuild editor state from `EditorSceneFile`:
+
+- clear current objects, physics, ragdolls, NavMesh, groups, cameras, lights, splines,
+- recreate primitives through `ImportMesh()`,
+- apply transforms and metadata,
+- restore physics entities,
+- restore game entities,
+- restore light cameras/camera animations/God Rays,
+- restore NavMesh authoring,
+- restore cameras and lights,
+- restore editor camera/layout/profile state,
+- reconcile selection and groups.
+
+This same rebuild logic is used by scene-wide undo snapshots.
+
+## Play Scene temporary export
+
+Play Scene writes a temporary `.t8scene` and runs it through `SceneTemplate`.
+
+Flow:
+
+1. If authored NavMesh is dirty, regenerate it first.
+2. Create `%TEMP%\T850\T8ditorPlay`.
+3. Build a virtual editor scene snapshot.
+4. Save `play_scene_<timestamp>.t8scene`.
+5. Create hosted `SceneTemplate` with its own `EngineContext` and physics runtime.
+6. Restore editor state and delete the temp file when Play Scene closes.
+
+This makes Play Scene a high-fidelity test of the actual runtime `.t8scene` loader.
+The exported temp scene is later loaded like any other `.t8scene`; if the Play Scene window fails to launch, inspect both the export log and the temp path passed to `LoadSceneFromFile()` / SceneTemplate.
+
+## Runtime `.t8scene` load: SceneTemplate
+
+`SceneTemplate` is the long-term runtime for editor-authored scenes.
+
+Scene path selection:
+
+1. launch descriptor `sceneFilePath`,
+2. `g_config.sceneFilePath`,
+3. default `Scenes/Q3/q3dm6_mod_3_jolt.t8scene`.
+
+`CreateAssets()` pre-reads the scene file when present so it can:
+
+- select profiles,
+- select render graph override from `render_graph`,
+- apply startup profile render-target settings before creating render targets.
+
+Then it loads the render graph and render targets, creates primitive managers/quads, and loads the active scene/model.
+
+Runtime object load:
+
+1. Iterate visible scene objects, with Android mobile visibility filtering.
+2. Normalize mesh path.
+3. Create mesh through `PrimitiveManager::CreateMesh()`.
+4. Create `PrimitiveInst`, set scale/rotation/translation/visibility, and update transform.
+5. Process object physics metadata.
+6. Attach skinned ragdoll if authored.
+7. Store scene mesh paths, object names, navigation metadata, ragdoll metadata, nav agent metadata.
+8. Create top-level physics entities.
+9. Apply cameras/lights/profiles/navigation/player setup.
+
+SceneTemplate then drives:
+
+- render graph execution,
+- physics update integration from app context,
+- NavMesh build/cache/baked load,
+- nav agents,
+- splines,
+- ragdoll animation/physics handoff,
+- camera/profile controls,
+- debug overlays.
+
+`Quake3Mock` and `SandboxScene` also contain embedded editor-scene loading paths for compatibility and experiments. Both can load `.t8scene` through `LoadEditorSceneFile()`, infer or use Q3 collision clips from the scene `collision` field or mesh data, and then apply their own scene-specific runtime behavior. `RagdollEditor` is primarily profile/model-centric and normally loads `Scenes/RagdollEditor.json`, but it can pre-read embedded scene profiles when launched in an embedded-scene mode.
+
+## SceneDescriptor and SceneSetup
+
+`SceneDescriptor` is a separate runtime JSON format used for scene setup and editor rendering controls.
+
+It contains:
+
+- cameras,
+- light cameras,
+- lights,
+- Gaussian filters,
+- splines,
+- mesh paths,
+- environment/IBL resources,
+- quality settings,
+- scene settings,
+- UI slider/checkbox/selector descriptions,
+- profiles.
+
+`SceneSetup::Load()` parses it, builds runtime `Camera`, `GaussFilter`, `Spline`, and `SplineAgent` objects, and stores asset paths.
+
+`SceneSetup::Apply()` wires cameras, light cameras, lights, Gauss kernels, quality, and settings into `SceneProps`.
+
+T8ditor uses `Scenes/Quake3Mock.json` as the editor's runtime render-control descriptor for Look & Lighting. SceneTemplate uses `Scenes/SceneTemplate.json` for control setup and profile defaults.
+
+## Profiles
+
+Profiles use `SandboxProfileDesc` and can live in both scene descriptor JSON and `.t8scene`.
+
+Profiles can target:
+
+- platform,
+- architecture,
+- GPU family,
+- GPU name substring,
+- model path/key.
+
+They can override:
+
+- sliders,
+- checkboxes,
+- selectors,
+- lights,
+- animations,
+- cubemap path,
+- camera/orbit camera,
+- frustum culling/debug flags,
+- current keyframe.
+
+SceneTemplate scores runtime profile matches and applies base/model-specific/runtime profiles before render target creation and during scene load. T8ditor upserts the current editor scene profile when saving.
+
+## Render graph references
+
+`.t8scene` may set `render_graph`.
+
+If empty, runtimes use their defaults:
+
+- SceneTemplate default: `Scenes/SceneTemplate_RenderGraph.json`
+- DayScene default: `Scenes/DayScene_RenderGraph.json`
+- Quake3Mock default: `Scenes/Quake3Mock_RenderGraph.json`
+- T8ditor default: `Scenes/T8ditor_RenderGraph.json`
+
+SceneTemplate disables or toggles certain passes depending on render graph and scene properties, such as disabling `Light Add` for default SceneTemplate graph or toggling DOF passes based on `SceneProps.ToogleDOF`.
+
+## Runtime scene variants
+
+### DayScene
+
+DayScene is an older high-end demo/benchmark scene. It:
+
+- uses `DayScene_RenderGraph.json`,
+- supports benchmark/offscreen matrix workflows,
+- has its own runtime profile setup,
+- can now be represented by `Assets/Scenes/DayScene.t8scene`, but the C++ scene still owns much of its runtime/benchmark behavior.
+`DayScene.t8scene` is a useful example of authored render graph, objects, static physics, cameras, lights, light cameras, camera animations, God Rays, splines, and profiles in one file.
+
+### SceneTemplate
+
+SceneTemplate is the target runtime for `.t8scene` authored content. It loads editor-authored objects, physics, ragdolls, navigation, profiles, cameras, lights, splines, God Rays, and render graph overrides.
+
+### Quake3Mock
+
+Quake3Mock is a Quake3-inspired experimental scene. It uses:
+
+- Quake3 assets,
+- Q3 collision resources such as `.t8q3clip`,
+- Quake-style character movement and jump pads,
+- Quake3Mock render graph,
+- navigation and ragdoll experiments.
+
+### Quake3 Jolt `.t8scene`
+
+`Scenes/Q3/q3dm6_mod_3_jolt.t8scene` is the default SceneTemplate `.t8scene`. It combines:
+
+- Q3 map mesh,
+- `.t8q3clip` collision reference,
+- static triangle mesh physics,
+- player physics entity,
+- character/nav-agent game entity,
+- skinned ragdoll object,
+- ragdoll authoring asset,
+- NavMesh settings and authored links.
+
+This is the bridge between earlier Quake3Mock experiments and the long-term SceneTemplate path.
+
+### Nexus `.t8scene`
+
+`Nexus.t8scene` is a large editor-authored terrain/RTS-style test. It demonstrates:
+
+- hidden but navigation-included terrain,
+- static triangle mesh physics entity,
+- authored NavMesh include/exclude volumes,
+- runtime mode `build_cached`,
+- editor camera/layout state.
+
+### Other `.t8scene` examples
+
+`Scenes/Q3/q3dm6_mod_3.t8scene` is a Q3 authored scene without the full Jolt/NavMesh block used by `q3dm6_mod_3_jolt.t8scene`; it is useful for comparing pre-Jolt and Jolt-enabled authoring. Several scenes include `profiles` sections so render/camera/material behavior can be adjusted without hardcoding per-platform variants.
+
+## Extension points
+
+When extending scene formats:
+
+1. Add fields to `EditorSceneFile.h`.
+2. Update `BuildEditorSceneSnapshot()` to save the data.
+3. Update editor load/restore paths to apply the data.
+4. Update SceneTemplate runtime load to consume the data.
+5. Add conversion helpers in `EditorSceneSerialization.cpp` if mapping between editor/runtime structs is non-trivial.
+6. Update Play Scene export if the data must be included in temporary runtime scenes.
+7. Update cache keys for systems affected by the new data, such as NavMesh or physics cooked assets.
+8. Update this documentation and examples.
+
+## Known limitations and gotchas
+
+- `.t8scene` and `SceneDescriptor` are different formats and are both actively used.
+- Unknown `.t8scene` keys are ignored, so typos may silently do nothing.
+- SceneTemplate skips invisible render objects, but hidden explicitly included navigation sources can still matter when authored correctly.
+- SceneTemplate caps runtime mesh slots through `kMaxSandboxMeshes`.
+- `render_graph` is optional; empty means default graph.
+- Legacy `object.ragdoll` and newer `ragdoll_authoring` both exist.
+- Rotation units differ by layer: `.t8scene` stores degrees for object/camera authoring, while many runtime fields use radians internally.
+- Play Scene uses a temporary `.t8scene`; if behavior differs, inspect the exported file.
+- DayScene/Quake3Mock still contain significant hardcoded runtime behavior outside `.t8scene`.
+
+## Debugging checklist
+
+1. If a scene does not load, check `LoadEditorSceneFile()` logs for read/parse errors.
+2. If a mesh path fails, check resource normalization and fallback directories.
+3. If objects are missing at runtime, check visibility, `mobile_visible`, and `kMaxSandboxMeshes`.
+4. If render output differs, verify `render_graph` path and active profiles.
+5. If physics differs, inspect both object `physics` metadata and top-level `physics_entities`.
+6. If ragdoll does not attach, verify the mesh is skinned and the ragdoll authoring asset path resolves.
+7. If navigation differs, check object navigation flags, top-level `navigation_mesh`, runtime mode, baked asset path, volumes, and links.
+8. If Play Scene differs from editor, inspect the temp `.t8scene` exported under `T850/T8ditorPlay`.
+9. If editor undo restores unexpected state, inspect `BuildEditorSceneSnapshot()` and `ApplyEditorUndoState()`.
+10. If a profile does not apply, check target fields and model key matching.

--- a/documentation/scenes/scene-format-and-runtime.md
+++ b/documentation/scenes/scene-format-and-runtime.md
@@ -1,0 +1,8 @@
+# Scene Format and Runtime
+
+Status: planned.
+
+This document will cover `.t8scene`, editor serialization, SceneTemplate, DayScene, Quake3Mock, Quake3 Jolt, profiles, render graphs, and runtime differences.
+
+See [stage-plan.md](../stage-plan.md#stage-10--scenes-and-formats).
+

--- a/documentation/scenes/scene-setup-descriptors.md
+++ b/documentation/scenes/scene-setup-descriptors.md
@@ -1,0 +1,424 @@
+# SceneSetup and Runtime Control Descriptors
+
+Status: Stage 18 draft.
+
+This document is the deeper appendix for T850's legacy/runtime `SceneDescriptor` and `SceneSetup` path. It explains the exact mapping from descriptor JSON into `SceneProps`, how runtime UI metadata is consumed, how cameras/lights/splines/environment fields are built, how SceneTemplate combines `.t8scene` content with descriptor-driven controls, and where older scene variants still depend on this path.
+
+Related documents:
+
+- [Scene format and runtime](scene-format-and-runtime.md)
+- [Main architecture](../architecture/main-architecture.md)
+- [Resource locator and cache paths](../architecture/resource-locator.md)
+- [Input, camera, and controls](../input/camera-and-controls.md)
+- [FrameworkImGui runtime UI](../editor/imgui-system.md)
+- [Textures, samplers, and IBL](../rendering/textures-and-ibl.md)
+- [Render graph](../rendering/render-graph.md)
+- [Editor overview](../editor/editor-overview.md)
+
+## Purpose and responsibilities
+
+`SceneDescriptor` is the older runtime JSON descriptor format used for render controls and scene setup defaults. It does not replace `.t8scene`; instead, it supplies runtime/editor control metadata, quality settings, cameras/lights/splines, environment paths, and profile overrides that several scenes still use.
+
+`SceneSetup` is the loader/applier for that descriptor:
+
+```mermaid
+flowchart TD
+  Json["Assets/Scenes/*.json"] --> Load["LoadSceneDescriptor"]
+  Load --> Descriptor["SceneDescriptor"]
+  Descriptor --> SceneSetup["SceneSetup::Load"]
+  SceneSetup --> Owned["owned cameras, light cameras, gauss filters, splines, agents"]
+  SceneSetup --> Paths["mesh/environment/IBL path strings"]
+  SceneSetup --> Apply["SceneSetup::Apply / ApplyQualityAndSettings"]
+  Apply --> SceneProps["SceneProps"]
+  Descriptor --> UI["sliders / checkboxes / selectors / profiles"]
+  UI --> DrawDevGui["scene/editor DrawDevGui"]
+```
+
+## Key files and examples
+
+| File | Role |
+|---|---|
+| `Framework/include/scene/SceneDescriptor.h` | JSON-serializable descriptor structs. |
+| `Framework/src/scene/SceneDescriptor.cpp` | Glaze read/write through `ResourceLocator::ReadText` and `WriteText`. |
+| `Framework/include/scene/SceneSetup.h` | `SceneSetup` owned runtime objects, descriptor copy, and environment path strings. |
+| `Framework/src/scene/SceneSetup.cpp` | Descriptor load, object construction, `SceneProps` mapping, and `SaveState`. |
+| `Assets/Scenes/DayScene.json` | Descriptor for the older DayScene runtime. |
+| `Assets/Scenes/SceneTemplate.json` | Control descriptor used by SceneTemplate. |
+| `Assets/Scenes/Quake3Mock.json` | Control descriptor used by Quake3Mock and T8ditor rendering panel defaults. |
+| `Assets/Scenes/SandboxScene.json` | Control descriptor used by SandboxScene. |
+| `Assets/Scenes/RagdollEditor.json` | Control descriptor used by RagdollEditor and hosted mesh/ragdoll editing views. |
+
+## Descriptor families and ownership
+
+`SceneDescriptor` contains:
+
+| Field group | Struct(s) | Meaning |
+|---|---|---|
+| cameras | `CameraDesc` | Runtime camera definitions. |
+| light cameras | `CameraDesc` | Shadow/God Rays/light camera definitions. |
+| lights | `LightDesc` | Directional and point light definitions. |
+| filters | `GaussFilterDesc` | Blur kernels for shadow, bloom, DOF, or scene-specific effects. |
+| splines | `SplineDesc`, `SplinePointDesc` | Camera/agent path splines and runtime agent defaults. |
+| meshes | `std::vector<std::string>` | Model paths; copied by `SceneSetup` but instantiated by scene code. |
+| environment | string fields | Sky cubemap and optional explicit IBL resource paths. |
+| quality | `QualityDesc` | Render-quality settings copied into `SceneProps`. |
+| settings | `SceneSettingsDesc` | Runtime render/lighting/material toggles copied into `SceneProps`. |
+| controls | `SliderDesc`, `CheckboxDesc`, `SelectorDesc` | Runtime UI metadata consumed by scene/editor panels. |
+| profiles | `SandboxProfileDesc` | Platform/model/GPU-specific override sets. |
+
+`SceneSetup` owns vectors of constructed cameras, light cameras, Gauss filters, splines, and spline agents. `SceneProps` stores pointers into those vectors after `SceneSetup::Apply()`, so `SceneSetup` is intentionally non-copyable.
+
+## Load flow
+
+`SceneSetup::Load(jsonPath)`:
+
+1. Resets `descriptor`, path strings, and owned vectors.
+2. Calls `LoadSceneDescriptor(jsonPath, descriptor)`.
+3. Copies descriptor name, mesh paths, and environment path fields into `SceneSetup`.
+4. Builds owned cameras.
+5. Builds owned light cameras.
+6. Builds owned Gauss filters and calls `GaussFilter::Update()`.
+7. Builds owned splines and spline agents.
+8. Logs object counts.
+
+`LoadSceneDescriptor()` uses `ResourceLocator::ReadText()` and Glaze with `error_on_unknown_keys = false`. Unknown JSON keys are ignored.
+
+## Built object mapping
+
+### Cameras and light cameras
+
+For each `CameraDesc` in `cameras` and `light_cameras`:
+
+| Descriptor field | Runtime mapping |
+|---|---|
+| `position` | Used as the camera position and assigned to `Camera::Eye`. |
+| `eye` | Serialized, but `SceneSetup::Load()` currently ignores it and uses `position`. |
+| `ortho` | Chooses `Camera::InitOrtho` vs `Camera::InitPerspective`. |
+| `width`, `height` | Orthographic dimensions when `ortho` is true. |
+| `fov`, `aspect` | Perspective projection values when `ortho` is false. |
+| `near_plane`, `far_plane` | Projection near/far planes. |
+| `left_handed` | Passed into camera initialization. |
+| `speed` | Assigned to `Camera::Speed`. |
+| `pitch`, `roll`, `yaw` | Assigned after initialization, then `Update(0.0f)` runs. |
+
+`SceneSetup::Apply()` adds all built cameras with `SceneProps::AddCamera()` and all light cameras with `SceneProps::AddLightCamera()`.
+
+### Lights
+
+For each `LightDesc`:
+
+| Descriptor field | Runtime mapping |
+|---|---|
+| `type == "directional"` | Calls `SceneProps::AddDirectionalLight(direction, color, intensity, enabled)`. |
+| any other `type` | Calls `SceneProps::AddLight(position, color, radius, intensity, LIGHT_POINT, enabled)`. |
+| `position` | Used for point lights. |
+| `direction` | Used for directional lights. |
+| `color` | Used for both directional and point lights. |
+| `radius` | Used for point lights. |
+| `intensity` | Used for both. |
+| `enabled` | Used for both. |
+
+Directional light `position` and `radius` are currently ignored by `SceneSetup::Apply()`.
+
+### Gauss filters
+
+For each `GaussFilterDesc`:
+
+| Descriptor field | Runtime mapping |
+|---|---|
+| `kernel_size` | `GaussFilter::kernelSize` |
+| `radius` | `GaussFilter::radius` |
+| `sigma` | `GaussFilter::sigma` |
+
+After assignment, `GaussFilter::Update()` is called. `SceneSetup::Apply()` adds the built filters to `SceneProps` through `AddGaussKernel()`.
+
+### Splines and agents
+
+For each `SplineDesc`:
+
+| Descriptor field | Runtime mapping |
+|---|---|
+| `points[].position` | Appended as `SplinePoint(x, y, z)`. |
+| `points[].velocity` | Stored on the appended spline point. |
+| `looped` | `Spline::m_looped`. |
+| `agent_offset` | Passed to `SplineAgent::SetOffset()`. |
+| `agent_velocity` | Assigned to `SplineAgent::m_velocity`. |
+| `attached_camera` | Stored in descriptor only; scene code consumes it where needed. |
+
+`SceneSetup::Load()` calls `Spline::Init()`, assigns each agent's `m_pSpline`, sets `m_moving = true`, and stores agent velocity.
+
+### Environment fields
+
+`SceneSetup::Load()` copies these strings:
+
+| Descriptor field | SceneSetup field | Typical consumer |
+|---|---|---|
+| `environment_map` | `environmentMap` | Runtime/editor cubemap load path. |
+| `environment_diffuse_ibl` | `environmentDiffuseIBL` | Explicit diffuse IBL path. |
+| `environment_specular_ibl` | `environmentSpecularIBL` | Explicit specular IBL path. |
+| `environment_brdf_lut` | `environmentBrdfLUT` | Explicit GGX BRDF LUT path. |
+| `environment_sheen_ibl` | `environmentSheenIBL` | Explicit Charlie/sheen IBL path. |
+| `environment_charlie_lut` | `environmentCharlieLUT` | Explicit Charlie LUT path. |
+| `environment_sheen_e_lut` | `environmentSheenELUT` | Explicit sheen E LUT path. |
+
+The actual texture creation happens in scene code through `BaseDriver::CreateTexture()` and `LoadEnvironmentIBLResources()`, not inside `SceneSetup`.
+
+## Exact `quality` to `SceneProps` mapping
+
+`SceneSetup::ApplyQualityAndSettings()` copies `QualityDesc` fields into `SceneProps`:
+
+| `QualityDesc` field | `SceneProps` field / behavior |
+|---|---|
+| `shadow_map_resolution` | `ShadowMapResolution` |
+| `god_rays_resolution` | `GoodRaysResolution` |
+| `pcf_scale` | `PCFScale` |
+| `pcf_samples` | `PCFSamples` |
+| `parallax_low_samples` | `ParallaxLowSamples` |
+| `parallax_high_samples` | `ParallaxHighSamples` |
+| `parallax_height` | `ParallaxHeight` |
+| `light_volume_steps` | `LightVolumeSteps` |
+| `ssao_radius` | `SSAOKernel.Radius`, then `SSAOKernel.Update()` |
+| `ssao_kernel_size` | `SSAOKernel.KernelSize`, then `SSAOKernel.Update()` |
+| `dof_near_samples` | `DOF_Near_Samples_squared` |
+| `dof_far_samples` | `DOF_Far_Samples_squared` |
+
+`GoodRaysResolution` is the current field name in `SceneProps` even though descriptor JSON names the concept `god_rays_resolution`.
+
+## Exact `settings` to `SceneProps` mapping
+
+`SceneSettingsDesc` fields map as follows:
+
+| `SceneSettingsDesc` field | `SceneProps` field / behavior |
+|---|---|
+| `exposure` | `Exposure` |
+| `bloom_factor` | `BloomFactor` |
+| `bloom_threshold` | `BloomThreshold` |
+| `tone_map_white_level` | `ToneMapWhiteLevel` |
+| `luminance_tau` | `LuminanceTau` |
+| `luminance_mode` | `LuminanceMode` |
+| `aperture` | `Aperture` |
+| `focal_length` | `FocalLength` |
+| `max_coc` | `MaxCoc` |
+| `ambient_color` | `AmbientColor` |
+| `active_lights` | `ActiveLights` |
+| `shadow_enabled` | `ToogleShadow` |
+| `ssao_enabled` | `ToogleSSAO` |
+| `dof_enabled` | `ToogleDOF` |
+| `parallax_enabled` | `ToogleParallax` |
+| `godrays_enabled` | `ToogleGodRays` |
+| `debug_mode` | `DebugMode` |
+| `auto_focus` | `AutoFocus` |
+| `shadow_bias` | `ShadowBias` |
+| `shadow_min` | `ShadowMin` |
+| `env_factor` | `EnvFactor` |
+| `ibl_factor` | `IBLFactor` |
+| `godrays_factor` | `GodRaysFactor` |
+| `light_radius_scale` | `LightRadiusScale` |
+| `light_intensity_scale` | `LightIntensityScale` |
+| `material_emissive_intensity` | `MaterialEmissiveIntensity` |
+| `material_transmission_multiplier` | `MaterialTransmissionMultiplier` |
+| `material_refraction_strength` | `MaterialRefractionStrength` |
+| `lightmap_intensity` | `LightmapIntensity` |
+| `point_lights_enabled` | `PointLightsEnabled` when present; otherwise defaults to true. |
+
+After applying descriptor settings, `ActiveGaussKernel` is reset to `0`.
+
+## UI control metadata
+
+Descriptor UI metadata defines how runtime/editor panels should present controls; it does not automatically bind controls by itself.
+
+| Metadata struct | Fields | Meaning |
+|---|---|---|
+| `SliderDesc` | `name`, `label`, `min_val`, `max_val`, `step`, `default_val` | Slider presentation metadata. |
+| `CheckboxDesc` | `name`, `label`, `default_val`, `enabled` | Checkbox presentation metadata. |
+| `SelectorDesc` | `name`, `label`, `options`, `default_index` | Combo/selector presentation metadata. |
+
+Panel code consumes these arrays by name:
+
+1. Iterate descriptor metadata.
+2. Find the name in a scene-specific mapping table.
+3. Read the current runtime value from `SceneProps` or scene-local state.
+4. Draw through `DevGuiContext::Slider`, `Checkbox`, or `Combo`.
+5. Write changed values back to `SceneProps`, render graph pass state, camera state, animation state, or scene-local flags.
+
+Unknown `name` values are ignored by those mapping loops.
+
+`default_val` and `default_index` are UI/default metadata. The actual runtime initial values come from `quality`, `settings`, scene startup state, profile overrides, or explicit scene code.
+
+## Common runtime control names
+
+The active scenes use overlapping, name-based mappings. Common slider names include:
+
+| Name | Typical target |
+|---|---|
+| `exposure` | `SceneProps::Exposure` |
+| `bloom_factor` | `SceneProps::BloomFactor` |
+| `bloom_threshold` | `SceneProps::BloomThreshold` |
+| `tm_white_level` | `SceneProps::ToneMapWhiteLevel` |
+| `tm_adapt_tau` | `SceneProps::LuminanceTau` |
+| `pcf_radius` | `SceneProps::PCFScale` |
+| `pcf_samples` | `SceneProps::PCFSamples` |
+| `ssao_kernel_size` | `SceneProps::SSAOKernel.KernelSize` + `Update()` |
+| `ssao_radius` | `SceneProps::SSAOKernel.Radius` |
+| `dof_aperture` | `SceneProps::Aperture` |
+| `dof_focal_length` | `SceneProps::FocalLength` |
+| `dof_max_coc` | `SceneProps::MaxCoc` |
+| `dof_far_samples` | `SceneProps::DOF_Far_Samples_squared` |
+| `dof_near_samples` | `SceneProps::DOF_Near_Samples_squared` |
+| `gauss_kernel_radius` | Active `GaussFilter::radius` + `Update()` |
+| `gauss_kernel_deviation` | Active `GaussFilter::sigma` + `Update()` |
+| `fov` | Active camera FOV |
+| `shadow_bias` | `SceneProps::ShadowBias` |
+| `shadow_min` | `SceneProps::ShadowMin` |
+| `env_factor` | `SceneProps::EnvFactor` |
+| `ibl_factor` | `SceneProps::IBLFactor` |
+| `lightmap_intensity` | `SceneProps::LightmapIntensity` |
+| `material_emissive_intensity` | `SceneProps::MaterialEmissiveIntensity` |
+| `material_transmission_multiplier` | `SceneProps::MaterialTransmissionMultiplier` |
+| `material_refraction_strength` | `SceneProps::MaterialRefractionStrength` |
+
+SceneTemplate/Quake3Mock/Sandbox/RagdollEditor also expose scene-specific names such as `anim_speed`; DayScene exposes extra parallax shadow controls.
+
+Common checkbox names:
+
+| Name | Typical target |
+|---|---|
+| `shadow_toggle` | `SceneProps::ToogleShadow` |
+| `ssao_toggle` | `SceneProps::ToogleSSAO` |
+| `dof_toggle` | `SceneProps::ToogleDOF` plus DOF render graph pass enablement in DayScene |
+| `dof_auto_focus` | `SceneProps::AutoFocus` |
+| `parallax_toggle` | `SceneProps::ToogleParallax` plus mesh parallax state in DayScene |
+| `parallax_shadow_toggle` | `SceneProps::ToogleParallaxShadow` / shadow strength |
+| `godrays_toggle` | `SceneProps::ToogleGodRays` |
+| `point_lights_enabled` | `SceneProps::PointLightsEnabled` |
+| `show_wireframe`, `show_skeleton`, `show_physics`, `show_navmesh`, `show_light_volumes` | Scene-local debug flags. |
+| `debug_luminance` | `SceneProps::DebugLuminanceEnabled`. |
+
+Common selector names:
+
+| Name | Typical target |
+|---|---|
+| `cubemap` | Current cubemap selector and pending cubemap path. |
+| `debug_render_target` | Debug RT selection. |
+| `gauss_kernel_sample_count` | Active `GaussFilter::kernelSize` + `Update()`. |
+| `active_gauss_kernel` | Active gauss kernel index. |
+| `luminance_mode` | `SceneProps::LuminanceMode`. |
+| `num_lights` | `SceneProps::ActiveLights` in DayScene. |
+| `active_camera` | Active camera selection in DayScene. |
+| `anim_select`, `anim_mode` | Current skinned animation set/mode in SceneTemplate-like scenes. |
+
+## Profiles
+
+`SandboxProfileDesc` is the descriptor's override format for runtime-specific state:
+
+| Field | Meaning |
+|---|---|
+| `name` | Profile label. |
+| `platform`, `architecture`, `gpu_family`, `gpu_name_contains`, `model` | Matching filters used by runtime profile selection code. |
+| `sliders` | `FloatOverrideDesc` name/value overrides. |
+| `checkboxes` | `BoolOverrideDesc` name/value overrides. |
+| `selectors` | `IntOverrideDesc` name/value overrides. |
+| `lights` | Per-light transform/color/intensity/attachment overrides. |
+| `animations` | Per-animation override state. |
+| `cubemap_path` | Explicit environment map override. |
+| `camera`, `orbit_camera` | Camera/profile pose override state. |
+| `frustum_culling`, `show_culling_debug`, `current_keyframe` | Runtime debug/animation state. |
+
+Profiles use the same `name` strings as slider/checkbox/selector metadata. Scene code computes sparse profile diffs by comparing current state to a baseline profile state, then stores only changed overrides.
+
+## SceneTemplate and `.t8scene` composition
+
+SceneTemplate combines two systems:
+
+1. `.t8scene` / `EditorSceneFile` supplies authored world content: objects, physics, ragdolls, navigation, lights, cameras, splines, editor state, and scene-local profile data.
+2. `SceneSetup` / `SceneDescriptor` supplies runtime render-control schema, quality defaults, environment defaults, selectors, and profile override machinery.
+
+Startup flow:
+
+```mermaid
+flowchart TD
+  Descriptor["Scenes/SceneTemplate.json"] --> ControlSetup["m_controlSetup.Load"]
+  ControlSetup --> Quality["ApplyQualityAndSettings(SceneProp)"]
+  T8Scene[".t8scene"] --> Assets["LoadEditorSceneAssets"]
+  T8Scene --> Profiles["embedded scene/profile overrides"]
+  Profiles --> Cubemap["ResolveStartupCubemapSelection"]
+  ControlSetup --> Env["environment_map and IBL paths"]
+  Env --> IBL["LoadEnvironmentIBLResources"]
+  Assets --> Runtime["SceneTemplate runtime"]
+```
+
+The descriptor does not author the world objects for SceneTemplate; it provides the control/render baseline around the `.t8scene` world.
+
+## Existing scene dependencies
+
+| Scene/tool | Descriptor dependency |
+|---|---|
+| DayScene | Owns `m_sceneSetup`, applies full setup, uses descriptor sliders/checkboxes/selectors, and can call `SaveState("Scenes/DayScene.json")`. |
+| SceneTemplate | Owns `m_controlSetup`, applies quality/settings, uses descriptor environment/IBL and UI metadata, then combines with `.t8scene` content. |
+| Quake3Mock | Owns `m_controlSetup`, loads `Scenes/Quake3Mock.json`, uses the same control/profile pattern as SceneTemplate. |
+| SandboxScene | Owns `m_controlSetup`, loads `Scenes/SandboxScene.json`, uses the same control/profile pattern as Quake3Mock. |
+| RagdollEditor | Owns `m_controlSetup`, loads `Scenes/RagdollEditor.json`, uses descriptor controls in runtime/hosted editor contexts. |
+| T8ditor | Uses `m_editorSceneSetup` and often loads `Scenes/Quake3Mock.json` for the editor rendering panel control metadata and defaults. Mesh Edit has its own `m_meshEditorSceneSetup`. |
+
+## SaveState behavior
+
+`SceneSetup::SaveState(scene, jsonPath)` writes runtime state back into the already-loaded descriptor and then calls `SaveSceneDescriptor()`.
+
+It saves:
+
+- camera and light camera transforms/projection parameters,
+- light position/direction/color/radius/intensity/enabled/type,
+- Gauss filter kernel/radius/sigma,
+- `quality` fields listed above,
+- `settings` fields listed above,
+- optional `point_lights_enabled` only when it differs from the default true value.
+
+It does not save:
+
+- `meshPaths`,
+- environment path strings,
+- slider/checkbox/selector metadata,
+- profiles,
+- splines or spline agents,
+- `.t8scene` authored objects/physics/navigation/ragdolls,
+- scene-local debug flags that are not mapped through `SceneProps`.
+
+`SaveState()` is therefore a runtime descriptor state writer, not a full scene authoring save path.
+
+## Extension rules
+
+When adding a new descriptor field:
+
+1. Add the field to `SceneDescriptor.h`.
+2. Update `SceneSetup::Load()` if it becomes an owned object or copied path.
+3. Update `ApplyQualityAndSettings()` if it maps into `SceneProps`.
+4. Update `SaveState()` if runtime edits should persist back to descriptor JSON.
+5. Update scene/editor `DrawDevGui()` mapping tables if the field is exposed through UI metadata.
+6. Update this document and [scene-format-and-runtime.md](scene-format-and-runtime.md).
+
+When adding a new UI control:
+
+1. Add a slider/checkbox/selector metadata entry to the descriptor JSON.
+2. Add name-to-setting mapping in every scene/tool that should respond to it.
+3. Add get/set behavior for that setting.
+4. Decide whether profiles should store sparse overrides for it.
+5. Avoid relying on `default_val` alone for runtime initialization; set initial state in `quality`, `settings`, profile overrides, or scene code.
+
+## Known limitations and gotchas
+
+- Unknown descriptor JSON keys are ignored by Glaze, so typos can be silent.
+- `CameraDesc::eye` is saved but currently ignored on load; `position` drives runtime `Camera::Eye`.
+- UI metadata is not self-binding. Each scene must map control names manually.
+- Descriptor profiles and `.t8scene` profiles overlap conceptually but are applied by scene-specific code.
+- `SaveState()` is partial and does not write profiles or authored `.t8scene` content.
+- `SceneSetup::Apply()` appends cameras/lights/kernels into `SceneProps`; callers should avoid applying repeatedly without resetting target state.
+
+## Debugging checklist
+
+1. If a JSON setting appears ignored, verify its key exists in `SceneDescriptor.h` and in the scene-specific mapping table.
+2. If a UI slider appears but does nothing, check the `desc.name` mapping and get/set lambdas in the scene's `DrawDevGui()`.
+3. If startup render quality is wrong, check `SceneSetup::ApplyQualityAndSettings()` before profile overrides.
+4. If cubemap/IBL selection is wrong, check `environment_map`, profile `cubemap_path`, selector `cubemap`, and the scene's cubemap resolution helper.
+5. If a saved descriptor does not include a field, check whether `SaveState()` writes that field.
+6. If SceneTemplate differs from T8ditor Play Scene, check both the `.t8scene` export and the `Scenes/SceneTemplate.json` control descriptor.
+

--- a/documentation/stage-plan.md
+++ b/documentation/stage-plan.md
@@ -78,7 +78,7 @@ Must cover:
 
 Target files:
 
-- `T850/Framework/include/Descriptors.h`
+- `T850/Framework/Descriptors.h`
 - shader key definitions.
 - `T850/Framework/src/utils/ShaderDiskCache.cpp`
 - `T850/Framework/src/utils/SPIRVReflection.cpp`
@@ -198,6 +198,8 @@ Output:
 
 - [physics/jolt-physics.md](physics/jolt-physics.md)
 
+Status: draft complete.
+
 Must cover:
 
 - Jolt setup.
@@ -222,6 +224,8 @@ Output:
 
 - [navigation/navmesh-detour.md](navigation/navmesh-detour.md)
 
+Status: draft complete.
+
 Must cover:
 
 - Recast build.
@@ -245,6 +249,8 @@ Target files:
 Output:
 
 - [editor/editor-overview.md](editor/editor-overview.md)
+
+Status: draft complete.
 
 Must cover:
 
@@ -276,6 +282,8 @@ Output:
 
 - [scenes/scene-format-and-runtime.md](scenes/scene-format-and-runtime.md)
 
+Status: draft complete.
+
 Must cover:
 
 - `.t8scene` schema.
@@ -291,15 +299,177 @@ Must cover:
 
 Outputs:
 
+- [dependency-map.md](dependency-map.md)
 - Updated links in every document.
 - Class dependency diagrams.
 - End-to-end flows across subsystems.
+
+Status: draft complete.
 
 ## Stage 12 — Review and gap pass
 
 Outputs:
 
+- [review-and-gaps.md](review-and-gaps.md)
 - TODO/gap list.
 - Troubleshooting index.
 - Known limitations.
 - Validation of class names and file paths.
+
+Status: draft complete.
+
+## Stage 13 — Debug and diagnostics
+
+Target files:
+
+- `T850/Framework/include/debug/LoadingProgress.h`
+- `T850/Framework/include/debug/RuntimeTelemetry.h`
+- `T850/Framework/include/debug/FrameDumper.h`
+- `T850/Framework/include/debug/RenderTrace.h`
+- `T850/Framework/include/debug/Profiler.h`
+- `T850/Framework/src/debug/*`
+- call sites in `DayScene`, `SceneTemplate`, `T8ditor`, render graph, shader, physics, and navigation code.
+
+Output:
+
+- [debug/diagnostics.md](debug/diagnostics.md)
+
+Status: draft complete.
+
+Must cover:
+
+- Loading progress snapshots and loading-frame rendering.
+- Runtime telemetry scopes, counters, output JSON, and benchmark usage.
+- Frame dump/replay snapshot flow and render target dump entries.
+- Render trace events for shaders, PSOs, buffers, render targets, textures, and draw calls.
+- Profiler scopes, draw-call counting, and runtime diagnostics workflow.
+- Debugging checklist for stalled loads, missing dumps, bad telemetry, or trace mismatch.
+
+## Stage 14 — Resource lookup and cache paths
+
+Target files:
+
+- `T850/Framework/include/utils/ResourceLocator.h`
+- `T850/Framework/src/utils/ResourceLocator.cpp`
+- `T850/Framework/src/utils/ResourceManager.cpp`
+- path users in shader cache, mesh preprocess cache, Jolt mesh cache, NavMesh cache, scene loading, texture loading, glTF buffers, and Android asset lookup.
+
+Output:
+
+- [architecture/resource-locator.md](architecture/resource-locator.md)
+
+Status: draft complete.
+
+Must cover:
+
+- Resource path normalization and `Assets/` stripping.
+- Base path, cache path, and resolved file path rules.
+- Desktop filesystem lookup versus Android asset manager lookup.
+- Case-insensitive Android packaged-asset fallback.
+- `ReadText`, `ReadBinary`, `Exists`, `ResolveFilePath`, `ResolveCachePath`, and recursive fallback APIs.
+- How cache-producing subsystems choose paths and invalidation keys.
+
+## Stage 15 — Input, controllers, and camera profiles
+
+Target files:
+
+- `T850/Framework/include/utils/InputManager.h`
+- platform input code under `T850/Framework/src/core/*`
+- `T850/Framework/include/utils/CameraProfiles.h`
+- `T850/Framework/src/utils/CameraProfiles.cpp`
+- `T850/Framework/include/utils/HandheldControllerOverlay.h`
+- scene/editor camera controller call sites in `SceneTemplate`, `DayScene`, `Quake3Mock`, and `T8ditor`.
+
+Output:
+
+- [input/camera-and-controls.md](input/camera-and-controls.md)
+
+Status: draft complete.
+
+Must cover:
+
+- Keyboard, mouse, controller, touch, and gamepad state flow.
+- Platform input translation into `InputManager`.
+- Camera profile set: Orbit, Free Fly, Colliding Fly, Grounded FPS, COD FPS, Quake 3 FPS.
+- Runtime profile selection and camera controller behavior.
+- Handheld/controller overlay behavior.
+- Editor versus runtime input routing, including hosted Play Scene/Mesh/Ragdoll windows.
+- Android and handheld-specific differences.
+
+## Stage 16 — FrameworkImGui runtime UI layer
+
+Target files:
+
+- `T850/FrameworkImGui/include/imgui/ImGuiSystem.h`
+- `T850/FrameworkImGui/src/ImGuiSystem.cpp`
+- `T850/FrameworkImGui/include/imgui/DevGuiContext.h`
+- `T850/FrameworkImGui/src/DevGuiContext.cpp`
+- T8ditor hosted viewport code and scene dev GUI call sites.
+
+Output:
+
+- [editor/imgui-system.md](editor/imgui-system.md)
+
+Status: draft complete.
+
+Must cover:
+
+- ImGui platform/backend initialization per API and platform.
+- Docking and viewport enablement.
+- Android native window binding/rebinding.
+- `DevGuiContext` and embedded panel helpers.
+- Relationship between runtime debug UI and T8ditor-specific panels.
+- Shutdown/reload hazards and hosted viewport integration.
+
+## Stage 17 — Textures, samplers, and IBL resources
+
+Target files:
+
+- API texture implementations under `T850/Framework/src/video/*/*Texture.cpp`
+- `T850/Framework/src/video/BaseDriver.cpp`
+- `T850/Framework/include/scene/IBLResources.h`
+- render graph environment slots in `T850/Framework/include/scene/RenderGraph.h`
+- material texture slots in `MaterialAsset` / `RenderMesh`
+- scene descriptor environment fields and editor cubemap/profile code.
+
+Output:
+
+- [rendering/textures-and-ibl.md](rendering/textures-and-ibl.md)
+
+Status: draft complete.
+
+Must cover:
+
+- Texture creation/loading from files and memory.
+- DDS/cubemap/float texture paths.
+- API-specific texture resource and sampler handling.
+- Mips, wrapping/filtering, SRV/sampler slots, and GL/D3D/Vulkan differences.
+- IBL resource slots: diffuse/specular/BRDF/Charlie/sheen resources.
+- Scene/profile/editor cubemap override workflow.
+- Texture debugging and common failure modes.
+
+## Stage 18 — SceneSetup and runtime control descriptors
+
+Target files:
+
+- `T850/Framework/include/scene/SceneDescriptor.h`
+- `T850/Framework/src/scene/SceneDescriptor.cpp`
+- `T850/Framework/include/scene/SceneSetup.h`
+- `T850/Framework/src/scene/SceneSetup.cpp`
+- JSON descriptor files under `T850/Assets/Scenes/*.json`
+- call sites in `DayScene`, `Quake3Mock`, `SandboxScene`, `RagdollEditor`, `SceneTemplate`, and `T8ditor`.
+
+Output:
+
+- [scenes/scene-setup-descriptors.md](scenes/scene-setup-descriptors.md)
+
+Status: draft complete.
+
+Must cover:
+
+- Exact mapping from `SceneDescriptor::quality` and `settings` to `SceneProps`.
+- Runtime UI slider/checkbox/selector metadata and how panels consume it.
+- Cameras, light cameras, lights, Gauss filters, splines, agents, environment maps, and IBL fields.
+- How SceneTemplate combines `.t8scene` profiles with `SceneSetup`.
+- How DayScene/Quake3Mock/Sandbox/RagdollEditor still depend on this older descriptor path.
+- SaveState behavior and limitations.

--- a/documentation/stage-plan.md
+++ b/documentation/stage-plan.md
@@ -60,6 +60,8 @@ Output:
 
 - [geometry/loading-geometry.md](geometry/loading-geometry.md)
 
+Status: draft complete.
+
 Must cover:
 
 - glTF / GLB path.
@@ -87,6 +89,8 @@ Output:
 
 - [rendering/shader-management.md](rendering/shader-management.md)
 
+Status: draft complete.
+
 Must cover:
 
 - `ShaderKey`.
@@ -110,6 +114,8 @@ Target files:
 Output:
 
 - [rendering/render-graph.md](rendering/render-graph.md)
+
+Status: draft complete.
 
 Must cover:
 
@@ -138,6 +144,8 @@ Output:
 
 - [rendering/geometry-rendering-flow.md](rendering/geometry-rendering-flow.md)
 
+Status: draft complete.
+
 Must cover:
 
 - `PrimitiveInst` to draw call.
@@ -162,6 +170,8 @@ Target files:
 Output:
 
 - [animation/animation-system.md](animation/animation-system.md)
+
+Status: draft complete.
 
 Must cover:
 

--- a/documentation/stage-plan.md
+++ b/documentation/stage-plan.md
@@ -1,0 +1,295 @@
+# Engine Documentation Stage Plan
+
+This plan breaks the full engine documentation effort into focused stages. Each stage should be small enough for a local agent to inspect a narrow set of files and produce one high-quality Markdown document.
+
+## Stage 0 — Documentation skeleton
+
+Outputs:
+
+- [README.md](README.md)
+- [doc-conventions.md](doc-conventions.md)
+- [glossary.md](glossary.md)
+- `documentation/` folder structure.
+
+Status: complete.
+
+## Stage 1 — Main architecture
+
+Target files:
+
+- `T850/Framework/include/core/*`
+- `T850/Framework/src/core/*`
+- `T850/Framework/include/scene/SceneProp.h`
+- `T850/Framework/src/scene/SceneProp.cpp`
+- `T850/Framework/include/scene/Primitive*.h`
+- `T850/Framework/src/scene/Primitive*.cpp`
+- scene app entry points under `T850/DayScene/`
+
+Output:
+
+- [architecture/main-architecture.md](architecture/main-architecture.md)
+- [architecture/platform-event-loop.md](architecture/platform-event-loop.md)
+
+Status: draft complete.
+
+Must cover:
+
+- Engine layers.
+- App lifecycle.
+- Scene versus Framework responsibilities.
+- Dev layer and debug UI.
+- Event loop.
+- Window ownership.
+- API/platform switching.
+- Windows, Android, Steam Deck differences.
+
+## Stage 2 — Loading Geometry
+
+Target files:
+
+- `T850/Framework/src/utils/gltf/*`
+- `T850/Framework/include/utils/gltf/*`
+- `T850/Framework/src/utils/XDataBase.cpp`
+- `T850/Framework/include/utils/XDataBase.h`
+- `T850/Framework/src/scene/RenderMesh.cpp`
+- `T850/Framework/include/scene/MeshAsset*.h`
+- `T850/Framework/src/scene/MeshAssetCache.cpp`
+- mesh pool and material cache files.
+
+Output:
+
+- [geometry/loading-geometry.md](geometry/loading-geometry.md)
+
+Must cover:
+
+- glTF / GLB path.
+- `.x` legacy path.
+- `XDataBase` as intermediate.
+- Vertex attributes.
+- Index buffer selection.
+- Material extraction.
+- Texture loading.
+- Static versus skinned detection.
+- Mesh cache and GPU upload.
+
+## Stage 3 — Shader management
+
+Target files:
+
+- `T850/Framework/include/Descriptors.h`
+- shader key definitions.
+- `T850/Framework/src/utils/ShaderDiskCache.cpp`
+- `T850/Framework/src/utils/SPIRVReflection.cpp`
+- API shader classes under `T850/Framework/src/video/*/*Shader.cpp`
+- shader assets under `T850/Assets/Shaders/`
+
+Output:
+
+- [rendering/shader-management.md](rendering/shader-management.md)
+
+Must cover:
+
+- `ShaderKey`.
+- Defines/permutations.
+- Pass keys.
+- HLSL sharing between D3D/Vulkan.
+- GLSL for GL.
+- Offline compilation/cache.
+- Reflection and resource binding.
+- Vulkan/D3D12 PSO considerations.
+
+## Stage 4 — Render graph
+
+Target files:
+
+- `T850/Framework/include/scene/RenderGraph*.h`
+- `T850/Framework/src/scene/RenderGraph*.cpp`
+- render graph JSON files in `T850/Assets/Scenes/`
+- `RenderQuad` / fullscreen pass code.
+
+Output:
+
+- [rendering/render-graph.md](rendering/render-graph.md)
+
+Must cover:
+
+- JSON schema.
+- Render targets.
+- Passes.
+- Inputs/outputs.
+- Push/pop RT.
+- State overrides.
+- Mesh versus quad draws.
+- Post-processing.
+- Final backbuffer pass.
+
+## Stage 5 — Rendering geometry flow
+
+Target files:
+
+- `PrimitiveInstance.*`
+- `RenderMesh.*`
+- `RenderSkinnedMesh.*`
+- `RenderQueue.*`
+- `MeshPool.*`
+- API buffer classes.
+
+Output:
+
+- [rendering/geometry-rendering-flow.md](rendering/geometry-rendering-flow.md)
+
+Must cover:
+
+- `PrimitiveInst` to draw call.
+- Transform composition.
+- VB/IB binding.
+- Material selection.
+- Shader selection.
+- State tracker.
+- PSO resolution.
+- DrawIndexed flow.
+- Wireframe/debug geometry path.
+
+## Stage 6 — Animation
+
+Target files:
+
+- `AnimationController.*`
+- `RenderSkinnedMesh.*`
+- glTF animation loading.
+- shader skinning paths.
+
+Output:
+
+- [animation/animation-system.md](animation/animation-system.md)
+
+Must cover:
+
+- Skeleton import.
+- Animation clips.
+- Interpolation.
+- Pose update.
+- Bone texture / constant data.
+- GPU skinning.
+- Snapshot/replay path.
+- Limitations and debug workflows.
+
+## Stage 7 — Physics
+
+Target files:
+
+- `T850/Framework/include/physics/*`
+- `T850/Framework/src/physics/*`
+- `RagdollEditorTool.*`
+- editor ragdoll panels.
+- SceneTemplate physics runtime sections.
+
+Output:
+
+- [physics/jolt-physics.md](physics/jolt-physics.md)
+
+Must cover:
+
+- Jolt setup.
+- Static triangle mesh cooking.
+- Physics authoring metadata.
+- Characters and CharacterVirtual.
+- Ragdoll binding.
+- Animation-to-ragdoll transition.
+- Collision layers.
+- Play Scene export.
+
+## Stage 8 — NavMesh and Detour
+
+Target files:
+
+- `NavigationSystem.*`
+- `NavigationDebugRenderer.*`
+- editor NavMesh authoring code.
+- SceneTemplate navigation runtime sections.
+
+Output:
+
+- [navigation/navmesh-detour.md](navigation/navmesh-detour.md)
+
+Must cover:
+
+- Recast build.
+- Detour query.
+- Source geometry.
+- Volumes/modifiers.
+- Area costs.
+- Link generation.
+- `.t8nav` bake/load.
+- Editor authoring workflow.
+
+## Stage 9 — Editor
+
+Target files:
+
+- `T850/T8ditor/*`
+- editor panel classes.
+- editor gizmo/camera/grid/scene files.
+- undo/redo.
+
+Output:
+
+- [editor/editor-overview.md](editor/editor-overview.md)
+
+Must cover:
+
+- Editor app lifecycle.
+- Panels.
+- Hierarchy.
+- Inspector.
+- Rendering panel.
+- Timeline.
+- Play Scene.
+- Mesh editor.
+- Ragdoll editor.
+- NavMesh authoring.
+- Undo/redo expectations.
+
+## Stage 10 — Scenes and formats
+
+Target files:
+
+- `EditorSceneFile.*`
+- `SceneSetup.*`
+- `SceneDescriptor.*`
+- `SceneTemplate.cpp`
+- `DayScene.cpp`
+- `Quake3Mock.cpp`
+- `.t8scene` examples.
+
+Output:
+
+- [scenes/scene-format-and-runtime.md](scenes/scene-format-and-runtime.md)
+
+Must cover:
+
+- `.t8scene` schema.
+- Editor save path.
+- Runtime load path.
+- SceneTemplate.
+- DayScene differences.
+- Quake3Mock/Jolt differences.
+- Profiles and render graph references.
+- Navigation/physics/animation/camera metadata.
+
+## Stage 11 — Cross-link and dependency pass
+
+Outputs:
+
+- Updated links in every document.
+- Class dependency diagrams.
+- End-to-end flows across subsystems.
+
+## Stage 12 — Review and gap pass
+
+Outputs:
+
+- TODO/gap list.
+- Troubleshooting index.
+- Known limitations.
+- Validation of class names and file paths.


### PR DESCRIPTION
## Summary
- Adds documentation stages 7 through 18 covering physics, navigation, editor, scenes, dependencies, diagnostics, resources, input/camera controls, FrameworkImGui, textures/IBL, and SceneSetup descriptors.
- Reorganizes the documentation index into clear grouped areas for architecture, rendering/assets, runtime systems, and editor/UI/scene formats.
- Updates glossary, dependency map, review/gap notes, stage plan, and related subsystem cross-links.

## Validation
- Markdown relative links validated.
- Inline source/file references validated.